### PR TITLE
cube: Fix cube when no skydome image is set

### DIFF
--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -455,33 +455,34 @@ class wayfire_cube : public wayfire_plugin_t
     {
         update_workspace_streams();
 
-        if (program.id == (uint)-1)
+        if (program.id == (uint32_t)-1)
             load_program();
+
+        OpenGL::render_begin(dest);
+        GL_CALL(glClear(GL_DEPTH_BUFFER_BIT));
 
         reload_background();
         background->render_frame(dest, animation);
 
         auto vp = calculate_vp_matrix(dest);
-        OpenGL::render_begin(dest);
 
+        GL_CALL(glUseProgram(program.id));
+        GL_CALL(glEnable(GL_DEPTH_TEST));
+        GL_CALL(glDepthFunc(GL_LESS));
 
-        GLfloat vertexData[] = {
+        static GLfloat vertexData[] = {
             -0.5,  0.5,
             0.5,  0.5,
             0.5, -0.5,
             -0.5, -0.5
         };
 
-        GLfloat coordData[] = {
+        static GLfloat coordData[] = {
             0.0f, 1.0f,
             1.0f, 1.0f,
             1.0f, 0.0f,
             0.0f, 0.0f
         };
-
-        GL_CALL(glUseProgram(program.id));
-        GL_CALL(glEnable(GL_DEPTH_TEST));
-        GL_CALL(glDepthFunc(GL_LESS));
 
         GL_CALL(glVertexAttribPointer(program.posID, 2, GL_FLOAT, GL_FALSE, 0, vertexData));
         GL_CALL(glVertexAttribPointer(program.uvID, 2, GL_FLOAT, GL_FALSE, 0, coordData));

--- a/plugins/cube/cube.hpp
+++ b/plugins/cube/cube.hpp
@@ -5,6 +5,8 @@
 #include <animation.hpp>
 #include <opengl.hpp>
 
+#define TEX_ERROR_FLAG_COLOR  0, 1, 0, 1
+
 struct wf_cube_animation_attribs
 {
     wf_duration duration;

--- a/plugins/cube/simple-background.cpp
+++ b/plugins/cube/simple-background.cpp
@@ -11,6 +11,6 @@ void wf_cube_simple_background::render_frame(const wf_framebuffer& fb,
 {
     OpenGL::render_begin(fb);
     OpenGL::clear(background_color->as_cached_color(),
-        GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+        GL_COLOR_BUFFER_BIT);
     OpenGL::render_end();
 }

--- a/plugins/cube/skydome.cpp
+++ b/plugins/cube/skydome.cpp
@@ -54,25 +54,25 @@ void wf_cube_background_skydome::reload_texture()
     last_background_image = background_image->as_string();
     OpenGL::render_begin();
 
-    if (tex == (uint)-1)
-    {
+    if (tex == (uint32_t)-1)
         GL_CALL(glGenTextures(1, &tex));
-    }
 
     GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
 
-    if (!image_io::load_from_file(last_background_image, GL_TEXTURE_2D))
+    if (image_io::load_from_file(last_background_image, GL_TEXTURE_2D))
     {
-        log_error("Failed to load skydome image from %s.",
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
+        GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
+    }
+    else
+    {
+        log_error("Failed to load skydome image from \"%s\".",
             last_background_image.c_str());
         GL_CALL(glDeleteTextures(1, &tex));
         tex = -1;
     }
-
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE));
-    GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
 
     GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
 
@@ -140,10 +140,13 @@ void wf_cube_background_skydome::render_frame(const wf_framebuffer& fb,
     reload_texture();
 
     if (tex == (uint32_t)-1)
+    {
+        GL_CALL(glClearColor(TEX_ERROR_FLAG_COLOR));
+        GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
         return;
+    }
 
     OpenGL::render_begin(fb);
-    GL_CALL(glClear(GL_DEPTH_BUFFER_BIT));
 
     GL_CALL(glUseProgram(program));
 


### PR DESCRIPTION
When skydome was selected with no image set, the cube would not
activate at all. This was partially because the background methods
were clearing the depth buffer and skydome was only doing this
when there was a texture set. This makes it so the background is
cleared to green when skydome or cubemap are selected but the
texture for them are not loaded.