### PR TITLE
view: add set_tiled() and tiled_edges

### DIFF
--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -327,7 +327,7 @@ class wayfire_move : public wayfire_plugin_t
                 return;
             }
 
-            stuck_in_slot = !view->maximized && !view->fullscreen;
+            stuck_in_slot = !view->tiled_edges && !view->fullscreen;
             grabbed_geometry = view->get_wm_geometry();
 
             GetTuple(sx, sy, get_input_coords());
@@ -377,7 +377,7 @@ class wayfire_move : public wayfire_plugin_t
             {
                 snap_signal data;
                 data.view = view;
-                data.tslot = (slot_type)slot.slot_id;
+                data.slot = (slot_type)slot.slot_id;
                 output->emit_signal("view-snap", &data);
 
                 /* Update slot, will hide the preview as well */
@@ -473,8 +473,14 @@ class wayfire_move : public wayfire_plugin_t
             stuck_in_slot = 1;
             if (view->fullscreen)
                 view->fullscreen_request(view->get_output(), false);
-            if (view->maximized)
-                view->maximize_request(false);
+
+            if (view->tiled_edges)
+            {
+                snap_signal data;
+                data.view = view;
+                data.slot = 0;
+                output->emit_signal("view-snap", &data);
+            }
 
             /* view geometry might change after unmaximize/unfullscreen, so update position */
             grabbed_geometry = view->get_wm_geometry();

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -206,6 +206,8 @@ class wayfire_resize : public wayfire_plugin_t
             view->set_fullscreen(false);
         if (view->maximized)
             view->set_maximized(false);
+        if (view->tiled_edges)
+            view->set_tiled(0);
 
         if (edges == 0) /* simply deactivate */
             input_pressed(WL_POINTER_BUTTON_STATE_RELEASED);

--- a/plugins/single_plugins/snap_signal.hpp
+++ b/plugins/single_plugins/snap_signal.hpp
@@ -32,7 +32,7 @@ struct snap_query_signal : public signal_data
 struct snap_signal : public signal_data
 {
     wayfire_view view;
-    slot_type tslot;
+    uint32_t slot; // 0 for unsnap
 };
 
 #endif /* end of include guard: SNAP_SIGNAL */

--- a/plugins/wobbly/wobbly.c
+++ b/plugins/wobbly/wobbly.c
@@ -177,7 +177,6 @@ modelSetMiddleAnchor (Model *model,
 		      int   width,
 		      int   height)
 {
-    fprintf(stderr, "set middle anchor");
     float gx, gy;
 
     gx = ((GRID_WIDTH  - 1) / 2 * width)  / (float) (GRID_WIDTH  - 1);
@@ -221,10 +220,7 @@ modelInitObjects (Model *model,
     }
 
     if (!model->anchorObject)
-    {
-        fprintf(stderr, "init model");
         modelSetMiddleAnchor (model, x, y, width, height);
-    }
 }
 
 static void
@@ -478,7 +474,7 @@ modelFindNearestObject (Model *model,
 {
     Object *object = &model->objects[0];
     float  distance, minDistance = 0.0;
-    int    i, final_i;
+    int    i;
 
     for (i = 0; i < model->numObjects; i++)
     {
@@ -487,11 +483,9 @@ modelFindNearestObject (Model *model,
 	{
 	    minDistance = distance;
 	    object = &model->objects[i];
-        final_i = i;
 	}
     }
 
-    fprintf(stderr, "choosing a final i %d", final_i);
     return object;
 }
 
@@ -810,7 +804,6 @@ void wobbly_unenforce_geometry(struct wobbly_surface *surface)
 
     if (wobblyEnsureModel(surface))
     {
-        fprintf(stderr, "unenfoce");
         if (modelRemoveEdgeAnchors(ww->model))
         {
             modelSetMiddleAnchor(ww->model, surface->x, surface->y, surface->width, surface->height);

--- a/src/api/signal-definitions.hpp
+++ b/src/api/signal-definitions.hpp
@@ -43,13 +43,6 @@ struct _view_state_signal : public _view_signal
 };
 bool get_signaled_state(signal_data *data);
 
-/* the view-fullscreen-request signal is sent on two ocassions:
- * 1. The app requests to be fullscreened
- * 2. Some plugin requests the view to be unfullscreened
- * callbacks for this signal can differentiate between the two cases
- * in the following way: when in case 1. then view->fullscreen != signal_data->state,
- * i.e the state hasn't been applied already. However, when some plugin etc.
- * wants to use this signal, then it should apply the state in advance */
 using view_maximized_signal = _view_state_signal;
 using view_fullscreen_signal = _view_state_signal;
 

--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -337,9 +337,11 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
         virtual void set_moving(bool moving);
 
         bool maximized = false, fullscreen = false, activated = false, minimized = false;
+        uint32_t tiled_edges = 0;
 
         /* Will also move the view to/from the minimized layer, if necessary */
         virtual void set_minimized(bool minimized);
+        virtual void set_tiled(uint32_t edges);
         virtual void set_maximized(bool maxim);
         virtual void set_fullscreen(bool fullscreen);
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -522,6 +522,18 @@ wf_geometry wayfire_view_t::get_bounding_box()
     return transform_region(get_untransformed_bounding_box());
 }
 
+void wayfire_view_t::set_tiled(uint32_t edges)
+{
+    /* Most shells don't support the tiled state. In this case, just default to maximize */
+    if (edges) {
+        set_maximized(true);
+    } else {
+        set_maximized(false);
+    }
+
+    tiled_edges = edges;
+}
+
 void wayfire_view_t::set_maximized(bool maxim)
 {
     maximized = maxim;
@@ -1101,6 +1113,8 @@ void wayfire_view_t::maximize_request(bool state)
     {
         set_geometry(output->workspace->get_workarea());
         set_maximized(state);
+        set_tiled(WLR_EDGE_TOP | WLR_EDGE_LEFT
+            | WLR_EDGE_BOTTOM | WLR_EDGE_RIGHT);
         output->emit_signal("view-maximized", &data);
     }
 }

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -321,6 +321,12 @@ void wayfire_xdg_view::activate(bool act)
     wayfire_view_t::activate(act);
 }
 
+void wayfire_xdg_view::set_tiled(uint32_t edges)
+{
+    wlr_xdg_toplevel_set_tiled(xdg_surface, edges);
+    this->tiled_edges = edges;
+}
+
 void wayfire_xdg_view::set_maximized(bool max)
 {
     wayfire_view_t::set_maximized(max);

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -52,6 +52,7 @@ class wayfire_xdg_view : public wayfire_view_t
     virtual wf_geometry get_wm_geometry();
 
     virtual void activate(bool act);
+    virtual void set_tiled(uint32_t edges);
     virtual void set_maximized(bool max);
     virtual void set_fullscreen(bool full);
     virtual void move(int w, int h, bool send);


### PR DESCRIPTION
Fixes #42.

Basically, we should indicate a tiled windowby tiling its edges. Maximize state is what comes from the client
itself.

@AdrianVovk Can you verify this fixes #42 (and breaks nothing else)?