### PR TITLE
Properly manage GL state

### DIFF
--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -102,8 +102,6 @@ class FireTransformer : public wf_view_transformer_t
         auto ortho = glm::ortho(1.0f * target_fb.geometry.x, 1.0f * target_fb.geometry.x + 1.0f * target_fb.geometry.width,
                                 1.0f * target_fb.geometry.y + 1.0f * target_fb.geometry.height, 1.0f * target_fb.geometry.y);
 
-        OpenGL::use_default_program();
-
         float x = src_box.x, y = src_box.y, w = src_box.width, h = src_box.height;
         gl_geometry src_geometry = {x, y, x + w, y + h * progress_line};
 

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -95,7 +95,7 @@ class FireTransformer : public wf_view_transformer_t
                                     wlr_box scissor_box,
                                     const wf_framebuffer& target_fb)
     {
-        target_fb.bind();
+        OpenGL::render_begin(target_fb);
         target_fb.scissor(scissor_box);
 
         // render view
@@ -118,7 +118,9 @@ class FireTransformer : public wf_view_transformer_t
 
         auto translate = glm::translate(glm::mat4(1.0),
                                         {src_box.x, src_box.y, 0});
-        ps.render(target_fb.transform * ortho * translate);
+
+        ps.render(target_fb.transform * ortho * translate); // will reset the gl program
+        OpenGL::render_end();
     }
 };
 

--- a/plugins/animate/fire/particle.cpp
+++ b/plugins/animate/fire/particle.cpp
@@ -165,7 +165,8 @@ int ParticleSystem::statistic()
 
 void ParticleSystem::create_program()
 {
-    wlr_renderer_begin(core->renderer, 10, 10); // load the proper context
+    /* Just load the proper context, viewport doesn't matter */
+    OpenGL::render_begin();
 
     auto vss = OpenGL::compile_shader(particle_vert_source, GL_VERTEX_SHADER);
     auto fss = OpenGL::compile_shader(particle_frag_source, GL_FRAGMENT_SHADER);
@@ -183,7 +184,7 @@ void ParticleSystem::create_program()
     program.matrix    = GL_CALL(glGetUniformLocation(program.id, "matrix"));
     program.smoothing = GL_CALL(glGetUniformLocation(program.id, "smoothing"));
 
-    wlr_renderer_end(core->renderer);
+    OpenGL::render_end();
 }
 
 void ParticleSystem::render(glm::mat4 matrix)
@@ -224,6 +225,8 @@ void ParticleSystem::render(glm::mat4 matrix)
     /* Darken the background */
     GL_CALL(glVertexAttribPointer(program.color, 4, GL_FLOAT,
                                   false, 0, dark_color.data()));
+
+    GL_CALL(glEnable(GL_BLEND));
     GL_CALL(glBlendFunc(GL_ZERO, GL_ONE_MINUS_SRC_ALPHA));
     GL_CALL(glUniform1f(program.smoothing, 0.7f));
     // TODO: optimize shaders for this case
@@ -242,6 +245,8 @@ void ParticleSystem::render(glm::mat4 matrix)
     GL_CALL(glVertexAttribDivisor(program.center, 0));
     GL_CALL(glVertexAttribDivisor(program.color, 0));
 
+    GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
+    GL_CALL(glUseProgram(0));
 
     GL_CALL(glDisableVertexAttribArray(program.position));
     GL_CALL(glDisableVertexAttribArray(program.radius));

--- a/plugins/animate/system_fade.hpp
+++ b/plugins/animate/system_fade.hpp
@@ -51,14 +51,16 @@ class wf_system_fade
             auto geometry = output->get_relative_geometry();
             geometry = get_output_box_from_box(geometry, output->handle->scale);
 
+            OpenGL::render_begin(output->render->get_target_framebuffer());
+
             float matrix[9];
             wlr_matrix_project_box(matrix, &geometry,
                                    WL_OUTPUT_TRANSFORM_NORMAL,
                                    0, output->handle->transform_matrix);
 
-            wlr_renderer_scissor(core->renderer, NULL);
             wlr_render_quad_with_matrix(core->renderer, color, matrix);
 
+            OpenGL::render_end();
             if (!duration.running())
                 finish();
         }

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -143,7 +143,7 @@ class simple_decoration_surface : public wayfire_compositor_subsurface_t, public
             float matrix[9];
             wlr_matrix_project_box(matrix, &geometry, WL_OUTPUT_TRANSFORM_NORMAL, 0, projection);
 
-            wlr_renderer_begin(core->renderer, fb.width, fb.height);
+            OpenGL::render_begin(fb.width, fb.height, fb.fb);
             auto sbox = scissor; wlr_renderer_scissor(core->renderer, &sbox);
 
             wlr_render_quad_with_matrix(core->renderer, active ? border_color : border_color_inactive, matrix);
@@ -165,7 +165,8 @@ class simple_decoration_surface : public wayfire_compositor_subsurface_t, public
             OpenGL::use_default_program();
             OpenGL::render_transformed_texture(tex, gg, {}, ortho, {1, 1, 1, 1}, TEXTURE_TRANSFORM_INVERT_Y);
 
-            wlr_renderer_end(core->renderer);
+            GL_CALL(glUseProgram(0));
+            OpenGL::render_end();
         }
 
         virtual void _render_pixman(const wlr_fb_attribs& fb, int x, int y, pixman_region32_t* damage)
@@ -193,7 +194,6 @@ class simple_decoration_surface : public wayfire_compositor_subsurface_t, public
 
         virtual void render_fb(pixman_region32_t* damage, wf_framebuffer fb)
         {
-            GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb.fb));
             auto obox = get_output_geometry();
             render_pixman(wlr_fb_attribs{fb}, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);
         }

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -162,8 +162,8 @@ class simple_decoration_surface : public wayfire_compositor_subsurface_t, public
             gg.x2 = geometry.x + geometry.width;
             gg.y2 = geometry.y + titlebar;
 
-            OpenGL::use_default_program();
-            OpenGL::render_transformed_texture(tex, gg, {}, ortho, {1, 1, 1, 1}, TEXTURE_TRANSFORM_INVERT_Y);
+            OpenGL::render_transformed_texture(tex, gg, {}, ortho, {1, 1, 1, 1},
+                TEXTURE_TRANSFORM_INVERT_Y);
 
             GL_CALL(glUseProgram(0));
             OpenGL::render_end();
@@ -192,7 +192,7 @@ class simple_decoration_surface : public wayfire_compositor_subsurface_t, public
             pixman_region32_fini(&frame_region);
         }
 
-        virtual void render_fb(pixman_region32_t* damage, wf_framebuffer fb)
+        virtual void render_fb(pixman_region32_t* damage, const wf_framebuffer& fb)
         {
             auto obox = get_output_geometry();
             render_pixman(wlr_fb_attribs{fb}, obox.x - fb.geometry.x, obox.y - fb.geometry.y, damage);

--- a/plugins/single_plugins/compositor-view-test.cpp
+++ b/plugins/single_plugins/compositor-view-test.cpp
@@ -27,13 +27,13 @@ class test_view : public wayfire_compositor_view_t, public wayfire_compositor_in
             float matrix[9];
             wlr_matrix_project_box(matrix, &g, WL_OUTPUT_TRANSFORM_NORMAL, 0, projection);
 
-            wlr_renderer_begin(core->renderer, fb.width, fb.height);
+            OpenGL::render_begin(fb.width, fb.height, fb.fb);
             auto sbox = scissor; wlr_renderer_scissor(core->renderer, &sbox);
 
             float color[] = {1.0f, 0.0, 1.0f, 1.0f};
 
             wlr_render_quad_with_matrix(core->renderer, color, matrix);
-            wlr_renderer_end(core->renderer);
+            OpenGL::render_end();
         }
 
         virtual bool accepts_input(int sx, int sy)

--- a/plugins/single_plugins/invert.cpp
+++ b/plugins/single_plugins/invert.cpp
@@ -44,92 +44,109 @@ class wayfire_invert_screen : public wayfire_plugin_t
     GLuint program, posID, uvID;
 
     public:
-        void init(wayfire_config *config)
+
+    void load_program()
+    {
+        OpenGL::render_begin();
+
+        auto vs = OpenGL::compile_shader(vertex_shader, GL_VERTEX_SHADER);
+        auto fs = OpenGL::compile_shader(fragment_shader, GL_FRAGMENT_SHADER);
+
+        program = GL_CALL(glCreateProgram());
+        GL_CALL(glAttachShader(program, vs));
+        GL_CALL(glAttachShader(program, fs));
+        GL_CALL(glLinkProgram(program));
+
+        /* won't be deleted until program is deleted */
+        GL_CALL(glDeleteShader(vs));
+        GL_CALL(glDeleteShader(fs));
+
+        posID = GL_CALL(glGetAttribLocation(program, "position"));
+        uvID  = GL_CALL(glGetAttribLocation(program, "uvPosition"));
+
+        OpenGL::render_end();
+    }
+
+
+    void init(wayfire_config *config)
+    {
+        auto section = config->get_section("invert");
+        auto toggle_key = section->get_option("toggle", "<super> KEY_I");
+
+        hook = [=] (uint32_t fb, uint32_t tex, uint32_t target)
         {
-            auto section = config->get_section("invert");
-            auto toggle_key = section->get_option("toggle", "<super> KEY_I");
-
-            hook = [=] (uint32_t fb, uint32_t tex, uint32_t target)
-            {
-                render(fb, tex, target);
-            };
+            render(fb, tex, target);
+        };
 
 
-            toggle_cb = [=] () {
-                if (active)
-                {
-                    output->render->rem_post(&hook);
-                } else
-                {
-                    output->render->add_post(&hook);
-                }
-
-                active = !active;
-            };
-
-            auto vs = OpenGL::compile_shader(vertex_shader, GL_VERTEX_SHADER);
-            auto fs = OpenGL::compile_shader(fragment_shader, GL_FRAGMENT_SHADER);
-
-            program = GL_CALL(glCreateProgram());
-            GL_CALL(glAttachShader(program, vs));
-            GL_CALL(glAttachShader(program, fs));
-            GL_CALL(glLinkProgram(program));
-
-            /* won't be deleted until program is deleted */
-            GL_CALL(glDeleteShader(vs));
-            GL_CALL(glDeleteShader(fs));
-
-            posID = GL_CALL(glGetAttribLocation(program, "position"));
-            uvID  = GL_CALL(glGetAttribLocation(program, "uvPosition"));
-
-            output->add_activator(toggle_key, &toggle_cb);
-        }
-
-        void render(uint32_t fb, uint32_t tex, uint32_t target)
-        {
-            log_info("invert gets %u %u", fb, target);
-            GL_CALL(glUseProgram(program));
-            GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
-            GL_CALL(glActiveTexture(GL_TEXTURE0));
-
-            static const float vertexData[] = {
-                -1.0f, -1.0f,
-                 1.0f, -1.0f,
-                 1.0f,  1.0f,
-                -1.0f,  1.0f
-            };
-
-            static const float coordData[] = {
-                0.0f, 0.0f,
-                1.0f, 0.0f,
-                1.0f, 1.0f,
-                0.0f, 1.0f
-            };
-
-            GL_CALL(glVertexAttribPointer(posID, 2, GL_FLOAT, GL_FALSE, 0, vertexData));
-            GL_CALL(glEnableVertexAttribArray(posID));
-
-            GL_CALL(glVertexAttribPointer(uvID, 2, GL_FLOAT, GL_FALSE, 0, coordData));
-            GL_CALL(glEnableVertexAttribArray(uvID));
-
-            GL_CALL(glDisable(GL_BLEND));
-            GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, target));
-            GL_CALL(glDrawArrays (GL_TRIANGLE_FAN, 0, 4));
-            GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
-
-            GL_CALL(glDisableVertexAttribArray(posID));
-            GL_CALL(glDisableVertexAttribArray(uvID));
-            GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
-        }
-
-        void fini()
-        {
+        toggle_cb = [=] () {
             if (active)
+            {
                 output->render->rem_post(&hook);
+            } else
+            {
+                output->render->add_post(&hook);
+            }
 
-            GL_CALL(glDeleteProgram(program));
-            output->rem_binding(&toggle_cb);
-        }
+            active = !active;
+        };
+
+        load_program();
+        output->add_activator(toggle_key, &toggle_cb);
+    }
+
+    void render(uint32_t fb, uint32_t tex, uint32_t target)
+    {
+        static const float vertexData[] = {
+            -1.0f, -1.0f,
+            1.0f, -1.0f,
+            1.0f,  1.0f,
+            -1.0f,  1.0f
+        };
+
+        static const float coordData[] = {
+            0.0f, 0.0f,
+            1.0f, 0.0f,
+            1.0f, 1.0f,
+            0.0f, 1.0f
+        };
+
+        OpenGL::render_begin(output->render->get_target_framebuffer());
+
+        GL_CALL(glUseProgram(program));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
+        GL_CALL(glActiveTexture(GL_TEXTURE0));
+
+        GL_CALL(glVertexAttribPointer(posID, 2, GL_FLOAT, GL_FALSE, 0, vertexData));
+        GL_CALL(glEnableVertexAttribArray(posID));
+
+        GL_CALL(glVertexAttribPointer(uvID, 2, GL_FLOAT, GL_FALSE, 0, coordData));
+        GL_CALL(glEnableVertexAttribArray(uvID));
+
+        GL_CALL(glDisable(GL_BLEND));
+        GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, target));
+        GL_CALL(glDrawArrays (GL_TRIANGLE_FAN, 0, 4));
+
+        GL_CALL(glEnable(GL_BLEND));
+
+        GL_CALL(glDisableVertexAttribArray(posID));
+        GL_CALL(glDisableVertexAttribArray(uvID));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+
+        OpenGL::render_end();
+    }
+
+    void fini()
+    {
+        if (active)
+            output->render->rem_post(&hook);
+
+        OpenGL::render_begin();
+        GL_CALL(glDeleteProgram(program));
+        OpenGL::render_end();
+
+        output->rem_binding(&toggle_cb);
+    }
 };
 
 extern "C"

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -585,13 +585,9 @@ class WayfireSwitcher : public wayfire_plugin_t
 
     void render_output(uint32_t fb)
     {
-        GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb));
-        OpenGL::use_device_viewport();
-
-        wlr_renderer_scissor(core->renderer, NULL);
-
-        GL_CALL(glClearColor(0.0, 0.0, 0.0, 1.0));
-        GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
+        OpenGL::render_begin(output->render->get_target_framebuffer());
+        OpenGL::clear({0, 0, 0, 1});
+        OpenGL::render_end();
 
         dim_background(background_dim_duration.progress());
         for (auto view : get_background_views())
@@ -615,8 +611,6 @@ class WayfireSwitcher : public wayfire_plugin_t
             if (!active)
                 deinit_switcher();
         }
-
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
     }
 
     /* delete all views matching the given criteria, skipping the first "start" views */

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -94,10 +94,7 @@ class WayfireSwitcher : public wayfire_plugin_t
         grab_interface->name = "switcher";
         grab_interface->abilities_mask = WF_ABILITY_CONTROL_WM;
 
-        switcher_renderer = [=] (uint32_t fb)
-        {
-            render_output(fb);
-        };
+        switcher_renderer = [=] (const wf_framebuffer& buffer) { render_output(buffer); };
 
         damage = [=] ()
         {
@@ -552,7 +549,7 @@ class WayfireSwitcher : public wayfire_plugin_t
         return SwitcherView{view, {}, SWITCHER_POSITION_CENTER};
     }
 
-    void render_view(const SwitcherView& sv)
+    void render_view(const SwitcherView& sv, const wf_framebuffer& buffer)
     {
         auto transform = dynamic_cast<wf_3D_view*> (
             sv.view->get_transformer(switcher_transformer).get());
@@ -583,26 +580,26 @@ class WayfireSwitcher : public wayfire_plugin_t
         transform->color[3] = 1.0;
     }
 
-    void render_output(uint32_t fb)
+    void render_output(const wf_framebuffer& fb)
     {
-        OpenGL::render_begin(output->render->get_target_framebuffer());
+        OpenGL::render_begin(fb);
         OpenGL::clear({0, 0, 0, 1});
         OpenGL::render_end();
 
         dim_background(background_dim_duration.progress());
         for (auto view : get_background_views())
-            view->render_fb(NULL, output->render->get_target_framebuffer());
+            view->render_fb(NULL, fb);
 
         /* Render in the reverse order because we don't use depth testing */
         auto it = views.rbegin();
         while (it != views.rend())
         {
-            render_view(*it);
+            render_view(*it, fb);
             ++it;
         }
 
         for (auto view : get_overlay_views())
-            view->render_fb(NULL, output->render->get_target_framebuffer());
+            view->render_fb(NULL, fb);
 
         if (!duration.running())
         {

--- a/plugins/single_plugins/zoom.cpp
+++ b/plugins/single_plugins/zoom.cpp
@@ -22,9 +22,8 @@ class wayfire_zoom_screen : public wayfire_plugin_t
     public:
         void init(wayfire_config *config)
         {
-            hook = [=] (uint32_t fb, uint32_t tex, uint32_t target)
-            {
-                render(fb, tex, target);
+            hook = [=] (const wf_framebuffer_base& source, const wf_framebuffer_base& dest) {
+                render(source, dest);
             };
 
             axis = [=] (wlr_event_pointer_axis* ev)
@@ -66,7 +65,8 @@ class wayfire_zoom_screen : public wayfire_plugin_t
             }
         }
 
-        void render(uint32_t fb, uint32_t tex, uint32_t target)
+        void render(const wf_framebuffer_base& source,
+            const wf_framebuffer_base& destination)
         {
             auto w = output->handle->width;
             auto h = output->handle->height;
@@ -86,11 +86,10 @@ class wayfire_zoom_screen : public wayfire_plugin_t
             const float x1 = x * scale;
             const float y1 = y * scale;
 
-            OpenGL::render_begin(output->render->get_target_framebuffer());
-            GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER, fb));
-            GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, target));
-
-            GL_CALL(glBlitFramebuffer(x1, y1, x1 + tw, y1 + th, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_LINEAR));
+            OpenGL::render_begin(source);
+            GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, destination.fb));
+            GL_CALL(glBlitFramebuffer(x1, y1, x1 + tw, y1 + th, 0, 0, w, h,
+                    GL_COLOR_BUFFER_BIT, GL_LINEAR));
             OpenGL::render_end();
 
             if (!duration.running() && current_zoom - 1 <= 0.01)

--- a/plugins/single_plugins/zoom.cpp
+++ b/plugins/single_plugins/zoom.cpp
@@ -86,11 +86,12 @@ class wayfire_zoom_screen : public wayfire_plugin_t
             const float x1 = x * scale;
             const float y1 = y * scale;
 
+            OpenGL::render_begin(output->render->get_target_framebuffer());
             GL_CALL(glBindFramebuffer(GL_READ_FRAMEBUFFER, fb));
             GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, target));
 
             GL_CALL(glBlitFramebuffer(x1, y1, x1 + tw, y1 + th, 0, 0, w, h, GL_COLOR_BUFFER_BIT, GL_LINEAR));
-            GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+            OpenGL::render_end();
 
             if (!duration.running() && current_zoom - 1 <= 0.01)
             {

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -52,7 +52,7 @@ void main()
             return;
 
         /* viewport dimensions don't matter really, we just care to get the proper GL context */
-        wlr_renderer_begin(core->renderer, 10, 10);
+        OpenGL::render_begin();
 
         auto vs = OpenGL::compile_shader(vertex_source, GL_VERTEX_SHADER);
         auto fs = OpenGL::compile_shader(frag_source, GL_FRAGMENT_SHADER);
@@ -69,19 +69,20 @@ void main()
         GL_CALL(glDeleteShader(vs));
         GL_CALL(glDeleteShader(fs));
 
-        wlr_renderer_end(core->renderer);
+        OpenGL::render_end();
     }
 
     void destroy_program()
     {
         if (--times_loaded == 0)
         {
-            wlr_renderer_begin(core->renderer, 10, 10);
+            OpenGL::render_begin();
             GL_CALL(glDeleteProgram(program));
-            wlr_renderer_end(core->renderer);
+            OpenGL::render_end();
         }
     }
 
+    /* Requires bound opengl context */
     void render_triangles(GLuint tex, glm::mat4 mat, float *pos, float *uv, int cnt)
     {
         GL_CALL(glUseProgram(program));
@@ -267,7 +268,7 @@ class wf_wobbly : public wf_view_transformer_t
     virtual void render_with_damage(uint32_t src_tex, wlr_box src_box,
                             wlr_box scissor_box, const wf_framebuffer& target_fb)
     {
-        target_fb.bind();
+        OpenGL::render_begin(target_fb);
         target_fb.scissor(scissor_box);
 
         auto ortho = glm::ortho(1.0f * target_fb.geometry.x, 1.0f * target_fb.geometry.x + 1.0f * target_fb.geometry.width,
@@ -325,6 +326,8 @@ class wf_wobbly : public wf_view_transformer_t
         wobbly_graphics::render_triangles(src_tex, target_fb.transform * ortho,
                                           vert.data(), uv.data(),
                                           model->x_cells * model->y_cells * 2);
+
+        OpenGL::render_end();
     }
 
     void start_grab(int x, int y)

--- a/src/api/compositor-surface.hpp
+++ b/src/api/compositor-surface.hpp
@@ -32,7 +32,7 @@ class wayfire_compositor_subsurface_t : public wayfire_surface_t, public wayfire
         virtual bool is_mapped() { return true; }
 
         virtual wf_geometry get_output_geometry() { assert(false); return {}; }
-        virtual void  render_fb(pixman_region32_t* damage, wf_framebuffer fb) { assert(false); }
+        virtual void  render_fb(pixman_region32_t* damage, const wf_framebuffer& fb) { assert(false); }
 
         virtual void send_frame_done(const timespec& now) {}
 

--- a/src/api/compositor-surface.hpp
+++ b/src/api/compositor-surface.hpp
@@ -35,6 +35,7 @@ class wayfire_compositor_subsurface_t : public wayfire_surface_t, public wayfire
         virtual void  render_fb(pixman_region32_t* damage, const wf_framebuffer& fb) { assert(false); }
 
         virtual void send_frame_done(const timespec& now) {}
+        virtual void subtract_opaque(pixman_region32_t* region, int x, int y) {}
 
         /* all input events coordinates are surface-local */
 

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -30,6 +30,7 @@ class wayfire_compositor_view_t : public wayfire_compositor_surface_t, public wa
     public:
         virtual bool is_mapped() { return _is_mapped; }
         virtual void send_frame_done(const timespec& now) {}
+        virtual void subtract_opaque(pixman_region32_t* region, int x, int y) {}
 
         /* override this if you want to get pointer events or to stop input passthrough */
         virtual bool accepts_input(int32_t sx, int32_t sy) { return false; }

--- a/src/api/compositor-view.hpp
+++ b/src/api/compositor-view.hpp
@@ -28,13 +28,11 @@ class wayfire_compositor_view_t : public wayfire_compositor_surface_t, public wa
         virtual void _wlr_render_box(const wlr_fb_attribs& fb, int x, int y, const wlr_box& scissor) { assert(false); }
 
     public:
-
         virtual bool is_mapped() { return _is_mapped; }
         virtual void send_frame_done(const timespec& now) {}
 
         /* override this if you want to get pointer events or to stop input passthrough */
         virtual bool accepts_input(int32_t sx, int32_t sy) { return false; }
-
 
     public:
         wayfire_compositor_view_t();
@@ -57,7 +55,7 @@ class wayfire_compositor_view_t : public wayfire_compositor_surface_t, public wa
         virtual bool should_be_decorated() { return false; }
 
         /* Usually compositor view implementations don't need to override this */
-        virtual void render_fb(pixman_region32_t* damage, wf_framebuffer fb);
+        virtual void render_fb(pixman_region32_t* damage, const wf_framebuffer& fb);
 
         /* NON-API functions which don't have a meaning for compositor views */
         virtual bool update_size() { assert(false); }
@@ -103,7 +101,7 @@ class wayfire_mirror_view_t : public wayfire_compositor_view_t
 
     virtual bool can_take_snapshot();
     virtual void take_snapshot();
-    virtual void render_fb(pixman_region32_t* damage, wf_framebuffer fb);
+    virtual void render_fb(pixman_region32_t* damage, const wf_framebuffer& fb);
 
     virtual wf_point get_output_position();
     virtual wf_geometry get_output_geometry();

--- a/src/api/core.hpp
+++ b/src/api/core.hpp
@@ -78,6 +78,7 @@ class wayfire_core : public wf_object_base
         wl_display *display;
         wl_event_loop *ev_loop;
         wlr_backend *backend;
+        wlr_egl *egl;
         wlr_renderer *renderer;
         wlr_output_layout *output_layout;
         wlr_compositor *compositor;

--- a/src/api/nonstd/noncopyable.hpp
+++ b/src/api/nonstd/noncopyable.hpp
@@ -1,0 +1,15 @@
+#ifndef NONCOPYABLE_HPP
+#define NONCOPYABLE_HPP
+
+class noncopyable_t
+{
+    public:
+        noncopyable_t() = default;
+        ~noncopyable_t() = default;
+
+    private:
+        noncopyable_t(const noncopyable_t&) = delete;
+        noncopyable_t& operator=(const noncopyable_t&) = delete;
+};
+
+#endif /* end of include guard: NONCOPYABLE_HPP */

--- a/src/api/opengl.hpp
+++ b/src/api/opengl.hpp
@@ -5,6 +5,7 @@
 #include <GLES3/gl3ext.h>
 
 #include <config.hpp>
+#include <nonstd/noncopyable.hpp>
 
 extern "C"
 {
@@ -31,45 +32,79 @@ void gl_call(const char*, uint32_t, const char*);
 #define TEXTURE_TRANSFORM_INVERT_X     (1 << 0)
 #define TEXTURE_TRANSFORM_INVERT_Y     (1 << 1)
 #define TEXTURE_TRANSFORM_USE_COLOR    (1 << 2)
-#define TEXTURE_TRANSFORM_USE_DEVCOORD (1 << 3)
 #define TEXTURE_USE_TEX_GEOMETRY       (1 << 4)
-#define DONT_RELOAD_PROGRAM            (1 << 5)
 
 struct gl_geometry
 {
     float x1, y1, x2, y2;
 };
 
-struct wf_framebuffer
+/* Simple framebuffer, used mostly to allocate framebuffers for workspace
+ * streams.
+ *
+ * Resources (tex/fb) are not automatically destroyed */
+struct wf_framebuffer_base : public noncopyable_t
 {
     GLuint tex = -1, fb = -1;
+    int32_t viewport_width = 0, viewport_height = 0;
+
+    wf_framebuffer_base() = default;
+    wf_framebuffer_base(wf_framebuffer_base&& other);
+    wf_framebuffer_base& operator = (wf_framebuffer_base&& other);
+
+    /* The functions below assume they are called between
+     * OpenGL::render_begin() and OpenGL::render_end() */
+
+    /* will invalidate texture contents if width or height changes.
+     * If tex and/or fb haven't been set, it creates them
+     * Return true if texture was created/invalidated */
+    bool allocate(int width, int height);
+
+    /* Make the framebuffer current, and adjust viewport to its size */
+    void bind() const;
+
+    /* Set the GL scissor to the given box, after inverting it to match GL
+     * coordinate space */
+    void scissor(wlr_box box) const;
+
+    /* Will destroy the texture and framebuffer
+     * Warning: will destroy tex/fb even if they have been allocated outside of
+     * allocate() */
+    void release();
+
+    /* Reset the framebuffer, WITHOUT freeing resources.
+     * There is no need to call reset() after release() */
+    void reset();
+
+    private:
+    void copy_state(wf_framebuffer_base&& other);
+};
+
+/* A more feature-complete framebuffer.
+ * It represents an area of the output, with the corresponding dimensions,
+ * transforms, etc */
+struct wf_framebuffer : public wf_framebuffer_base
+{
     wf_geometry geometry = {0, 0, 0, 0};
 
     glm::mat4 transform = glm::mat4(1.0);
     uint32_t wl_transform = WL_OUTPUT_TRANSFORM_NORMAL;
-
-    uint32_t viewport_width, viewport_height;
-
-    void init();
-    void init(int w, int h);
-    void bind() const;
-    void scissor(wlr_box box) const;
-    void release();
 };
 
 namespace OpenGL
 {
-    /* Different Context is kept for each output */
-    /* Each of the following functions uses the currently bound context */
-    struct context_t {
-        GLuint program;
-
-        GLuint mvpID, colorID;
-        GLuint position, uvPosition;
-
-        wayfire_output *output;
-        int32_t width, height;
-    };
+    /* NOT API
+     * Initialize OpenGL helper functions */
+    void init();
+    /* NOT API
+     * Destroys the default GL program and resources */
+    void fini();
+    /* NOT API
+     * Indicate we have started repainting the given output */
+    void bind_output(wayfire_output *output);
+    /* NOT API
+     * Indicate the output frame has been finished */
+    void unbind_output(wayfire_output *output);
 
     /* "Begin" rendering to the given framebuffer and the given viewport.
      * All rendering operations should happen between render_begin and render_end, because
@@ -78,21 +113,16 @@ namespace OpenGL
      * The other functions below assume they are called between render_begin()
      * and render_end() */
     void render_begin(); // use if you just want to bind GL context but won't draw
-    void render_begin(const wf_framebuffer& fb);
+    void render_begin(const wf_framebuffer_base& fb);
     void render_begin(int32_t viewport_width, int32_t viewport_height, uint32_t fb = 0);
 
-    /* Resets bound framebuffer and scissor box */
+    /* Call this to indicate an end of the rendering.
+     * Resets bound framebuffer and scissor box.
+     * render_end() must be called for each render_begin() */
     void render_end();
 
-    wf_geometry get_device_viewport();
-    /* simply calls glViewport() with the geometry from get_device_viewport() */
-    void use_device_viewport();
-
+    /* Clear the currently bound framebuffer with the given color */
     void clear(wf_color color, uint32_t mask = GL_COLOR_BUFFER_BIT);
-
-    context_t* create_gles_context(wayfire_output *output, const char *shader_src_path);
-    void bind_context(context_t* ctx);
-    void release_context(context_t *ctx);
 
     /* texg arguments are used only when bits has USE_TEX_GEOMETRY
      * if you don't wish to use them, simply pass {} as argument */
@@ -103,21 +133,10 @@ namespace OpenGL
                                     glm::vec4 color = glm::vec4(1.f),
                                     uint32_t bits = 0);
 
-    void render_texture(GLuint tex, const gl_geometry& g,
-                        const gl_geometry& texg, uint32_t bits);
-
-    GLuint load_shader(const char *path, GLuint type);
-    GLuint compile_shader(const char *src, GLuint type);
-
-    void prepare_framebuffer(GLuint& fbuff, GLuint& texture,
-                             float scale_x = 1, float scale_y = 1);
-
-    void prepare_framebuffer_size(int w, int h,
-                                  GLuint& fbuff, GLuint& texture,
-                                  float scale_x = 1, float scale_y = 1);
-
-    /* set program to current program */
-    void use_default_program();
+    /* Reads the shader source from the given file and compiles it */
+    GLuint load_shader(std::string path, GLuint type);
+    /* Compiles the given shader source */
+    GLuint compile_shader(std::string source, GLuint type);
 }
 
 /* utils */

--- a/src/api/view-transform.hpp
+++ b/src/api/view-transform.hpp
@@ -33,7 +33,7 @@ class wf_view_transformer_t
                                         wlr_box scissor_box,
                                         const wf_framebuffer& target_fb) = 0;
 
-        virtual ~wf_view_transformer_t() {log_info("destoryed"); }
+        virtual ~wf_view_transformer_t() {}
 };
 
 enum

--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -123,6 +123,10 @@ class wayfire_surface_t
         virtual bool accepts_input(int32_t sx, int32_t sy);
         virtual void send_frame_done(const timespec& now);
 
+        /* Subtract the opaque region of the surface from region, supposing
+         * the surface is positioned at (x, y) */
+        virtual void subtract_opaque(pixman_region32_t* region, int x, int y);
+
         virtual wl_client *get_client();
 
         virtual bool is_mapped();

--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -160,7 +160,7 @@ class wayfire_surface_t
         virtual void  render_pixman(const wlr_fb_attribs& fb, int x, int y, pixman_region32_t* damage);
 
         /* render the surface to the given fb */
-        virtual void render_fb(pixman_region32_t* damage, wf_framebuffer fb);
+        virtual void render_fb(pixman_region32_t* damage, const wf_framebuffer& fb);
 
         /* iterate all (sub) surfaces, popups, etc. in top-most order
          * for example, first popups, then subsurfaces, then main surface
@@ -206,19 +206,14 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
         uint32_t id;
         virtual void damage(const wlr_box& box);
 
-        struct offscreen_buffer_t
+        struct offscreen_buffer_t : public wf_framebuffer_base
         {
-            uint32_t fbo = -1, tex = -1;
             /* used to store output_geometry when the view has been destroyed */
             int32_t output_x = 0, output_y = 0;
-            int32_t fb_width = 0, fb_height = 0;
             float fb_scale = 1;
+
             pixman_region32_t cached_damage;
-
-            void init(int w, int h);
-            void fini();
             bool valid();
-
         } offscreen_buffer;
 
         // the last buffer_age of this view for which the buffer was made
@@ -399,7 +394,7 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
 
         bool has_transformer();
 
-        virtual void render_fb(pixman_region32_t* damage, wf_framebuffer framebuffer);
+        virtual void render_fb(pixman_region32_t* damage, const wf_framebuffer& framebuffer);
 
         bool has_snapshot = false;
         virtual bool can_take_snapshot();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -43,9 +43,6 @@ void wayfire_core::configure(wayfire_config *config)
 
     vwidth  = *section->get_option("vwidth", "3");
     vheight = *section->get_option("vheight", "3");
-
-    shadersrc   = section->get_option("shadersrc", INSTALL_PREFIX "/share/wayfire/shaders")->as_string();
-    run_panel   = section->get_option("run_panel", "1")->as_int();
 }
 
 static void handle_output_layout_changed(wl_listener*, void *)
@@ -172,6 +169,8 @@ void wayfire_core::init(wayfire_config *conf)
 #ifdef BUILD_WITH_IMAGEIO
     image_io::init();
 #endif
+
+    OpenGL::init();
 }
 
 void refocus_idle_cb(void *data)
@@ -327,10 +326,6 @@ void wayfire_core::remove_output(wayfire_output *output)
         uninhibit_output(output);
 
     delete output;
-
-    /* Make sure we have a bound context */
-    for (auto& wo : outputs)
-        OpenGL::bind_context(wo.second->render->ctx);
 }
 
 void wayfire_core::refocus_active_output_active_view()

--- a/src/core/gldebug.hpp
+++ b/src/core/gldebug.hpp
@@ -1,0 +1,57 @@
+#include <GLES3/gl32.h>
+#include <debug.hpp>
+
+const char *getStrSrc(GLenum src)
+{
+    if(src == GL_DEBUG_SOURCE_API            )return "API";
+    if(src == GL_DEBUG_SOURCE_WINDOW_SYSTEM  )return "WINDOW_SYSTEM";
+    if(src == GL_DEBUG_SOURCE_SHADER_COMPILER)return "SHADER_COMPILER";
+    if(src == GL_DEBUG_SOURCE_THIRD_PARTY    )return "THIRD_PARTYB";
+    if(src == GL_DEBUG_SOURCE_APPLICATION    )return "APPLICATIONB";
+    if(src == GL_DEBUG_SOURCE_OTHER          )return "OTHER";
+    else return "UNKNOWN";
+}
+
+const char *getStrType(GLenum type)
+{
+    if(type == GL_DEBUG_TYPE_ERROR              )return "ERROR";
+    if(type == GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR)return "DEPRECATED_BEHAVIOR";
+    if(type == GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR )return "UNDEFINED_BEHAVIOR";
+    if(type == GL_DEBUG_TYPE_PORTABILITY        )return "PORTABILITY";
+    if(type == GL_DEBUG_TYPE_PERFORMANCE        )return "PERFORMANCE";
+    if(type == GL_DEBUG_TYPE_OTHER              )return "OTHER";
+    return "UNKNOWN";
+}
+
+const char *getStrSeverity(GLenum severity)
+{
+    if(severity == GL_DEBUG_SEVERITY_HIGH  )return "HIGH";
+    if(severity == GL_DEBUG_SEVERITY_MEDIUM)return "MEDIUM";
+    if(severity == GL_DEBUG_SEVERITY_LOW   )return "LOW";
+    if(severity == GL_DEBUG_SEVERITY_NOTIFICATION) return "NOTIFICATION";
+    return "UNKNOWN";
+}
+
+void errorHandler(GLenum src, GLenum type, GLuint id, GLenum severity,
+    GLsizei len, const GLchar *msg, const void *dummy)
+{
+    // ignore notifications
+    if(severity == GL_DEBUG_SEVERITY_NOTIFICATION)
+        return;
+
+    log_info(
+        "_______________________________________________\n"
+        "Source: %s\n"
+        "Type: %s\n"
+        "Severity: %s\n"
+        "Msg: %s\n"
+        "_______________________________________________\n",
+        getStrSrc(src), getStrType(type), getStrSeverity(severity), msg);
+}
+
+void enable_gl_synchronuous_debug()
+{
+    glEnable(GL_DEBUG_OUTPUT);
+    glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
+    glDebugMessageCallback(errorHandler, 0);
+}

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -5,11 +5,9 @@
 #include "core.hpp"
 #include "render-manager.hpp"
 
-#include <glm/gtc/matrix_transform.hpp>
+// #include "gldebug.hpp"
 
-namespace {
-    OpenGL::context_t *bound;
-}
+#include <glm/gtc/matrix_transform.hpp>
 
 const char* gl_error_string(const GLenum err) {
     switch (err) {
@@ -35,10 +33,22 @@ void gl_call(const char *func, uint32_t line, const char *glfunc) {
 
 namespace OpenGL
 {
-    GLuint compile_shader_from_file(const char *path, const char *src, GLuint type)
+    /* Different Context is kept for each output */
+    /* Each of the following functions uses the currently bound context */
+    struct
+    {
+        GLuint id;
+
+        GLuint mvpID, colorID;
+        GLuint position, uvPosition;
+    } program;
+
+    GLuint compile_shader_from_file(std::string path, std::string source, GLuint type)
     {
         GLuint shader = GL_CALL(glCreateShader(type));
-        GL_CALL(glShaderSource(shader, 1, &src, NULL));
+
+        const char *c_src = source.c_str();
+        GL_CALL(glShaderSource(shader, 1, &c_src, NULL));
 
         int s;
         char b1[10000];
@@ -48,26 +58,25 @@ namespace OpenGL
 
         if (s == GL_FALSE)
         {
-            log_error("Failed to load shader from %s\n; Errors:\n%s", path, b1);
+            log_error("Failed to load shader from %s\n; Errors:\n%s", path.c_str(), b1);
             return -1;
         }
 
         return shader;
     }
 
-    GLuint compile_shader(const char *src, GLuint type)
+    GLuint compile_shader(std::string source, GLuint type)
     {
-        return compile_shader_from_file("internal", src, type);
+        return compile_shader_from_file("internal", source, type);
     }
 
-    GLuint load_shader(const char *path, GLuint type) {
-
+    GLuint load_shader(std::string path, GLuint type)
+    {
         std::fstream file(path, std::ios::in);
-
         if(!file.is_open())
         {
-            log_error("cannot open shader file %s", path);
-            std::exit(1);
+            log_error("cannot open shader file %s", path.c_str());
+            return -1;
         }
 
         std::string str, line;
@@ -77,140 +86,60 @@ namespace OpenGL
         return compile_shader(str.c_str(), type);
     }
 
-    /*
-    const char *getStrSrc(GLenum src) {
-        if(src == GL_DEBUG_SOURCE_API            )return "API";
-        if(src == GL_DEBUG_SOURCE_WINDOW_SYSTEM  )return "WINDOW_SYSTEM";
-        if(src == GL_DEBUG_SOURCE_SHADER_COMPILER)return "SHADER_COMPILER";
-        if(src == GL_DEBUG_SOURCE_THIRD_PARTY    )return "THIRD_PARTYB";
-        if(src == GL_DEBUG_SOURCE_APPLICATION    )return "APPLICATIONB";
-        if(src == GL_DEBUG_SOURCE_OTHER          )return "OTHER";
-        else return "UNKNOWN";
-    }
 
-    const char *getStrType(GLenum type) {
-        if(type==GL_DEBUG_TYPE_ERROR              )return "ERROR";
-        if(type==GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR)return "DEPRECATED_BEHAVIOR";
-        if(type==GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR )return "UNDEFINED_BEHAVIOR";
-        if(type==GL_DEBUG_TYPE_PORTABILITY        )return "PORTABILITY";
-        if(type==GL_DEBUG_TYPE_PERFORMANCE        )return "PERFORMANCE";
-        if(type==GL_DEBUG_TYPE_OTHER              )return "OTHER";
-        return "UNKNOWN";
-    }
-
-    const char *getStrSeverity(GLenum severity) {
-        if(severity == GL_DEBUG_SEVERITY_HIGH  )return "HIGH";
-        if(severity == GL_DEBUG_SEVERITY_MEDIUM)return "MEDIUM";
-        if(severity == GL_DEBUG_SEVERITY_LOW   )return "LOW";
-        if(severity == GL_DEBUG_SEVERITY_NOTIFICATION) return "NOTIFICATION";
-        return "UNKNOWN";
-    }
-
-    void errorHandler(GLenum src, GLenum type,
-            GLuint id, GLenum severity,
-            GLsizei len, const GLchar *msg,
-            const void *dummy) {
-        // ignore notifications
-        if(severity == GL_DEBUG_SEVERITY_NOTIFICATION)
-            return;
-        debug << "_______________________________________________\n";
-        debug << "GLES debug: \n";
-        debug << "Source: " << getStrSrc(src) << std::endl;
-        debug << "Type: " << getStrType(type) << std::endl;
-        debug << "ID: " << id << std::endl;
-        debug << "Severity: " << getStrSeverity(severity) << std::endl;
-        debug << "Msg: " << msg << std::endl;;
-        debug << "_______________________________________________\n";
-    } */
-
-    context_t* create_gles_context(wayfire_output *output, const char *shaderSrcPath)
+    void init()
     {
-        context_t *ctx = new context_t;
-        ctx->output = output;
+        render_begin();
 
-        /*
-        if (file_debug == &file_info) {
-            glEnable(GL_DEBUG_OUTPUT);
-            glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-            glDebugMessageCallback(errorHandler, 0);
-        } */
+        // enable_gl_synchronuous_debug()
+        std::string shader_path = INSTALL_PREFIX "/share/wayfire/shaders";
+        GLuint vss = load_shader(shader_path + "/vertex.glsl", GL_VERTEX_SHADER);
+        GLuint fss = load_shader(shader_path + "/frag.glsl", GL_FRAGMENT_SHADER);
 
-        GLuint vss = load_shader(std::string(shaderSrcPath)
-                    .append("/vertex.glsl").c_str(),
-                     GL_VERTEX_SHADER);
+        program.id = GL_CALL(glCreateProgram());
 
-#ifndef WAYFIRE_GRAPHICS_DEBUG
-        GLuint fss = load_shader(std::string(shaderSrcPath)
-                    .append("/frag.glsl").c_str(),
-                    GL_FRAGMENT_SHADER);
-#else
-        GLuint fss = load_shader(std::string(shaderSrcPath)
-                    .append("/solid_frag.glsl").c_str(),
-                     GL_FRAGMENT_SHADER);
-#endif
-        ctx->program = GL_CALL(glCreateProgram());
+        GL_CALL(glAttachShader(program.id, vss));
+        GL_CALL(glAttachShader(program.id, fss));
+        GL_CALL(glLinkProgram(program.id));
 
-        GL_CALL(glAttachShader(ctx->program, vss));
-        GL_CALL(glAttachShader(ctx->program, fss));
-        GL_CALL(glLinkProgram(ctx->program));
-
-        ctx->mvpID      = GL_CALL(glGetUniformLocation(ctx->program, "MVP"));
-        ctx->colorID    = GL_CALL(glGetUniformLocation(ctx->program, "color"));
-        ctx->position   = GL_CALL(glGetAttribLocation(ctx->program, "position"));
-        ctx->uvPosition = GL_CALL(glGetAttribLocation(ctx->program, "uvPosition"));
+        program.mvpID      = GL_CALL(glGetUniformLocation(program.id, "MVP"));
+        program.colorID    = GL_CALL(glGetUniformLocation(program.id, "color"));
+        program.position   = GL_CALL(glGetAttribLocation(program.id, "position"));
+        program.uvPosition = GL_CALL(glGetAttribLocation(program.id, "uvPosition"));
 
         GL_CALL(glDeleteShader(vss));
         GL_CALL(glDeleteShader(fss));
-        return ctx;
+
+        render_end();
     }
 
-    void use_default_program() {
-         GL_CALL(glUseProgram(bound->program));
-    }
-
-    void bind_context(context_t *ctx) {
-        bound = ctx;
-
-        bound->width  = ctx->output->handle->width;
-        bound->height = ctx->output->handle->height;
-    }
-
-    wf_geometry get_device_viewport()
+    void fini()
     {
-        return {0, 0, bound->width, bound->height};
+        render_begin();
+        GL_CALL(glDeleteProgram(program.id));
+        render_end();
     }
 
-    void use_device_viewport()
+    namespace
     {
-        const auto vp = get_device_viewport();
-        GL_CALL(glViewport(vp.x, vp.y, vp.width, vp.height));
+        wayfire_output *current_output = NULL;
     }
 
-    void release_context(context_t *ctx)
+    void bind_output(wayfire_output *output)
     {
-        GL_CALL(glDeleteProgram(ctx->program));
-        delete ctx;
+        current_output = output;
     }
 
-    void render_texture(GLuint tex, const gl_geometry& g,
-            const gl_geometry& texg, uint32_t bits)
+    void unbind_output(wayfire_output *output)
     {
-        render_transformed_texture(tex, g, texg, glm::mat4(1.0f), glm::vec4(1.0), bits);
+        current_output = NULL;
     }
 
     void render_transformed_texture(GLuint tex,
-                                    const gl_geometry& g,
-                                    const gl_geometry& texg,
-                                    glm::mat4 model,
-                                    glm::vec4 color,
-                                    uint32_t bits)
+        const gl_geometry& g, const gl_geometry& texg,
+        glm::mat4 model, glm::vec4 color, uint32_t bits)
     {
-        /* TODO: perhaps clean many of the flags, as we won't use them anymore in wlroots */
-        if ((bits & DONT_RELOAD_PROGRAM) == 0)
-            GL_CALL(glUseProgram(bound->program));
-
-        if ((bits & TEXTURE_TRANSFORM_USE_DEVCOORD))
-            use_device_viewport();
+        GL_CALL(glUseProgram(program.id));
 
         gl_geometry final_g = g;
         if (bits & TEXTURE_TRANSFORM_INVERT_Y)
@@ -244,92 +173,23 @@ namespace OpenGL
 
         GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
         GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+
         GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
         GL_CALL(glActiveTexture(GL_TEXTURE0));
 
-        GL_CALL(glVertexAttribPointer(bound->position, 2, GL_FLOAT, GL_FALSE, 0, vertexData));
-        GL_CALL(glEnableVertexAttribArray(bound->position));
+        GL_CALL(glVertexAttribPointer(program.position, 2, GL_FLOAT, GL_FALSE, 0, vertexData));
+        GL_CALL(glEnableVertexAttribArray(program.position));
 
-        GL_CALL(glVertexAttribPointer(bound->uvPosition, 2, GL_FLOAT, GL_FALSE, 0, coordData));
-        GL_CALL(glEnableVertexAttribArray(bound->uvPosition));
+        GL_CALL(glVertexAttribPointer(program.uvPosition, 2, GL_FLOAT, GL_FALSE, 0, coordData));
+        GL_CALL(glEnableVertexAttribArray(program.uvPosition));
 
-        GL_CALL(glUniformMatrix4fv(bound->mvpID, 1, GL_FALSE, &model[0][0]));
-        GL_CALL(glUniform4fv(bound->colorID, 1, &color[0]));
+        GL_CALL(glUniformMatrix4fv(program.mvpID, 1, GL_FALSE, &model[0][0]));
+        GL_CALL(glUniform4fv(program.colorID, 1, &color[0]));
         GL_CALL(glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA));
-        GL_CALL(glDrawArrays (GL_TRIANGLE_FAN, 0, 4));
-
-#ifdef WAYFIRE_GRAPHICS_DEBUG
-        float c[4] = {0, 0, 0, -100};
-        GL_CALL(glUniform4fv(bound->colorID, 1, c));
         GL_CALL(glDrawArrays(GL_TRIANGLE_FAN, 0, 4));
-#endif
 
-        GL_CALL(glDisableVertexAttribArray(bound->uvPosition));
-        GL_CALL(glDisableVertexAttribArray(bound->position));
-    }
-
-    void prepare_framebuffer(GLuint &fbuff, GLuint &texture,
-                             float scale_x, float scale_y)
-    {
-        if (fbuff == (uint)-1)
-            GL_CALL(glGenFramebuffers(1, &fbuff));
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, fbuff));
-
-        bool existing_texture = (texture != (uint)-1);
-        if (!existing_texture)
-            GL_CALL(glGenTextures(1, &texture));
-
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
-
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
-
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-
-        if (!existing_texture)
-            GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
-                        bound->width * scale_x, bound->height * scale_y,
-                        0, GL_RGBA, GL_UNSIGNED_BYTE, 0));
-
-        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                texture, 0));
-
-        auto status = GL_CALL(glCheckFramebufferStatus(GL_FRAMEBUFFER));
-        if (status != GL_FRAMEBUFFER_COMPLETE)
-            log_error("failed to initialize framebuffer");
-
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
-    }
-
-    void prepare_framebuffer_size(int w, int h,
-                                  GLuint &fbuff, GLuint &texture,
-                                  float scale_x, float scale_y)
-    {
-        GL_CALL(glGenFramebuffers(1, &fbuff));
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, fbuff));
-
-        GL_CALL(glGenTextures(1, &texture));
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, texture));
-
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
-
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
-        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, w, h,
-                             0, GL_RGBA, GL_UNSIGNED_BYTE, 0));
-
-        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                texture, 0));
-
-        auto status = GL_CALL(glCheckFramebufferStatus(GL_FRAMEBUFFER));
-        if (status != GL_FRAMEBUFFER_COMPLETE)
-            log_error("failed to initialize framebuffer");
-
-        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
-        GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+        GL_CALL(glDisableVertexAttribArray(program.uvPosition));
+        GL_CALL(glDisableVertexAttribArray(program.position));
     }
 
     void render_begin()
@@ -338,15 +198,19 @@ namespace OpenGL
         render_begin(10, 10, 0);
     }
 
-    void render_begin(const wf_framebuffer& fb)
+    void render_begin(const wf_framebuffer_base& fb)
     {
         render_begin(fb.viewport_width, fb.viewport_height, fb.fb);
     }
 
     void render_begin(int32_t viewport_width, int32_t viewport_height, uint32_t fb)
     {
+        if (!current_output && !wlr_egl_is_current(core->egl))
+            wlr_egl_make_current(core->egl, EGL_NO_SURFACE, NULL);
+
         wlr_renderer_begin(core->renderer, viewport_width, viewport_height);
         GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, fb));
+        log_info("binding %dx%d, fb: %d", viewport_width, viewport_height, fb);
     }
 
     void clear(wf_color col, uint32_t mask)
@@ -363,45 +227,130 @@ namespace OpenGL
     }
 }
 
-void wf_framebuffer::init()
+bool wf_framebuffer_base::allocate(int width, int height)
 {
-    tex = fb = -1;
-    OpenGL::prepare_framebuffer(fb, tex, 1, 1);
-    geometry.width = bound->width;
-    geometry.height = bound->height;
+    bool first_allocate = false;
+    if (fb == (uint32_t)-1)
+    {
+        first_allocate = true;
+        GL_CALL(glGenFramebuffers(1, &fb));
+        log_info("alloc fb %d", fb);
+    }
+
+    if (tex == (uint32_t)-1)
+    {
+
+        first_allocate = true;
+        GL_CALL(glGenTextures(1, &tex));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
+        log_info("alloc tex %d", tex);
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+    }
+
+    log_info("first allocate %d, %dx%d", first_allocate, width, height);
+    bool is_resize = false;
+    /* Special case: fb = 0. This occurs in the default workspace streams, we don't resize anything */
+    if (fb != 0)
+    {
+        if (first_allocate || width != viewport_width || height != viewport_height)
+        {
+            log_info("is resize");
+            is_resize = true;
+            GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
+            GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, width, height,
+                    0, GL_RGBA, GL_UNSIGNED_BYTE, 0));
+        }
+    }
+
+    if (first_allocate)
+    {
+        log_info("set attachemt %d -> %d", tex, fb);
+        GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, fb));
+        GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
+        GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                GL_TEXTURE_2D, tex, 0));
+    }
+
+    if (is_resize || first_allocate)
+    {
+        auto status = GL_CALL(glCheckFramebufferStatus(GL_FRAMEBUFFER));
+        if (status != GL_FRAMEBUFFER_COMPLETE)
+        {
+            log_error("failed to initialize framebuffer");
+            return false;
+        }
+    }
+
+    viewport_width = width;
+    viewport_height = height;
+
+    log_info("set size to %d %d", viewport_width, viewport_height);
+
+    GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
+    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+
+    return is_resize || first_allocate;
 }
 
-void wf_framebuffer::init(int w, int h)
+void wf_framebuffer_base::copy_state(wf_framebuffer_base&& other)
 {
-    tex = fb = -1;
-    OpenGL::prepare_framebuffer_size(w, h, fb, tex, 1, 1);
-    geometry.width = w;
-    geometry.height = h;
+    this->viewport_width = other.viewport_width;
+    this->viewport_height = other.viewport_height;
+
+    this->fb = other.fb;
+    this->tex = other.tex;
+
+    other.reset();
 }
 
-void wf_framebuffer::bind() const
+wf_framebuffer_base::wf_framebuffer_base(wf_framebuffer_base&& other)
+{
+    copy_state(std::move(other));
+}
+
+wf_framebuffer_base& wf_framebuffer_base::operator = (wf_framebuffer_base&& other)
+{
+    if (this == &other)
+        return *this;
+
+    release();
+    copy_state(std::move(other));
+
+    return *this;
+}
+
+void wf_framebuffer_base::bind() const
 {
     GL_CALL(glBindFramebuffer(GL_DRAW_FRAMEBUFFER, fb));
     GL_CALL(glViewport(0, 0, viewport_width, viewport_height));
 }
 
-void wf_framebuffer::scissor(wlr_box box) const
+void wf_framebuffer_base::scissor(wlr_box box) const
 {
     GL_CALL(glEnable(GL_SCISSOR_TEST));
     GL_CALL(glScissor(box.x, viewport_height - box.y - box.height,
                       box.width, box.height));
 }
 
-void wf_framebuffer::release()
+void wf_framebuffer_base::release()
 {
-    if (fb == uint32_t(-1))
-        return;
+    log_info("release %d %d", fb, tex);
+    if (fb != uint32_t(-1) && fb != 0)
+        GL_CALL(glDeleteFramebuffers(1, &fb));
+    if (tex != uint32_t(-1) && (fb != 0 || tex != 0))
+        GL_CALL(glDeleteTextures(1, &tex));
 
-    GL_CALL(glDeleteFramebuffers(1, &fb));
-    GL_CALL(glDeleteTextures(1, &tex));
+    reset();
+}
 
+void wf_framebuffer_base::reset()
+{
     fb = -1;
     tex = -1;
+    viewport_width = viewport_height = 0;
 }
 
 #define WF_PI 3.141592f

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,8 @@ std::map<EGLint, EGLint> default_attribs = {
     {EGL_DEPTH_SIZE, 1},
 };
 
+std::map<wlr_renderer*, wlr_egl*> egl_for_renderer;
+
 /* Merge the default config and the config we need */
 static std::vector<EGLint> generate_config_attribs(EGLint *renderer_attribs)
 {
@@ -120,6 +122,7 @@ wlr_renderer *add_egl_depth_renderer(wlr_egl *egl, EGLenum platform,
         return NULL;
     }
 
+    egl_for_renderer[renderer] = egl;
     return renderer;
 }
 
@@ -175,6 +178,8 @@ int main(int argc, char *argv[])
     core->ev_loop  = wl_display_get_event_loop(core->display);
     core->backend  = wlr_backend_autocreate(core->display, add_egl_depth_renderer);
     core->renderer = wlr_backend_get_renderer(core->backend);
+    core->egl = egl_for_renderer[core->renderer];
+    assert(core->egl);
 
     log_info("using config file: %s", config_file.c_str());
     core->config = new wayfire_config(config_file);

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -104,6 +104,7 @@ void frame_cb (wl_listener*, void *data)
 render_manager::render_manager(wayfire_output *o)
 {
     output = o;
+    default_buffer.tex = default_buffer.fb = 0;
 
     /* TODO: do we really need a unique_ptr? */
     output_damage = std::unique_ptr<wf_output_damage>(new wf_output_damage(output->handle));
@@ -114,38 +115,24 @@ render_manager::render_manager(wayfire_output *o)
 
     pixman_region32_init(&frame_damage);
 
+    init_default_streams();
     schedule_redraw();
 }
 
 void render_manager::init_default_streams()
 {
-    GetTuple(vw, vh, output->workspace->get_workspace_grid_size());
-    output_streams.resize(vw);
-
-    for (int i = 0; i < vw; i++) {
-        for (int j = 0; j < vh; j++) {
+    /* We use core->vwidth/vheight directly because it is likely workspace_manager
+     * hasn't been initialized yet */
+    output_streams.resize(core->vwidth);
+    for (int i = 0; i < core->vwidth; i++)
+    {
+        for (int j = 0; j < core->vheight; j++)
+        {
             output_streams[i].push_back(wf_workspace_stream{});
-            output_streams[i][j].tex = output_streams[i][j].fbuff = 0;
+            output_streams[i][j].buffer.fb = output_streams[i][j].buffer.tex = 0;
             output_streams[i][j].ws = std::make_tuple(i, j);
         }
     }
-}
-
-void render_manager::load_context()
-{
-    ctx = OpenGL::create_gles_context(output, core->shadersrc.c_str());
-    OpenGL::bind_context(ctx);
-
-    dirty_context = false;
-    output->emit_signal("reload-gl", nullptr);
-
-    init_default_streams();
-}
-
-void render_manager::release_context()
-{
-    OpenGL::release_context(ctx);
-    dirty_context = true;
 }
 
 render_manager::~render_manager()
@@ -157,7 +144,12 @@ render_manager::~render_manager()
     if (idle_damage_source)
         wl_event_source_remove(idle_damage_source);
 
-    release_context();
+    for (auto& row : output_streams)
+    {
+        for (auto& stream : row)
+            stream.buffer.release();
+    }
+
     pixman_region32_fini(&frame_damage);
 }
 
@@ -184,7 +176,8 @@ wf_framebuffer render_manager::get_target_framebuffer() const
     fb.geometry = output->get_relative_geometry();
     fb.wl_transform = output->get_transform();
     fb.transform = get_output_matrix_from_transform(output->get_transform());
-    fb.fb = default_fb;
+    fb.fb = default_buffer.fb;
+    fb.tex = default_buffer.tex;
     fb.viewport_width = output->handle->width;
     fb.viewport_height = output->handle->height;
 
@@ -275,11 +268,6 @@ void render_manager::set_renderer(render_hook_t rh)
     renderer = rh;
 }
 
-void render_manager::set_hide_overlay_panels(bool set)
-{
-    draw_overlay_panel = !set;
-}
-
 static inline int64_t timespec_to_msec(const struct timespec *a) {
      return (int64_t)a->tv_sec * 1000 + a->tv_nsec / 1000000;
 }
@@ -288,7 +276,9 @@ struct render_manager::wf_post_effect
 {
     post_hook_t *hook;
     bool to_remove = false;
-    GLuint target_fbo = 0, target_tex = 0;
+    wf_framebuffer_base buffer;
+
+    wf_post_effect() {buffer.fb = buffer.tex = 0;}
 };
 
 void render_manager::paint()
@@ -312,10 +302,17 @@ void render_manager::paint()
         return;
     }
 
+    OpenGL::bind_output(output);
+    log_info("frame");
+
+    OpenGL::render_begin();
+    default_buffer.allocate(output->handle->width, output->handle->height);
+    OpenGL::render_end();
+
     pixman_region32_t swap_damage;
     pixman_region32_init(&swap_damage);
 
-        if (runtime_config.damage_debug)
+    if (runtime_config.damage_debug)
     {
         pixman_region32_union_rect(&swap_damage, &swap_damage, 0, 0,
                               output->handle->width, output->handle->height);
@@ -325,15 +322,9 @@ void render_manager::paint()
         OpenGL::render_end();
     }
 
-    OpenGL::render_begin(get_target_framebuffer());
-    if (dirty_context)
-        load_context();
-    OpenGL::bind_context(ctx);
-    OpenGL::render_end();
-
     if (renderer)
     {
-        renderer(default_fb);
+        renderer(get_target_framebuffer());
         pixman_region32_union_rect(&swap_damage, &swap_damage, 0, 0,
                               output->handle->width, output->handle->height);
         /* TODO: let custom renderers specify what they want to repaint... */
@@ -376,16 +367,20 @@ void render_manager::paint()
 
     if (post_effects.size())
     {
-        GLuint last_fb = default_fb, last_tex = default_tex;
+        auto last_buffer = &default_buffer;
         for (auto post : post_effects)
         {
-            (*post->hook)(last_fb, last_tex, post->target_fbo);
+            OpenGL::render_begin();
+            /* Make sure we have the correct resolution, in case the output was resized */
+            post->buffer.allocate(output->handle->width, output->handle->height);
+            OpenGL::render_end();
 
-            last_fb = post->target_fbo;
-            last_tex = post->target_tex;
+            log_info("render from %d to %d", last_buffer->fb, post->buffer.fb);
+            (*post->hook)(*last_buffer, post->buffer);
+            last_buffer = &post->buffer;
         }
 
-        assert(last_fb == 0 && last_tex == 0);
+        assert(last_buffer->fb == 0 && last_buffer->tex == 0);
     }
 
     if (output_inhibit)
@@ -395,6 +390,7 @@ void render_manager::paint()
         OpenGL::render_end();
     }
 
+    OpenGL::unbind_output(output);
     output_damage->swap_buffers(&repaint_started, &swap_damage);
     pixman_region32_fini(&swap_damage);
     post_paint();
@@ -464,20 +460,19 @@ void render_manager::rem_effect(const effect_hook_t *hook, wf_output_effect_type
 
 void render_manager::add_post(post_hook_t* hook)
 {
-    auto last_fb = &default_fb, last_tex = &default_tex;
-
+    auto buffer = &default_buffer;
     if (!post_effects.empty())
-    {
-        last_fb  = &post_effects.back()->target_fbo;
-        last_tex = &post_effects.back()->target_tex;
-    }
+        buffer = &post_effects.back()->buffer;
 
-    *last_fb = *last_tex = -1;
-    OpenGL::prepare_framebuffer(*last_fb, *last_tex);
+    buffer->reset();
+    buffer->allocate(output->handle->width, output->handle->height);
     damage(NULL);
 
     auto new_hook = new wf_post_effect;
     new_hook->hook = hook;
+    new_hook->buffer.fb = new_hook->buffer.tex = 0;
+    /* Just resize the framebuffer, to match real size */
+    new_hook->buffer.allocate(output->handle->width, output->handle->height);
 
     post_effects.push_back(new_hook);
 }
@@ -489,12 +484,7 @@ void render_manager::_rem_post(wf_post_effect *post)
     {
         if ((*it) == post)
         {
-            if ((*it)->target_fbo != 0)
-            {
-                GL_CALL(glDeleteFramebuffers(1, &(*it)->target_fbo));
-                GL_CALL(glDeleteTextures(1, &(*it)->target_tex));
-            }
-
+            (*it)->buffer.release();
             delete *it;
             it = post_effects.erase(it);
         } else
@@ -503,19 +493,14 @@ void render_manager::_rem_post(wf_post_effect *post)
         }
     }
 
-    auto last_fb = &default_fb, last_tex = &default_tex;
+    auto buffer = &default_buffer;
     if (!post_effects.empty())
-    {
-        last_fb  = &post_effects.back()->target_fbo;
-        last_tex = &post_effects.back()->target_tex;
-    }
+        buffer = &post_effects.back()->buffer;
 
-    if (last_fb != 0)
+    if (buffer->fb != 0)
     {
-        GL_CALL(glDeleteFramebuffers(1, last_fb));
-        GL_CALL(glDeleteTextures(1, last_tex));
-
-        *last_fb = *last_tex = 0;
+        buffer->release();
+        buffer->fb = buffer->tex = 0;
     }
 
     damage(NULL);
@@ -550,11 +535,6 @@ void render_manager::workspace_stream_start(wf_workspace_stream *stream)
     stream->running = true;
     stream->scale_x = stream->scale_y = 1;
 
-    OpenGL::bind_context(output->render->ctx);
-
-    if (stream->fbuff == (uint)-1 || stream->tex == (uint)-1)
-        OpenGL::prepare_framebuffer(stream->fbuff, stream->tex);
-
     GetTuple(vx, vy, stream->ws);
     GetTuple(cx, cy, output->workspace->get_current_workspace());
 
@@ -575,7 +555,6 @@ void render_manager::workspace_stream_start(wf_workspace_stream *stream)
 void render_manager::workspace_stream_update(wf_workspace_stream *stream,
                                              float scale_x, float scale_y)
 {
-    OpenGL::bind_context(output->render->ctx);
     auto g = output->get_relative_geometry();
 
     GetTuple(x, y, stream->ws);
@@ -604,6 +583,7 @@ void render_manager::workspace_stream_update(wf_workspace_stream *stream,
                 sw, sh);
     }
 
+    log_info("update stream %d %d", stream->buffer.fb, stream->buffer.tex);
     /* we don't have to update anything */
     if (!pixman_region32_not_empty(&ws_damage))
     {
@@ -769,21 +749,22 @@ void render_manager::workspace_stream_update(wf_workspace_stream *stream,
     std::swap(wayfire_view_transform::global_scale, scale);
     std::swap(wayfire_view_transform::global_translate, translate);
     */
+    OpenGL::render_begin();
+    stream->buffer.allocate(output->handle->width, output->handle->height);
 
     auto fb = get_target_framebuffer();
-    fb.fb = (stream->fbuff == 0 ? default_fb : stream->fbuff);
-    fb.tex = (stream->fbuff == 0 ? default_tex : stream->tex);
+    fb.fb = (stream->buffer.fb == 0) ? default_buffer.fb : stream->buffer.fb;
+    fb.tex = (stream->buffer.tex == 0) ? default_buffer.tex : stream->buffer.tex;
+    log_info("stream to %d", fb.fb);
+    fb.bind();
 
-    OpenGL::render_begin(fb);
 
     int n_rect;
     auto rects = pixman_region32_rectangles(&ws_damage, &n_rect);
     for (int i = 0; i < n_rect; i++)
     {
         wlr_box damage = wlr_box_from_pixman_box(rects[i]);
-        auto box = get_scissor_box(output, damage);
-
-        wlr_renderer_scissor(core->renderer, &box);
+        fb.scissor(get_scissor_box(output, damage));
         OpenGL::clear({0, 0, 0, 1}, GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
     }
     OpenGL::render_end();
@@ -819,5 +800,3 @@ void render_manager::workspace_stream_stop(wf_workspace_stream *stream)
 }
 
 /* End render_manager */
-
-

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -363,11 +363,19 @@ void render_manager::paint()
     }
 
     run_effects(effects[WF_OUTPUT_EFFECT_OVERLAY]);
+
     if (post_effects.size())
     {
         pixman_region32_union_rect(&swap_damage, &swap_damage, 0, 0,
                                    output->handle->width, output->handle->height);
+    }
 
+    OpenGL::render_begin(get_target_framebuffer());
+    wlr_output_render_software_cursors(output->handle, &swap_damage);
+    OpenGL::render_end();
+
+    if (post_effects.size())
+    {
         GLuint last_fb = default_fb, last_tex = default_tex;
         for (auto post : post_effects)
         {

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -677,16 +677,7 @@ void render_manager::workspace_stream_update(wf_workspace_stream *stream,
                 ds->surface = surface;
 
                 if (ds->surface->alpha >= 0.999f)
-                {
-                    /* TODO: wrong, we should transform opaque as well */
-                    pixman_region32_t opaque;
-                    pixman_region32_init(&opaque);
-                    // pixman_region32_copy(&opaque, &surface->surface->current.opaque);
-                    pixman_region32_translate(&opaque, x, y);
-                    wlr_region_scale(&opaque, &opaque, output->handle->scale);
-                    //pixman_region32_subtract(&ws_damage, &ws_damage, &opaque);
-                    pixman_region32_fini(&opaque);
-                }
+                    ds->surface->subtract_opaque(&ws_damage, x, y);
 
                 to_render.push_back(std::move(ds));
             }

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -74,7 +74,7 @@ void wayfire_compositor_view_t::close()
     destroy();
 }
 
-void wayfire_compositor_view_t::render_fb(pixman_region32_t *damage, wf_framebuffer fb)
+void wayfire_compositor_view_t::render_fb(pixman_region32_t *damage, const wf_framebuffer& fb)
 {
     /* We only want to circumvent wayfire_surface_t::render_fb,
      * because it relies on the surface having a buffer
@@ -100,7 +100,7 @@ void wayfire_mirror_view_t::_render_pixman(const wlr_fb_attribs& fb, int x, int 
     original_view->render_pixman(fb, x, y, damage);
 }
 
-void wayfire_mirror_view_t::render_fb(pixman_region32_t* damage, wf_framebuffer fb)
+void wayfire_mirror_view_t::render_fb(pixman_region32_t* damage, const wf_framebuffer& fb)
 {
     /* If we have transformers, we're fine. take_snapshot will do the things needed */
     if (has_transformer())
@@ -115,10 +115,16 @@ void wayfire_mirror_view_t::render_fb(pixman_region32_t* damage, wf_framebuffer 
     auto base_bounding_box = original_view->get_bounding_box();
     auto bbox = get_bounding_box();
 
-    fb.geometry.x += base_bounding_box.x - bbox.x;
-    fb.geometry.y += base_bounding_box.y - bbox.y;
+    /* Normally we shouldn't copy framebuffers. But in this case we can assume
+     * nothing will break, because the copy will be destroyed immediately */
+    wf_framebuffer copy;
+    memcpy(&copy, &fb, sizeof(wf_framebuffer));
+    copy.geometry.x += base_bounding_box.x - bbox.x;
+    copy.geometry.y += base_bounding_box.y - bbox.y;
 
-    original_view->render_fb(damage, fb);
+    original_view->render_fb(damage, copy);
+
+    copy.reset();
 }
 
 wayfire_mirror_view_t::wayfire_mirror_view_t(wayfire_view original_view)
@@ -170,26 +176,18 @@ void wayfire_mirror_view_t::take_snapshot()
     int scaled_width = scale * obox.width;
     int scaled_height = scale * obox.height;
 
-    if (offscreen_buffer.fb_width != scaled_width ||
-        offscreen_buffer.fb_height != scaled_height)
-    {
-        offscreen_buffer.fini();
-    }
-
-    if (!offscreen_buffer.valid())
-        offscreen_buffer.init(scaled_width, scaled_height);
-
     offscreen_buffer.output_x = buffer_geometry.x;
     offscreen_buffer.output_y = buffer_geometry.y;
     offscreen_buffer.fb_scale = scale;
 
-    OpenGL::render_begin(offscreen_buffer.fb_width, offscreen_buffer.fb_height,
-        offscreen_buffer.fbo);
+    OpenGL::render_begin();
+    offscreen_buffer.allocate(scaled_width, scaled_height);
+    offscreen_buffer.bind();
     OpenGL::clear({0, 0, 0, 0});
     OpenGL::render_end();
 
     wf_framebuffer fb;
-    fb.fb = offscreen_buffer.fbo;
+    fb.fb = offscreen_buffer.fb;
     fb.tex = offscreen_buffer.tex;
 
     fb.geometry = obox;

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -138,6 +138,24 @@ bool wayfire_surface_t::accepts_input(int32_t sx, int32_t sy)
     return wlr_surface_point_accepts_input(surface, sx, sy);
 }
 
+void wayfire_surface_t::subtract_opaque(pixman_region32_t *region, int x, int y)
+{
+    if (!surface)
+        return;
+
+    pixman_region32_t opaque;
+    pixman_region32_init(&opaque);
+
+    pixman_region32_copy(&opaque, &surface->current.opaque);
+    pixman_region32_translate(&opaque, x, y);
+    wlr_region_scale(&opaque, &opaque, output->handle->scale);
+    if (output->handle->scale != (float)surface->current.scale)
+        wlr_region_expand(&opaque, &opaque, -1); // remove the effect of ceiling
+
+    pixman_region32_subtract(region, region, &opaque);
+    pixman_region32_fini(&opaque);
+}
+
 wl_client* wayfire_surface_t::get_client()
 {
     if (surface)

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -444,7 +444,7 @@ void wayfire_surface_t::render_pixman(const wlr_fb_attribs& fb, int x, int y, pi
     pixman_region32_fini(&full_region);
 }
 
-void wayfire_surface_t::render_fb(pixman_region32_t *damage, wf_framebuffer fb)
+void wayfire_surface_t::render_fb(pixman_region32_t *damage, const wf_framebuffer& fb)
 {
     if (!is_mapped() || !wlr_surface_has_buffer(surface))
         return;

--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -143,10 +143,11 @@ void wf_2D_view::render_with_damage(uint32_t src_tex,
 
     auto transform = fb.transform * ortho * translate * rotate;
 
-    fb.bind();
+    OpenGL::render_begin(fb);
     fb.scissor(scissor_box);
     OpenGL::render_transformed_texture(src_tex, quad.geometry, {},
                                        transform, {1.0f, 1.0f, 1.0f, alpha});
+    OpenGL::render_end();
 }
 
 const float wf_3D_view::fov = PI/4;
@@ -201,9 +202,6 @@ void wf_3D_view::render_with_damage(uint32_t       src_tex,
                                     wlr_box        scissor_box,
                                     const wf_framebuffer& fb)
 {
-    fb.bind();
-    fb.scissor(scissor_box);
-
     auto quad = center_geometry(fb.geometry, src_box, get_center(src_box));
 
     auto transform = calculate_total_transform();
@@ -215,6 +213,10 @@ void wf_3D_view::render_with_damage(uint32_t       src_tex,
                             });
 
     transform = fb.transform * scale * translate * transform;
+
+    OpenGL::render_begin(fb);
+    fb.scissor(scissor_box);
     OpenGL::render_transformed_texture(src_tex, quad.geometry, {},
                                        transform, color);
+    OpenGL::render_end();
 }


### PR DESCRIPTION
We now bind the proper context before each rendering operation and clean up gl state after rendering is done.

Fixes #104 #44 