### PR TITLE
Add compositor view support

### DIFF
--- a/plugins/animate/animate.cpp
+++ b/plugins/animate/animate.cpp
@@ -41,7 +41,10 @@ struct animation_hook
         output = view->get_output();
 
         if (close_animation)
+        {
+            view->inc_keep_count();
             view->take_snapshot();
+        }
 
         view->damage();
         base = dynamic_cast<animation_base*> (new animation_type());
@@ -147,9 +150,6 @@ class wayfire_animation : public wayfire_plugin_t {
         /* TODO: check if this is really needed */
         if (view->role == WF_VIEW_ROLE_SHELL_VIEW)
             return;
-
-        if (close_animation->as_string() != "none")
-            view->inc_keep_count();
 
         if (open_animation->as_string() == "fade")
             new animation_hook<fade_animation, false>(view, duration);

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -195,13 +195,7 @@ class simple_decoration_surface : public wayfire_compositor_subsurface_t, public
         {
             GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb.fb));
             auto obox = get_output_geometry();
-
-            wlr_fb_attribs attribs;
-            attribs.width = output->handle->width;
-            attribs.height = output->handle->height;
-            attribs.transform = output->handle->transform;
-
-            render_pixman(attribs, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
+            render_pixman(wlr_fb_attribs{fb}, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
         }
 
         /* all input events coordinates are surface-local */

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -64,7 +64,7 @@ GLuint get_text_texture(int width, int height, std::string text, std::string cai
     return tex;
 }
 
-class simple_decoration_surface : public wayfire_compositor_surface_t, public wf_decorator_frame_t
+class simple_decoration_surface : public wayfire_compositor_subsurface_t, public wf_decorator_frame_t
 {
     int thickness = normal_thickness;
     int titlebar = titlebar_thickness;
@@ -103,7 +103,7 @@ class simple_decoration_surface : public wayfire_compositor_surface_t, public wf
             if (this->output)
                 this->output->disconnect_signal("view-title-changed", &title_set);
 
-            wayfire_compositor_surface_t::set_output(next_output);
+            wayfire_compositor_subsurface_t::set_output(next_output);
 
             if (this->output)
                 this->output->connect_signal("view-title-changed", &title_set);

--- a/plugins/single_plugins/compositor-view-test.cpp
+++ b/plugins/single_plugins/compositor-view-test.cpp
@@ -1,0 +1,73 @@
+#include "compositor-view.hpp"
+#include "render-manager.hpp"
+#include "output.hpp"
+#include "core.hpp"
+#include "debug.hpp"
+
+extern "C"
+{
+#define static
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/types/wlr_matrix.h>
+#include <wlr/types/wlr_xcursor_manager.h>
+#undef static
+}
+
+class test_view : public wayfire_compositor_view_t, public wayfire_compositor_interactive_view
+{
+    public:
+        virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor)
+        {
+            wlr_box g {x, y, geometry.width, geometry.height};
+            geometry = get_output_box_from_box(g, output->handle->scale);
+
+            float projection[9];
+            wlr_matrix_projection(projection, fb.width, fb.height, fb.transform);
+
+            float matrix[9];
+            wlr_matrix_project_box(matrix, &g, WL_OUTPUT_TRANSFORM_NORMAL, 0, projection);
+
+            wlr_renderer_begin(core->renderer, fb.width, fb.height);
+            auto sbox = scissor; wlr_renderer_scissor(core->renderer, &sbox);
+
+            float color[] = {1.0f, 0.0, 1.0f, 1.0f};
+
+            wlr_render_quad_with_matrix(core->renderer, color, matrix);
+            wlr_renderer_end(core->renderer);
+        }
+
+        virtual bool accepts_input(int sx, int sy)
+        {
+            return 0 <= sx && sx < geometry.width &&
+                0 <= sy && sy < geometry.height;
+        }
+};
+
+class wayfire_cvtest : public wayfire_plugin_t
+{
+    key_callback binding;
+    public:
+        void init(wayfire_config *config)
+        {
+            binding = [=] (uint32_t) {test();};
+            output->add_key(new_static_option("<shift> <super> KEY_T"), &binding);
+        }
+
+        void test()
+        {
+            auto cv = new test_view;
+            auto v = std::unique_ptr<wayfire_view_t>{cv};
+            core->add_view(std::move(v));
+
+            cv->set_geometry({100, 100, 100, 100});
+            cv->map();
+        }
+};
+
+extern "C"
+{
+    wayfire_plugin_t* newInstance()
+    {
+        return new wayfire_cvtest;
+    }
+}

--- a/plugins/single_plugins/compositor-view-test.cpp
+++ b/plugins/single_plugins/compositor-view-test.cpp
@@ -55,11 +55,10 @@ class wayfire_cvtest : public wayfire_plugin_t
 
         void test()
         {
-            auto cv = new test_view;
+            auto cv = new wayfire_mirror_view_t(output->get_top_view());
+
             auto v = std::unique_ptr<wayfire_view_t>{cv};
             core->add_view(std::move(v));
-
-            cv->set_geometry({100, 100, 100, 100});
             cv->map();
         }
 };

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -177,7 +177,7 @@ class wayfire_grid : public wayfire_plugin_t
     activator_callback bindings[10];
     wf_option keys[10];
 
-    signal_callback_t snap_cb, maximized_cb, fullscreen_cb;
+    signal_callback_t snap_cb, snap_query_cb, maximized_cb, fullscreen_cb;
 
     wf_option animation_duration, animation_type;
 
@@ -208,6 +208,15 @@ class wayfire_grid : public wayfire_plugin_t
         using namespace std::placeholders;
         snap_cb = std::bind(std::mem_fn(&wayfire_grid::snap_signal_cb), this, _1);
         output->connect_signal("view-snap", &snap_cb);
+
+        snap_query_cb = [=] (signal_data *data) {
+            auto query = static_cast<snap_query_signal*> (data);
+            assert(query);
+
+            query->out_geometry = get_slot_dimensions(query->slot,
+                output->workspace->get_workarea());
+        };
+        output->connect_signal("query-snap-geometry", &snap_query_cb);
 
         maximized_cb = std::bind(std::mem_fn(&wayfire_grid::maximize_signal_cb), this, _1);
         output->connect_signal("view-maximized-request", &maximized_cb);
@@ -352,6 +361,7 @@ class wayfire_grid : public wayfire_plugin_t
             output->rem_binding(&bindings[i]);
 
         output->disconnect_signal("view-snap", &snap_cb);
+        output->disconnect_signal("query-snap-geometry", &snap_query_cb);
         output->disconnect_signal("view-maximized-request", &maximized_cb);
         output->disconnect_signal("view-fullscreen-request", &fullscreen_cb);
         output->disconnect_signal("output-resized", &output_resized_cb);

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -74,7 +74,7 @@ class wayfire_grid_view_cdata : public wf_custom_data_t
         this->tiled = tiled;
 
         auto type = animation_type->as_string();
-        if (output->is_plugin_active("wobbly") || !is_active)
+        if (view->get_transformer("wobbly") || !is_active)
             type = "wobbly";
 
         if (type == "none")

--- a/plugins/single_plugins/meson.build
+++ b/plugins/single_plugins/meson.build
@@ -18,4 +18,6 @@ invert        = shared_module('invert',        'invert.cpp',        include_dire
 fisheye       = shared_module('fisheye',       'fisheye.cpp',       include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 zoom          = shared_module('zoom',          'zoom.cpp',          include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 alpha         = shared_module('alpha',         'alpha.cpp',         include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
-idle_inhibit  = shared_module('idle-inhibit',  'idle-inhibit.cpp',     include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
+
+idle_inhibit  = shared_module('idle-inhibit',   'idle-inhibit.cpp',                 include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
+cvtest        = shared_module('cvtest',         'compositor-view-test.cpp',         include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -58,9 +58,7 @@ class wf_move_mirror_view : public wayfire_mirror_view_t
         if (show_animation)
             emit_view_unmap(self());
 
-        original_view->disconnect_signal("damaged-region", &base_view_damaged);
-        original_view = nullptr;
-
+        unset_original_view();
         emit_map_state_change(this);
     }
 };

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -63,6 +63,10 @@ class wf_move_mirror_view : public wayfire_mirror_view_t
     }
 };
 
+class wf_move_snap_preview : public wayfire_compositor_view_t
+{
+};
+
 class wayfire_move : public wayfire_plugin_t
 {
     signal_callback_t move_request, view_destroyed;

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -350,7 +350,12 @@ class wayfire_move : public wayfire_plugin_t
             auto new_g = new_output->get_full_geometry();
             auto wm_g = view->get_wm_geometry();
 
-            view->move(wm_g.x + old_g.x - new_g.x, wm_g.y + old_g.y - new_g.y, false);
+            int dx = old_g.x - new_g.x;
+            int dy = old_g.y - new_g.y;
+
+            view->move(wm_g.x + dx, wm_g.y + dy, true);
+            translate_wobbly(view, dx, dy);
+
             view->set_moving(false);
 
             core->move_view_to_output(view, new_output);

--- a/plugins/single_plugins/snap_signal.hpp
+++ b/plugins/single_plugins/snap_signal.hpp
@@ -1,8 +1,14 @@
 #ifndef SNAP_SIGNAL
 #define SNAP_SIGNAL
 
+/* A private signal, currently shared by move & grid
+ *
+ * It is used to provide autosnap functionality for the move plugin,
+ * by reusing grid's abilities */
+
 #include <view.hpp>
 
+/* The "slot" where the view should be snapped */
 enum slot_type {
     SLOT_BL     = 1,
     SLOT_BOTTOM = 2,
@@ -15,7 +21,16 @@ enum slot_type {
     SLOT_TR     = 9,
 };
 
-struct snap_signal : public signal_data {
+/* Query the dimensions of the given slot */
+struct snap_query_signal : public signal_data
+{
+    slot_type slot;
+    wf_geometry out_geometry;
+};
+
+/* Do snap the view to the given slot */
+struct snap_signal : public signal_data
+{
     wayfire_view view;
     slot_type tslot;
 };

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -466,6 +466,15 @@ class WayfireSwitcher : public wayfire_plugin_t
 
     void dearrange()
     {
+        /* When we have just 2 views on the workspace, we have 2 copies
+         * of the unfocused view. When dearranging those copies, they overlap.
+         * If the view is translucent, this means that the view gets darker than
+         * it really is.  * To circumvent this, we just fade out one of the copies */
+        wayfire_view fading_view = nullptr;
+        if (count_different_active_views() == 2)
+            fading_view = get_unfocused_view();
+
+
         for (auto& sv : views)
         {
             sv.attribs.off_x = {duration.progress(sv.attribs.off_x), 0};
@@ -477,6 +486,13 @@ class WayfireSwitcher : public wayfire_plugin_t
 
             sv.attribs.rotation = {duration.progress(sv.attribs.rotation), 0};
             sv.attribs.alpha    = {duration.progress(sv.attribs.alpha), 1.0};
+
+            if (sv.view == fading_view)
+            {
+                sv.attribs.alpha.end = 0.0;
+                // make sure we don't fade out the other unfocused view instance as well
+                fading_view = nullptr;
+            }
         }
 
         background_dim_duration.start(background_dim_duration.progress(), 1);

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -568,6 +568,11 @@ class WayfireSwitcher : public wayfire_plugin_t
 
         transform->color[3] = duration.progress(sv.attribs.alpha);
         sv.view->render_fb(NULL, output->render->get_target_framebuffer());
+
+        transform->translation = glm::mat4();
+        transform->scaling = glm::mat4();
+        transform->rotation = glm::mat4();
+        transform->color[3] = 1.0;
     }
 
     void render_output(uint32_t fb)

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -372,6 +372,7 @@ class wf_wobbly : public wf_view_transformer_t
     void translate(int dx, int dy)
     {
         wobbly_translate(model.get(), dx, dy);
+        wobbly_add_geometry(model.get());
     }
 
     void destroy_self()

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -150,7 +150,7 @@ class wf_wobbly : public wf_view_transformer_t
 {
     wayfire_view view;
     effect_hook_t pre_hook;
-    signal_callback_t view_removed, view_geometry_changed;
+    signal_callback_t view_removed, view_geometry_changed, view_output_changed;
     wayfire_grab_interface iface;
 
     std::unique_ptr<wobbly_surface> model;
@@ -191,25 +191,31 @@ class wf_wobbly : public wf_view_transformer_t
         };
         view->get_output()->render->add_effect(&pre_hook, WF_OUTPUT_EFFECT_PRE);
 
-        view_removed = [=] (signal_data *data)
-        {
-            if (get_signaled_view(data) == view)
-                destroy_self();
+        view_removed = [=] (signal_data *data) {
+            destroy_self();
         };
 
-        view_geometry_changed = [=] (signal_data *data)
-        {
-            if (get_signaled_view(data) == view)
-            {
-                auto sig = static_cast<view_geometry_changed_signal*> (data);
-                update_view_geometry(sig->old_geometry);
-            }
+        view_geometry_changed = [=] (signal_data *data) {
+            auto sig = static_cast<view_geometry_changed_signal*> (data);
+            update_view_geometry(sig->old_geometry);
         };
 
-        view->get_output()->connect_signal("detach-view", &view_removed);
-        view->get_output()->connect_signal("unmap-view", &view_removed);
-        view->get_output()->connect_signal("view-geometry-changed", &view_geometry_changed);
-        view->get_output()->activate_plugin(iface);
+        view_output_changed = [=] (signal_data *data) {
+            auto sig = static_cast<_output_signal*> (data);
+
+            if (!view->get_output())
+                return destroy_self();
+
+            /* Wobbly is active only when there's already been an output */
+            assert(sig->output);
+
+            sig->output->render->rem_effect(&pre_hook, WF_OUTPUT_EFFECT_PRE);
+            view->get_output()->render->add_effect(&pre_hook, WF_OUTPUT_EFFECT_PRE);
+        };
+
+        view->connect_signal("unmap", &view_removed);
+        view->connect_signal("set-output", &view_output_changed);
+        view->connect_signal("geometry-changed", &view_geometry_changed);
     }
 
     virtual wlr_box get_bounding_box(wf_geometry, wf_geometry)
@@ -388,11 +394,11 @@ class wf_wobbly : public wf_view_transformer_t
     virtual ~wf_wobbly()
     {
         wobbly_fini(model.get());
-        view->get_output()->deactivate_plugin(iface);
         view->get_output()->render->rem_effect(&pre_hook, WF_OUTPUT_EFFECT_PRE);
-        view->get_output()->disconnect_signal("view-geometry-changed", &view_geometry_changed);
-        view->get_output()->disconnect_signal("detach-view", &view_removed);
-        view->get_output()->disconnect_signal("unmap-view", &view_removed);
+
+        view->disconnect_signal("unmap", &view_removed);
+        view->disconnect_signal("set-output", &view_output_changed);
+        view->disconnect_signal("geometry-changed", &view_geometry_changed);
     }
 };
 

--- a/src/api/compositor-surface.hpp
+++ b/src/api/compositor-surface.hpp
@@ -3,29 +3,31 @@
 
 #include "view.hpp"
 
-/* This is the base class for compositor-created surfaces
- * They don't have a corresponding client, surface, or buffer,
- * but are rendered from the compositor itself
- *
- * To implement a custom compositor surface, override all the
- * virtual functions marked with "assert(false)" below
- *
- * You might also need to override other functions, depending
- * on the exact use-case you want to achieve. For example,
- * decorations are implemented as subsurfaces - so they need
- * to implement other methods, like get_child_position()
- *
- * */
+/* The base class for a compositor surface, it just supports cursor and touch input */
+class wayfire_compositor_surface_t
+{
+    public:
+    virtual ~wayfire_compositor_surface_t() {}
 
-class wayfire_compositor_surface_t : public wayfire_surface_t
+    virtual void on_pointer_enter(int x, int y) {}
+    virtual void on_pointer_leave() {}
+    virtual void on_pointer_motion(int x, int y) {}
+    virtual void on_pointer_button(uint32_t button, uint32_t state) {}
+
+    virtual void on_touch_down(int x, int y) {}
+    virtual void on_touch_up() {}
+    virtual void on_touch_motion(int x, int y) {}
+};
+
+class wayfire_compositor_subsurface_t : public wayfire_surface_t, public wayfire_compositor_surface_t
 {
     protected:
         virtual void damage(const wlr_box& box) { assert(false); }
         virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor) { assert(false); }
 
     public:
-        wayfire_compositor_surface_t() {}
-        virtual ~wayfire_compositor_surface_t() {}
+        wayfire_compositor_subsurface_t() {}
+        virtual ~wayfire_compositor_subsurface_t() {}
 
         virtual bool is_mapped() { return true; }
 
@@ -39,15 +41,6 @@ class wayfire_compositor_surface_t : public wayfire_surface_t
         /* override this if you want to get pointer events or to stop input passthrough */
         virtual bool accepts_input(int32_t sx, int32_t sy) { return false; }
 
-        virtual void on_pointer_enter(int x, int y) {}
-        virtual void on_pointer_leave() {}
-        virtual void on_pointer_motion(int x, int y) {}
-        virtual void on_pointer_button(uint32_t button, uint32_t state) {}
-
-        // XXX: supports only single touch
-        virtual void on_touch_down(int x, int y) {}
-        virtual void on_touch_up() {}
-        virtual void on_touch_motion(int x, int y) {}
 };
 
 static wayfire_compositor_surface_t *wf_compositor_surface_from_surface(wayfire_surface_t *surface)

--- a/src/api/compositor-surface.hpp
+++ b/src/api/compositor-surface.hpp
@@ -48,6 +48,6 @@ static wayfire_compositor_surface_t *wf_compositor_surface_from_surface(wayfire_
     return dynamic_cast<wayfire_compositor_surface_t*> (surface);
 }
 
-/* TODO: implement compositor views - needs a real use-case */
+void emit_map_state_change(wayfire_surface_t *surface);
 
 #endif /* end of include guard: COMPOSITOR_SURFACE_HPP */

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -1,0 +1,80 @@
+#ifndef COMPOSITOR_VIEW_HPP
+#define COMPOSITOR_VIEW_HPP
+
+#include "compositor-surface.hpp"
+
+/* Subclass this if you want the view to be able to interact with keyboard
+ * and to receive focus */
+class wayfire_compositor_interactive_view
+{
+    public:
+        void handle_keyboard_enter() {}
+        void handle_keyboard_leave() {}
+        void handle_key(uint32_t key, uint32_t state) {}
+};
+
+static wayfire_compositor_interactive_view *interactive_view_from_view(wayfire_view_t *view)
+{
+    return dynamic_cast<wayfire_compositor_interactive_view*> (view);
+}
+
+/* a base class for writing compositor views
+ *
+ * It can be used by plugins to create views with compositor-generated content */
+class wayfire_compositor_view_t : virtual public wayfire_compositor_surface_t, virtual public wayfire_view_t
+{
+    protected:
+        /* Implement _wlr_render_box to get something on screen */
+        virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor) { assert(false); }
+
+    public:
+
+        virtual bool is_mapped() { return map_state; }
+        virtual void send_frame_done(const timespec& now) {}
+
+        /* override this if you want to get pointer events or to stop input passthrough */
+        virtual bool accepts_input(int32_t sx, int32_t sy) { return false; }
+
+
+    public:
+        wayfire_compositor_view_t();
+        virtual ~wayfire_compositor_view_t() {}
+
+        /* By default, use move/resize/set_geometry to set the size */
+        virtual wf_point get_output_position();
+        virtual wf_geometry get_output_geometry();
+        virtual wf_geometry get_wm_geometry();
+        virtual void set_geometry(wf_geometry g) {wayfire_view_t::geometry = g;}
+
+        virtual void activate(bool active) {}
+        virtual void close();
+
+        virtual wlr_surface *get_keyboard_focus_surface() { return nullptr; };
+
+        virtual std::string get_app_id() { return "wayfire-compositor-view"; }
+        virtual std::string get_title() { return "wayfire-compositor-view-" + this->wf_object_base::to_string(); }
+
+        virtual bool should_be_decorated() { return false; }
+
+        /* Usually compositor view implementations don't need to override this */
+        virtual void render_fb(pixman_region32_t* damage, wf_framebuffer fb);
+
+        /* NON-API functions which don't have a meaning for compositor views */
+        virtual bool update_size() { assert(false); }
+
+        virtual void get_child_position(int &x, int &y) { x = y = 0; }
+        virtual bool is_subsurface() { return false; }
+
+        virtual void get_child_offset(int &x, int &y) { x = y = 0;}
+
+        bool map_state = false;
+        virtual void map();
+        virtual void map(wlr_surface *surface) {map();}
+        virtual void unmap();
+
+        virtual wlr_buffer *get_buffer() { return NULL; }
+        virtual bool can_take_snapshot() { return is_mapped(); }
+        virtual void commit() {assert(false); }
+};
+
+#endif /* end of include guard: COMPOSITOR_VIEW_HPP */

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -21,7 +21,7 @@ static wayfire_compositor_interactive_view *interactive_view_from_view(wayfire_v
 /* a base class for writing compositor views
  *
  * It can be used by plugins to create views with compositor-generated content */
-class wayfire_compositor_view_t : virtual public wayfire_compositor_surface_t, virtual public wayfire_view_t
+class wayfire_compositor_view_t : public wayfire_compositor_surface_t, public wayfire_view_t
 {
     protected:
         /* Implement _wlr_render_box to get something on screen */
@@ -85,9 +85,9 @@ class wayfire_compositor_view_t : virtual public wayfire_compositor_surface_t, v
  * once the base view gets unmapped, this one is automatically unmapped as well */
 class wayfire_mirror_view_t : public wayfire_compositor_view_t
 {
+    protected:
     signal_callback_t base_view_unmapped, base_view_damaged;
 
-    protected:
     virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor);
     virtual void _render_pixman(const wlr_fb_attribs& fb, int x, int y, pixman_region32_t *damage);
     wayfire_view original_view;
@@ -102,7 +102,12 @@ class wayfire_mirror_view_t : public wayfire_compositor_view_t
     virtual wf_geometry get_output_geometry();
     virtual wf_geometry get_wm_geometry();
 
+    virtual void unmap();
+
     virtual wayfire_view get_original_view() { return original_view; }
 };
+
+void emit_view_map(wayfire_view view);
+void emit_view_unmap(wayfire_view view);
 
 #endif /* end of include guard: COMPOSITOR_VIEW_HPP */

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -29,7 +29,7 @@ class wayfire_compositor_view_t : virtual public wayfire_compositor_surface_t, v
 
     public:
 
-        virtual bool is_mapped() { return map_state; }
+        virtual bool is_mapped() { return _is_mapped; }
         virtual void send_frame_done(const timespec& now) {}
 
         /* override this if you want to get pointer events or to stop input passthrough */
@@ -67,7 +67,6 @@ class wayfire_compositor_view_t : virtual public wayfire_compositor_surface_t, v
 
         virtual void get_child_offset(int &x, int &y) { x = y = 0;}
 
-        bool map_state = false;
         virtual void map();
         virtual void map(wlr_surface *surface) {map();}
         virtual void unmap();

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -77,4 +77,33 @@ class wayfire_compositor_view_t : virtual public wayfire_compositor_surface_t, v
         virtual void commit() {assert(false); }
 };
 
+/* A special type of compositor view - mirror view.
+ * It takes another view and has the same size & contents, plus it "inherits"
+ * all the transforms of the original view. However, it can have additional transforms,
+ * be on another output, etc.
+ *
+ * The lifetime of a mirrored view isn't longer than that of the real view:
+ * once the base view gets unmapped, this one is automatically unmapped as well */
+class wayfire_mirror_view_t : public wayfire_compositor_view_t
+{
+    signal_callback_t base_view_unmapped, base_view_damaged;
+
+    protected:
+    virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor);
+    virtual void _render_pixman(const wlr_fb_attribs& fb, int x, int y, pixman_region32_t *damage);
+    wayfire_view original_view;
+
+    public:
+    wayfire_mirror_view_t(wayfire_view original_view);
+
+    virtual bool can_take_snapshot();
+    virtual void take_snapshot();
+
+    virtual wf_point get_output_position();
+    virtual wf_geometry get_output_geometry();
+    virtual wf_geometry get_wm_geometry();
+
+    virtual wayfire_view get_original_view() { return original_view; }
+};
+
 #endif /* end of include guard: COMPOSITOR_VIEW_HPP */

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -44,7 +44,7 @@ class wayfire_compositor_view_t : public wayfire_compositor_surface_t, public wa
         virtual wf_point get_output_position();
         virtual wf_geometry get_output_geometry();
         virtual wf_geometry get_wm_geometry();
-        virtual void set_geometry(wf_geometry g) {wayfire_view_t::geometry = g;}
+        virtual void set_geometry(wf_geometry g);
 
         virtual void activate(bool active) {}
         virtual void close();
@@ -108,6 +108,29 @@ class wayfire_mirror_view_t : public wayfire_compositor_view_t
     virtual void unmap();
 
     virtual wayfire_view get_original_view() { return original_view; }
+};
+
+/* A specialization of wayfire_compositor_view_t
+ * Provides a simple view which is a colored rectangle with a border */
+class wayfire_color_rect_view_t : public wayfire_compositor_view_t
+{
+    void _render_rect(float projection[9], int x, int y, int w, int h,
+        const wf_color& color);
+
+    protected:
+        wf_color _color;
+        wf_color _border_color;
+        int border;
+
+        virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor);
+
+    public:
+        wayfire_color_rect_view_t();
+
+        /* The color settings accept non-premultiplied alpha */
+        virtual void set_color(wf_color color);
+        virtual void set_border_color(wf_color border);
+        virtual void set_border(int width);
 };
 
 void emit_view_map(wayfire_view view);

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -90,7 +90,10 @@ class wayfire_mirror_view_t : public wayfire_compositor_view_t
 
     virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor);
     virtual void _render_pixman(const wlr_fb_attribs& fb, int x, int y, pixman_region32_t *damage);
+
     wayfire_view original_view;
+    /* sets original_view to NULL and removes signal handlers */
+    void unset_original_view();
 
     public:
     wayfire_mirror_view_t(wayfire_view original_view);

--- a/src/api/opengl.hpp
+++ b/src/api/opengl.hpp
@@ -42,7 +42,9 @@ struct wf_framebuffer
 {
     GLuint tex = -1, fb = -1;
     wf_geometry geometry = {0, 0, 0, 0};
+
     glm::mat4 transform = glm::mat4(1.0);
+    uint32_t wl_transform = WL_OUTPUT_TRANSFORM_NORMAL;
 
     uint32_t viewport_width, viewport_height;
 

--- a/src/api/render-manager.hpp
+++ b/src/api/render-manager.hpp
@@ -58,7 +58,6 @@ class render_manager
 
         bool dirty_context = true;
         void load_context();
-        void release_context();
 
         bool draw_overlay_panel = true;
 
@@ -95,7 +94,7 @@ class render_manager
         void init_default_streams();
 
     public:
-        OpenGL::context_t *ctx;
+        static OpenGL::context_t *ctx;
 
         render_manager(wayfire_output *o);
         ~render_manager();

--- a/src/api/render-manager.hpp
+++ b/src/api/render-manager.hpp
@@ -58,6 +58,7 @@ class render_manager
 
         bool dirty_context = true;
         void load_context();
+        void release_context();
 
         bool draw_overlay_panel = true;
 
@@ -94,7 +95,7 @@ class render_manager
         void init_default_streams();
 
     public:
-        static OpenGL::context_t *ctx;
+        OpenGL::context_t *ctx;
 
         render_manager(wayfire_output *o);
         ~render_manager();

--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -380,6 +380,7 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
         virtual void render_fb(pixman_region32_t* damage, wf_framebuffer framebuffer);
 
         bool has_snapshot = false;
+        virtual bool can_take_snapshot();
         virtual void take_snapshot();
 };
 

--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -179,8 +179,14 @@ enum wf_view_role
 class wayfire_view_t : public wayfire_surface_t, public wf_object_base
 {
     friend void surface_destroyed_cb(wl_listener*, void *data);
-
     protected:
+
+        /* Whether this view is really mapped
+         *
+         * The only time when this is different from is_mapped() is when the view
+         * is about to be unmapped. In this case we no longer have a valid keyboard
+         * focus for this view, but the view is still "mapped", e.g. visible */
+        bool _is_mapped = false;
 
         /* those two point to the same object. Two fields are used to avoid
          * constant casting to and from types */
@@ -295,7 +301,9 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
          * returns the (sub)surface under the cursor or NULL iff the cursor is outside of the view
          * TODO: it should be overwritable by plugins which deform the view */
         virtual wayfire_surface_t *map_input_coordinates(int cursor_x, int cursor_y, int &sx, int &sy);
-        virtual wlr_surface *get_keyboard_focus_surface() { return surface; };
+
+        /* Returns the wlr_surface which should receive focus if this view is activated */
+        virtual wlr_surface *get_keyboard_focus_surface();
 
         virtual void set_geometry(wf_geometry g);
 

--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -84,6 +84,10 @@ class wayfire_surface_t
 
         struct wlr_fb_attribs
         {
+            wlr_fb_attribs();
+            wlr_fb_attribs(const wf_framebuffer& source);
+
+            uint32_t fb;
             int width, height;
             wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
         };
@@ -382,6 +386,9 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
         bool has_snapshot = false;
         virtual bool can_take_snapshot();
         virtual void take_snapshot();
+
+        /* NOT API */
+        int64_t get_buffer_age() { return buffer_age; }
 };
 
 wayfire_view wl_surface_to_wayfire_view(wl_resource *surface);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -22,6 +22,7 @@ extern "C"
 #include "core.hpp"
 #include "signal-definitions.hpp"
 #include "workspace-manager.hpp"
+#include "render-manager.hpp"
 #include "seat/input-manager.hpp"
 #include "seat/input-inhibit.hpp"
 #include "seat/touch.hpp"
@@ -330,6 +331,10 @@ void wayfire_core::remove_output(wayfire_output *output)
         uninhibit_output(output);
 
     delete output;
+
+    /* Make sure we have a bound context */
+    for (auto& wo : outputs)
+        OpenGL::bind_context(wo.second->render->ctx);
 }
 
 void wayfire_core::refocus_active_output_active_view()

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -50,6 +50,7 @@ void input_manager::handle_new_input(wlr_input_device *dev)
     if (!cursor)
         create_seat();
 
+    log_info("handle new input: %s, default mapping: %s", dev->name, dev->output_name);
     if (dev->type == WLR_INPUT_DEVICE_KEYBOARD)
         keyboards.push_back(std::unique_ptr<wf_keyboard> (new wf_keyboard(dev, core->config)));
 
@@ -74,7 +75,8 @@ void input_manager::handle_new_input(wlr_input_device *dev)
         configure_input_device(wlr_libinput_get_device_handle(dev));
 
     auto section = core->config->get_section(nonull(dev->name));
-    auto mapped_output = section->get_option("output", nonull(dev->output_name))->raw_value;
+    auto mapped_output = section->get_option("output",
+        nonull(dev->output_name))->as_string();
 
     auto wo = core->get_output(mapped_output);
     if (wo)

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -100,6 +100,8 @@ class input_manager
         int count_other_inputs = 0;
         std::vector<std::function<void()>> match_keys(uint32_t mods, uint32_t key);
 
+        wayfire_view keyboard_focus;
+
     public:
 
         input_manager();
@@ -125,7 +127,7 @@ class input_manager
         void update_capabilities();
         void set_cursor(wlr_seat_pointer_request_set_cursor_event *ev);
 
-        void set_keyboard_focus(wlr_surface *surface, wlr_seat *seat);
+        void set_keyboard_focus(wayfire_view view, wlr_seat *seat);
 
         bool grab_input(wayfire_grab_interface);
         void ungrab_input();

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ wayfire_sources = ['main.cpp',
                    'view/xwayland.cpp',
                    'view/layer-shell.cpp',
                    'view/view-3d.cpp',
+                   'view/compositor-view.cpp',
 
                    'output/plugin-loader.cpp',
                    'output/output.cpp',

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -277,6 +277,7 @@ wayfire_output::wayfire_output(wlr_output *handle, wayfire_config *c)
     {
         auto view = get_signaled_view(data);
 
+        log_info("unmapped view %p, active is %p", view.get(), active_view.get());
         if (view == active_view)
             refocus(active_view, workspace->get_view_layer(view));
     };
@@ -536,6 +537,7 @@ void wayfire_output::set_active_view(wayfire_view v, wlr_seat *seat)
         seat = core->get_current_seat();
 
     bool refocus = (active_view == v);
+    log_info("set active view %p", v.get());
 
     /* don't deactivate view if the next focus is not a toplevel */
     if (v == nullptr || v->role == WF_VIEW_ROLE_TOPLEVEL)

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -6,6 +6,7 @@
 #include "signal-definitions.hpp"
 #include "render-manager.hpp"
 #include "workspace-manager.hpp"
+#include "compositor-view.hpp"
 #include "wayfire-shell.hpp"
 #include "../core/seat/input-manager.hpp"
 
@@ -550,7 +551,7 @@ void wayfire_output::set_active_view(wayfire_view v, wlr_seat *seat)
     active_view = v;
     if (active_view)
     {
-        core->input->set_keyboard_focus(active_view->get_keyboard_focus_surface(), seat);
+        core->input->set_keyboard_focus(active_view, seat);
 
         if (!refocus)
             active_view->activate(true);
@@ -574,7 +575,8 @@ void wayfire_output::focus_view(wayfire_view v, wlr_seat *seat)
 
     if (v && v->is_mapped())
     {
-        if (v->get_keyboard_focus_surface())
+        if (v->get_keyboard_focus_surface() ||
+            interactive_view_from_view(v.get()))
         {
             set_active_view(v, seat);
             bring_to_front(v);

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -297,7 +297,8 @@ void wayfire_output::refocus(wayfire_view skip_view, uint32_t layers)
 
     for (auto v : views)
     {
-        if (v != skip_view && v->is_mapped())
+        if (v != skip_view && v->is_mapped() &&
+            v->get_keyboard_focus_surface())
         {
             next_focus = v;
             break;

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -182,6 +182,7 @@ wf_framebuffer render_manager::get_target_framebuffer() const
 {
     wf_framebuffer fb;
     fb.geometry = output->get_relative_geometry();
+    fb.wl_transform = output->get_transform();
     fb.transform = get_output_matrix_from_transform(output->get_transform());
     fb.fb = default_fb;
     fb.viewport_width = output->handle->width;

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -20,6 +20,8 @@ extern "C"
 
 #include "view/priv-view.hpp"
 
+OpenGL::context_t *render_manager::ctx;
+
 struct wf_output_damage
 {
     pixman_region32_t frame_damage;
@@ -142,12 +144,6 @@ void render_manager::load_context()
     init_default_streams();
 }
 
-void render_manager::release_context()
-{
-    OpenGL::release_context(ctx);
-    dirty_context = true;
-}
-
 render_manager::~render_manager()
 {
     wl_list_remove(&frame_listener.link);
@@ -158,7 +154,6 @@ render_manager::~render_manager()
         wl_event_source_remove(idle_damage_source);
 
     pixman_region32_fini(&frame_damage);
-    release_context();
 }
 
 void render_manager::damage(const wlr_box& box)

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -20,8 +20,6 @@ extern "C"
 
 #include "view/priv-view.hpp"
 
-OpenGL::context_t *render_manager::ctx;
-
 struct wf_output_damage
 {
     pixman_region32_t frame_damage;
@@ -144,6 +142,12 @@ void render_manager::load_context()
     init_default_streams();
 }
 
+void render_manager::release_context()
+{
+    OpenGL::release_context(ctx);
+    dirty_context = true;
+}
+
 render_manager::~render_manager()
 {
     wl_list_remove(&frame_listener.link);
@@ -153,6 +157,7 @@ render_manager::~render_manager()
     if (idle_damage_source)
         wl_event_source_remove(idle_damage_source);
 
+    release_context();
     pixman_region32_fini(&frame_damage);
 }
 
@@ -328,6 +333,7 @@ void render_manager::paint()
 
     if (dirty_context)
         load_context();
+    OpenGL::bind_context(ctx);
 
     if (renderer)
     {

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -1,0 +1,72 @@
+#include "priv-view.hpp"
+#include "output.hpp"
+#include "workspace-manager.hpp"
+#include "compositor-view.hpp"
+
+wayfire_compositor_view_t::wayfire_compositor_view_t()
+{
+    role = WF_VIEW_ROLE_TOPLEVEL;
+}
+
+wf_point wayfire_compositor_view_t::get_output_position()
+{
+    return {geometry.x, geometry.y};
+}
+
+wf_geometry wayfire_compositor_view_t::get_output_geometry()
+{
+    return geometry;
+}
+
+wf_geometry wayfire_compositor_view_t::get_wm_geometry()
+{
+    return geometry;
+}
+
+void wayfire_compositor_view_t::map()
+{
+    if (map_state)
+        return;
+
+    output->attach_view(self());
+    emit_view_map(self());
+
+    map_state = true;
+}
+
+void wayfire_compositor_view_t::unmap()
+{
+    if (!map_state)
+        return;
+
+    if (output)
+        emit_view_unmap(self());
+
+    map_state = false;
+}
+
+void wayfire_compositor_view_t::close()
+{
+    unmap();
+    destroy();
+}
+
+void wayfire_compositor_view_t::render_fb(pixman_region32_t *damage, wf_framebuffer fb)
+{
+    /* We only want to circumvent wayfire_surface_t::render_fb,
+     * because it relies on the surface having a buffer
+     *
+     * If there is a transform though, we're fine with what wayfire_view_t provides */
+    if (has_transformer())
+        return wayfire_view_t::render_fb(damage, fb);
+
+    GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb.fb));
+    auto obox = get_output_geometry();
+
+    wlr_fb_attribs attribs;
+    attribs.width = output->handle->width;
+    attribs.height = output->handle->height;
+    attribs.transform = output->handle->transform;
+
+    render_pixman(attribs, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
+}

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -143,6 +143,11 @@ void wayfire_mirror_view_t::take_snapshot()
     if (!offscreen_buffer.valid())
         offscreen_buffer.init(scaled_width, scaled_height);
 
+    auto buffer_geometry = get_untransformed_bounding_box();
+    offscreen_buffer.output_x = buffer_geometry.x;
+    offscreen_buffer.output_y = buffer_geometry.y;
+    offscreen_buffer.fb_scale = scale;
+
     GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, offscreen_buffer.fbo));
     wlr_renderer_begin(core->renderer, offscreen_buffer.fb_width, offscreen_buffer.fb_height);
     wlr_renderer_scissor(core->renderer, NULL);
@@ -160,7 +165,6 @@ void wayfire_mirror_view_t::take_snapshot()
 
     original_view->render_fb(NULL, fb);
 }
-
 
 wf_point wayfire_mirror_view_t::get_output_position()
 {

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -103,7 +103,6 @@ wayfire_mirror_view_t::wayfire_mirror_view_t(wayfire_view original_view)
     this->original_view = original_view;
 
     base_view_unmapped = [=] (signal_data*) {
-        this->original_view = nullptr;
         unmap();
         destroy();
     };
@@ -190,4 +189,12 @@ wf_geometry wayfire_mirror_view_t::get_wm_geometry()
     geometry.height = bbox.height;
 
     return geometry;
+}
+
+void wayfire_mirror_view_t::unmap()
+{
+    original_view->disconnect_signal("damaged-region", &base_view_damaged);
+
+    original_view = nullptr;
+    wayfire_compositor_view_t::unmap();
 }

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -30,25 +30,24 @@ wf_geometry wayfire_compositor_view_t::get_wm_geometry()
 
 void wayfire_compositor_view_t::map()
 {
-    if (map_state)
+    if (_is_mapped)
         return;
+    _is_mapped = true;
 
     output->attach_view(self());
     emit_view_map(self());
     emit_map_state_change(this);
-
-    map_state = true;
 }
 
 void wayfire_compositor_view_t::unmap()
 {
-    if (!map_state)
+    if (!_is_mapped)
         return;
 
     if (output)
         emit_view_unmap(self());
 
-    map_state = false;
+    _is_mapped = false;
 
     if (output)
         emit_map_state_change(this);

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -195,10 +195,16 @@ wf_geometry wayfire_mirror_view_t::get_wm_geometry()
     return geometry;
 }
 
-void wayfire_mirror_view_t::unmap()
+void wayfire_mirror_view_t::unset_original_view()
 {
     original_view->disconnect_signal("damaged-region", &base_view_damaged);
+    original_view->disconnect_signal("unmap", &base_view_unmapped);
 
     original_view = nullptr;
+}
+
+void wayfire_mirror_view_t::unmap()
+{
+    unset_original_view();
     wayfire_compositor_view_t::unmap();
 }

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -1,7 +1,12 @@
 #include "priv-view.hpp"
+#include "core.hpp"
 #include "output.hpp"
+#include "opengl.hpp"
 #include "workspace-manager.hpp"
 #include "compositor-view.hpp"
+#include "debug.hpp"
+
+#include <glm/gtc/matrix_transform.hpp>
 
 wayfire_compositor_view_t::wayfire_compositor_view_t()
 {
@@ -30,6 +35,7 @@ void wayfire_compositor_view_t::map()
 
     output->attach_view(self());
     emit_view_map(self());
+    emit_map_state_change(this);
 
     map_state = true;
 }
@@ -43,6 +49,9 @@ void wayfire_compositor_view_t::unmap()
         emit_view_unmap(self());
 
     map_state = false;
+
+    if (output)
+        emit_map_state_change(this);
 }
 
 void wayfire_compositor_view_t::close()
@@ -62,11 +71,124 @@ void wayfire_compositor_view_t::render_fb(pixman_region32_t *damage, wf_framebuf
 
     GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb.fb));
     auto obox = get_output_geometry();
+    render_pixman(wlr_fb_attribs{fb}, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
+}
 
-    wlr_fb_attribs attribs;
-    attribs.width = output->handle->width;
-    attribs.height = output->handle->height;
-    attribs.transform = output->handle->transform;
+void wayfire_mirror_view_t::_wlr_render_box(const wlr_fb_attribs& fb,
+        int x, int y, const wlr_box& scissor)
+{
+    wlr_renderer_begin(core->renderer, fb.width, fb.height);
+    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, fb.fb));
+    auto sbox = scissor; wlr_renderer_scissor(core->renderer, &sbox);
 
-    render_pixman(attribs, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
+    auto ortho = glm::ortho(0.0f, 1.0f * fb.width, 1.0f * fb.height, 0.0f);
+
+    gl_geometry render_geometry;
+    render_geometry.x1 = x;
+    render_geometry.y1 = y;
+    render_geometry.x2 = x + geometry.width;
+    render_geometry.y2 = y + geometry.height;
+
+    OpenGL::render_transformed_texture(offscreen_buffer.tex, render_geometry, {}, ortho);
+    wlr_renderer_end(core->renderer);
+}
+
+void wayfire_mirror_view_t::_render_pixman(const wlr_fb_attribs& fb, int x, int y, pixman_region32_t *damage)
+{
+    take_snapshot();
+    wayfire_compositor_view_t::_render_pixman(fb, x, y, damage);
+}
+
+wayfire_mirror_view_t::wayfire_mirror_view_t(wayfire_view original_view)
+{
+    this->original_view = original_view;
+
+    base_view_unmapped = [=] (signal_data*) {
+        this->original_view = nullptr;
+        unmap();
+        destroy();
+    };
+
+    original_view->connect_signal("unmap", &base_view_unmapped);
+
+    base_view_damaged = [=] (signal_data* ) {
+        damage();
+    };
+
+    original_view->connect_signal("damaged-region", &base_view_damaged);
+}
+
+bool wayfire_mirror_view_t::can_take_snapshot()
+{
+    return original_view.get();
+}
+
+void wayfire_mirror_view_t::take_snapshot()
+{
+    if (!can_take_snapshot())
+        return;
+
+    auto obox = original_view->get_bounding_box();
+    geometry.width = obox.width;
+    geometry.height = obox.height;
+
+    float scale = output ? output->handle->scale : 1;
+    int scaled_width = scale * obox.width;
+    int scaled_height = scale * obox.height;
+
+    if (offscreen_buffer.fb_width != scaled_width ||
+        offscreen_buffer.fb_height != scaled_height)
+    {
+        offscreen_buffer.fini();
+    }
+
+    if (!offscreen_buffer.valid())
+        offscreen_buffer.init(scaled_width, scaled_height);
+
+    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, offscreen_buffer.fbo));
+    wlr_renderer_begin(core->renderer, offscreen_buffer.fb_width, offscreen_buffer.fb_height);
+    wlr_renderer_scissor(core->renderer, NULL);
+    float clear_color[] = {0, 0, 0, 0};
+    wlr_renderer_clear(core->renderer, clear_color);
+    wlr_renderer_end(core->renderer);
+
+    wf_framebuffer fb;
+    fb.fb = offscreen_buffer.fbo;
+    fb.tex = offscreen_buffer.tex;
+
+    fb.geometry = obox;
+    fb.viewport_width = scaled_width;
+    fb.viewport_height = scaled_height;
+
+    original_view->render_fb(NULL, fb);
+}
+
+
+wf_point wayfire_mirror_view_t::get_output_position()
+{
+    return wayfire_compositor_view_t::get_output_position();
+}
+
+wf_geometry wayfire_mirror_view_t::get_output_geometry()
+{
+    if (!original_view)
+        return wayfire_compositor_view_t::get_output_geometry();
+
+    auto bbox = original_view->get_bounding_box();
+    geometry.width = bbox.width;
+    geometry.height = bbox.height;
+
+    return geometry;
+}
+
+wf_geometry wayfire_mirror_view_t::get_wm_geometry()
+{
+    if (!original_view)
+        return wayfire_compositor_view_t::get_wm_geometry();
+
+    auto bbox = original_view->get_bounding_box();
+    geometry.width = bbox.width;
+    geometry.height = bbox.height;
+
+    return geometry;
 }

--- a/src/view/priv-view.hpp
+++ b/src/view/priv-view.hpp
@@ -6,13 +6,14 @@
 #include <assert.h>
 #include <nonstd/make_unique.hpp>
 
+// for emit_map_*()
+#include <compositor-view.hpp>
+#include <compositor-surface.hpp>
+
 wayfire_surface_t* wf_surface_from_void(void *handle);
 wayfire_view_t* wf_view_from_void(void *handle);
 wlr_box wlr_box_from_pixman_box(const pixman_box32_t& box);
 
-void emit_view_map(wayfire_view view);
-void emit_view_unmap(wayfire_view view);
-void emit_map_state_change(wayfire_surface_t *surface);
 void emit_title_changed(wayfire_view view);
 void emit_app_id_changed(wayfire_view view);
 

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -407,8 +407,10 @@ void wayfire_surface_t::_wlr_render_box(const wlr_fb_attribs& fb, int x, int y, 
                            0, projection);
 
     wlr_renderer_begin(core->renderer, fb.width, fb.height);
+
     auto sbox = scissor; wlr_renderer_scissor(core->renderer, &sbox);
     wlr_render_texture_with_matrix(core->renderer, get_buffer()->texture, matrix, alpha);
+
 
 #ifdef WAYFIRE_GRAPHICS_DEBUG
     float scissor_proj[9];
@@ -455,11 +457,5 @@ void wayfire_surface_t::render_fb(pixman_region32_t *damage, wf_framebuffer fb)
 
     GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb.fb));
     auto obox = get_output_geometry();
-
-    wlr_fb_attribs attribs;
-    attribs.width = output->handle->width;
-    attribs.height = output->handle->height;
-    attribs.transform = output->handle->transform;
-
-    render_pixman(attribs, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
+    render_pixman(wlr_fb_attribs{fb}, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
 }

--- a/src/view/view-util.cpp
+++ b/src/view/view-util.cpp
@@ -155,3 +155,14 @@ wlr_box wlr_box_from_pixman_box(const pixman_box32_t& box)
 
     return d;
 }
+
+wayfire_view_t::wlr_fb_attribs::wlr_fb_attribs() { }
+
+wayfire_view_t::wlr_fb_attribs::wlr_fb_attribs(const wf_framebuffer& fb)
+{
+    this->width = fb.viewport_width;
+    this->height = fb.viewport_height;
+    this->fb = fb.fb;
+    this->transform = (wl_output_transform) fb.wl_transform;
+}
+

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -435,6 +435,8 @@ void wayfire_view_t::damage(const wlr_box& box)
     {
         output->render->damage(damage_box);
     }
+
+    emit_signal("damaged-region", nullptr);
 }
 
 void wayfire_view_t::offscreen_buffer_t::init(int w, int h)
@@ -515,6 +517,7 @@ void wayfire_view_t::take_snapshot()
     wlr_renderer_end(core->renderer);
 
     wlr_fb_attribs fb;
+    fb.fb = offscreen_buffer.fbo;
     fb.width = offscreen_buffer.fb_width;
     fb.height = offscreen_buffer.fb_height;
 
@@ -708,6 +711,7 @@ void emit_view_map(wayfire_view view)
     map_view_signal data;
     data.view = view;
     view->get_output()->emit_signal("map-view", &data);
+    view->emit_signal("map", &data);
     emit_map_state_change(view.get());
 }
 
@@ -766,7 +770,9 @@ void emit_view_unmap(wayfire_view view)
 {
     unmap_view_signal data;
     data.view = view;
+
     view->get_output()->emit_signal("unmap-view", &data);
+    view->emit_signal("unmap", &data);
 }
 
 void wayfire_view_t::unmap()
@@ -779,6 +785,7 @@ void wayfire_view_t::unmap()
         c->set_toplevel_parent(nullptr);
 
     log_info("unmap %s %s %p", get_title().c_str(), get_app_id().c_str(), this);
+
     if (output)
         emit_view_unmap(self());
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -51,7 +51,7 @@ void wayfire_view_t::set_output(wayfire_output *wo)
 
 wayfire_view wayfire_view_t::self()
 {
-    return core->find_view((wayfire_surface_t*) this);
+    return wayfire_view(this);
 }
 
 bool wayfire_view_t::is_visible()
@@ -469,9 +469,14 @@ void wayfire_view_t::offscreen_buffer_t::fini()
     fbo = tex = -1;
 }
 
+bool wayfire_view_t::can_take_snapshot()
+{
+    return get_buffer();
+}
+
 void wayfire_view_t::take_snapshot()
 {
-    if (!get_buffer())
+    if (!can_take_snapshot())
         return;
 
     auto buffer_geometry = get_untransformed_bounding_box();
@@ -524,7 +529,7 @@ void wayfire_view_t::take_snapshot()
 void wayfire_view_t::render_fb(pixman_region32_t* damage, wf_framebuffer fb)
 {
     in_paint = true;
-    if (transforms.size())
+    if (has_transformer())
     {
         pixman_region32_t fb_region;
         if (damage == NULL)

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -44,9 +44,15 @@ std::string wayfire_view_t::to_string() const
 
 void wayfire_view_t::set_output(wayfire_output *wo)
 {
+    _output_signal data;
+    data.output = output;
+
     wayfire_surface_t::set_output(wo);
     if (decoration)
         decoration->set_output(wo);
+
+    if (wo != data.output)
+        emit_signal("set-output", &data);
 }
 
 wayfire_view wayfire_view_t::self()
@@ -117,7 +123,10 @@ void wayfire_view_t::move(int x, int y, bool send_signal)
     damage();
 
     if (send_signal)
+    {
         output->emit_signal("view-geometry-changed", &data);
+        emit_signal("geometry-changed", &data);
+    }
 }
 
 void wayfire_view_t::resize(int w, int h, bool send_signal)
@@ -132,7 +141,10 @@ void wayfire_view_t::resize(int w, int h, bool send_signal)
     damage();
 
     if (send_signal)
+    {
         output->emit_signal("view-geometry-changed", &data);
+        emit_signal("geometry-changed", &data);
+    }
 }
 
 wayfire_surface_t *wayfire_view_t::map_input_coordinates(int cx, int cy, int& sx, int& sy)

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -137,7 +137,7 @@ void wayfire_view_t::resize(int w, int h, bool send_signal)
 
 wayfire_surface_t *wayfire_view_t::map_input_coordinates(int cx, int cy, int& sx, int& sy)
 {
-    if (!is_mapped())
+    if (!_is_mapped || !is_mapped())
         return nullptr;
 
     wayfire_surface_t *ret = NULL;
@@ -167,6 +167,14 @@ wayfire_surface_t *wayfire_view_t::map_input_coordinates(int cx, int cy, int& sx
         });
 
     return ret;
+}
+
+wlr_surface *wayfire_view_t::get_keyboard_focus_surface()
+{
+    if (_is_mapped)
+        return surface;
+
+    return NULL;
 }
 
 void wayfire_view_t::set_geometry(wf_geometry g)
@@ -741,6 +749,7 @@ void wayfire_view_t::reposition_relative_to_parent()
 
 void wayfire_view_t::map(wlr_surface *surface)
 {
+    _is_mapped = true;
     wayfire_surface_t::map(surface);
 
     if (role == WF_VIEW_ROLE_TOPLEVEL && !parent && !maximized && !fullscreen)
@@ -777,6 +786,8 @@ void emit_view_unmap(wayfire_view view)
 
 void wayfire_view_t::unmap()
 {
+    _is_mapped = false;
+
     if (parent)
         set_toplevel_parent(nullptr);
 

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -388,6 +388,8 @@ void wayfire_unmanaged_xwayland_view::commit()
 
 void wayfire_unmanaged_xwayland_view::map(wlr_surface *surface)
 {
+    _is_mapped = true;
+
     /* move to the output where our center is
      * FIXME: this is a bad idea, because a dropdown menu might get sent to
      * an incorrect output. However, no matter how we calculate the real
@@ -436,6 +438,8 @@ void wayfire_unmanaged_xwayland_view::map(wlr_surface *surface)
 
 void wayfire_unmanaged_xwayland_view::unmap()
 {
+    _is_mapped = false;
+
     if (wlr_xwayland_or_surface_wants_focus(xw))
         emit_view_unmap(self());
 
@@ -518,7 +522,7 @@ wlr_surface *wayfire_unmanaged_xwayland_view::get_keyboard_focus_surface()
 {
     if (!wlr_xwayland_or_surface_wants_focus(xw))
         return nullptr;
-    return surface;
+    return wayfire_view_t::get_keyboard_focus_surface();
 }
 
 void wayfire_unmanaged_xwayland_view::destroy()


### PR DESCRIPTION
This PR implements a new type of view, compositor views. They have the same interface as regular views, however they come with compositor-generated content. Current use: move plugin. Using compositor views we can temporarily show a view on multiple monitors, so that the user sees a "smooth" transition between outputs. Once the move plugin exits, the view remains visible on only one output, as is designed.

The PR also uses compositor views to provide preview when snapping windows with the move plugin.

Fixes #99 Fixes #92 Fixes #12 