### PR TITLE
Add option to repeat key/button binding for command

### DIFF
--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -106,12 +106,12 @@ class wayfire_cube : public wayfire_plugin_t
         };
 
         auto key_left = section->get_option("rotate_left", "<alt> <ctrl> KEY_LEFT");
-        rotate_left = [=] () {
+        rotate_left = [=] (wf_activator_source, uint32_t) {
             move_vp(-1);
         };
 
         auto key_right = section->get_option("rotate_right", "<alt> <ctrl> KEY_RIGHT");
-        rotate_right = [=] () {
+        rotate_right = [=] (wf_activator_source, uint32_t) {
             move_vp(1);
         };
 

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -34,7 +34,7 @@ class wayfire_command : public wayfire_plugin_t
             auto comvalue = section->get_option(command, "")->as_string();
             auto activator = section->get_option(binding, "none");
 
-            cmds[i++] = [=] () { core->run(comvalue.c_str()); };
+            cmds[i++] = [=] (wf_activator_source, uint32_t) { core->run(comvalue.c_str()); };
             output->add_activator(activator, &cmds[i - 1]);
         }
     }

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -2,13 +2,134 @@
 #include <core.hpp>
 #include <linux/input.h>
 #include <linux/input-event-codes.h>
+#include <debug.hpp>
 
-#define TYPE_COMMAND 1
-#define TYPE_BINDING 2
+static bool begins_with(std::string word, std::string prefix)
+{
+    if (word.length() < prefix.length())
+        return false;
+
+    return word.substr(0, prefix.length()) == prefix;
+}
+
+/* Initial repeat delay passed */
+static int repeat_delay_timeout_handler(void *callback)
+{
+    (*reinterpret_cast<std::function<void()>*> (callback)) ();
+    return 1; // disconnect
+};
+
+/* Between each repeat */
+static int repeat_once_handler(void *callback)
+{
+    (*reinterpret_cast<std::function<void()>*> (callback)) ();
+    return 1; // continue timer
+}
+
+/* Provides a way to bind specific commands to activator bindings.
+ *
+ * It supports 2 modes:
+ *
+ * 1. Regular bindings
+ * 2. Repeatable bindings - for example, if the user binds a keybinding, then
+ * after a specific delay the command begins to be executed repeatedly, until
+ * the user released the key. In the config file, repeatable bindings have the
+ * prefix repeatable_ */
 
 class wayfire_command : public wayfire_plugin_t
 {
-    std::vector<activator_callback> cmds;
+    std::vector<activator_callback> bindings;
+
+    struct
+    {
+        uint32_t pressed_button = 0;
+        uint32_t pressed_key = 0;
+        std::string repeat_command;
+    } repeat;
+
+    wl_event_source *repeat_source = NULL, *repeat_delay_source = NULL;
+
+    void on_binding(std::string command, bool enable_repeat, wf_activator_source source,
+        uint32_t value)
+    {
+        /* We already have a repeatable command, do not accept further bindings */
+        if (repeat.pressed_key || repeat.pressed_button)
+            return;
+
+        if (!output->activate_plugin(grab_interface))
+            return;
+
+        core->run(command.c_str());
+        /* No repeat necessary in any of those cases */
+        if (!enable_repeat || source == ACTIVATOR_SOURCE_GESTURE || value == 0)
+        {
+            output->deactivate_plugin(grab_interface);
+            return;
+        }
+
+        /* Grab if grab wasn't active up to now */
+        if (!grab_interface->is_grabbed())
+            grab_interface->grab();
+
+        repeat.repeat_command = command;
+        if (source == ACTIVATOR_SOURCE_KEYBINDING) {
+            repeat.pressed_key = value;
+        } else {
+            repeat.pressed_button = value;
+        }
+
+        repeat_delay_source = wl_event_loop_add_timer(core->ev_loop,
+            repeat_delay_timeout_handler, &on_repeat_delay_timeout);
+        wl_event_source_timer_update(repeat_delay_source, 400);
+    }
+
+    std::function<void()> on_repeat_delay_timeout = [=] ()
+    {
+        repeat_delay_source = NULL;
+        repeat_source = wl_event_loop_add_timer(core->ev_loop,
+            repeat_once_handler, &on_repeat_once);
+        on_repeat_once();
+    };
+
+    std::function<void()> on_repeat_once = [=] ()
+    {
+        wl_event_source_timer_update(repeat_source, 25);
+        core->run(repeat.repeat_command.c_str());
+    };
+
+    void reset_repeat()
+    {
+        if (repeat_delay_source)
+        {
+            wl_event_source_remove(repeat_delay_source);
+            repeat_delay_source = NULL;
+        }
+
+        if (repeat_source)
+        {
+            wl_event_source_remove(repeat_source);
+            repeat_source = NULL;
+        }
+
+        repeat.pressed_key = repeat.pressed_button = 0;
+
+        grab_interface->ungrab();
+        output->deactivate_plugin(grab_interface);
+    }
+
+    std::function<void(uint32_t, uint32_t)> on_button =
+        [=] (uint32_t button, uint32_t state)
+    {
+        if (button == repeat.pressed_button && state == WLR_BUTTON_RELEASED)
+            reset_repeat();
+    };
+
+    std::function<void(uint32_t, uint32_t)> on_key =
+        [=] (uint32_t key, uint32_t state)
+    {
+        if (key == repeat.pressed_key && state == WLR_KEY_RELEASED)
+            reset_repeat();
+    };
 
     public:
 
@@ -16,35 +137,52 @@ class wayfire_command : public wayfire_plugin_t
     {
         auto section = config->get_section("command");
 
-        std::vector<std::string> commands;
+        std::vector<std::string> command_names;
+        const std::string exec_prefix = "command_";
         for (auto command : section->options)
         {
-            if (command->name.length() > 8 && command->name.substr(0, 8) == "command_")
-                commands.push_back(command->name.substr(8, command->name.size() - 8));
+            if (begins_with(command->name, exec_prefix))
+            {
+                command_names.push_back(
+                    command->name.substr(exec_prefix.length()));
+            }
         }
 
-        cmds.resize(commands.size());
-        int i = 0;
+        bindings.resize(command_names.size());
+        const std::string norepeat;
 
-        for (auto num : commands)
+        for (size_t i = 0; i < command_names.size(); i++)
         {
-            auto command = "command_" + num;
-            auto binding = "binding_" + num;
+            auto command = exec_prefix + command_names[i];
+            auto regular_binding_name = "binding_" + command_names[i];
+            auto repeat_binding_name = "repeatable_binding_" + command_names[i];
 
-            auto comvalue = section->get_option(command, "")->as_string();
-            auto activator = section->get_option(binding, "none");
+            auto executable = section->get_option(command, "")->as_string();
+            auto repeatable_opt = section->get_option(repeat_binding_name, norepeat);
+            auto regular_opt = section->get_option(regular_binding_name, "none");
 
-            cmds[i++] = [=] (wf_activator_source, uint32_t) { core->run(comvalue.c_str()); };
-            output->add_activator(activator, &cmds[i - 1]);
+            using namespace std::placeholders;
+            if (repeatable_opt->as_string() != norepeat)
+            {
+                bindings[i] = std::bind(std::mem_fn(&wayfire_command::on_binding),
+                    this, executable, true, _1, _2);
+                output->add_activator(repeatable_opt, &bindings[i]);
+            }
+            else
+            {
+                bindings[i] = std::bind(std::mem_fn(&wayfire_command::on_binding),
+                    this, executable, false, _1, _2);
+                output->add_activator(regular_opt, &bindings[i]);
+            }
         }
     }
 
     void clear_bindings()
     {
-        for (size_t i = 0; i < cmds.size(); i++)
-            output->rem_binding(&cmds[i]);
+        for (auto& binding : bindings)
+            output->rem_binding(&binding);
 
-        cmds.clear();
+        bindings.clear();
     }
 
     signal_callback_t reload_config;
@@ -52,6 +190,10 @@ class wayfire_command : public wayfire_plugin_t
     void init(wayfire_config *config)
     {
         grab_interface->name = "command";
+        grab_interface->abilities_mask = WF_ABILITY_GRAB_INPUT;
+        grab_interface->callbacks.pointer.button = on_button;
+        grab_interface->callbacks.keyboard.key = on_key;
+
         using namespace std::placeholders;
 
         setup_bindings_from_config(config);

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -199,6 +199,7 @@ class wayfire_command : public wayfire_plugin_t
         grab_interface->abilities_mask = WF_ABILITY_GRAB_INPUT;
         grab_interface->callbacks.pointer.button = on_button;
         grab_interface->callbacks.keyboard.key = on_key;
+        grab_interface->callbacks.cancel = [=]() {reset_repeat();};
 
         using namespace std::placeholders;
 

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -17,7 +17,7 @@ class wayfire_expo : public wayfire_plugin_t
 {
     private:
 
-    activator_callback toggle_cb = [=] ()
+    activator_callback toggle_cb = [=] (wf_activator_source, uint32_t)
     {
         if (!state.active) {
             activate();

--- a/plugins/single_plugins/fisheye.cpp
+++ b/plugins/single_plugins/fisheye.cpp
@@ -138,7 +138,7 @@ class wayfire_fisheye : public wayfire_plugin_t
                 render(source, dest);
             };
 
-            toggle_cb = [=] ()
+            toggle_cb = [=] (wf_activator_source, uint32_t)
             {
                     if (active)
                     {

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -199,10 +199,12 @@ class wayfire_grid : public wayfire_plugin_t
         animation_duration = section->get_option("duration", "300");
         animation_type = section->get_option("type", "simple");
 
-        for (int i = 1; i < 10; i++) {
+        for (int i = 1; i < 10; i++)
+        {
             keys[i] = section->get_option("slot_" + slots[i], default_keys[i]);
 
-            bindings[i] = [=] () {
+            bindings[i] = [=] (wf_activator_source, uint32_t)
+            {
                 auto view = output->get_active_view();
                 if (!view || view->role != WF_VIEW_ROLE_TOPLEVEL)
                     return;

--- a/plugins/single_plugins/idle-inhibit.cpp
+++ b/plugins/single_plugins/idle-inhibit.cpp
@@ -17,7 +17,7 @@ class wayfire_idle_inhibit : public wayfire_plugin_t
     {
         auto binding = config->get_section("idle-inhibit")->get_option("toggle", "<super> <shift> KEY_I");
 
-        toggle = [=] ()
+        toggle = [=] (wf_activator_source, uint32_t)
         {
             enabled = !enabled;
             wlr_idle_set_enabled(core->protocols.idle, NULL, enabled);
@@ -29,7 +29,7 @@ class wayfire_idle_inhibit : public wayfire_plugin_t
     void fini()
     {
         if (!enabled) // enable idle if the plugin is disabled
-            toggle();
+            toggle(ACTIVATOR_SOURCE_KEYBINDING, 0);
 
         output->rem_binding(&toggle);
     }

--- a/plugins/single_plugins/invert.cpp
+++ b/plugins/single_plugins/invert.cpp
@@ -68,7 +68,7 @@ class wayfire_invert_screen : public wayfire_plugin_t
         };
 
 
-        toggle_cb = [=] () {
+        toggle_cb = [=] (wf_activator_source, uint32_t) {
             if (active)
             {
                 output->render->rem_post(&hook);

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -27,7 +27,8 @@ class wayfire_output_manager : public wayfire_plugin_t
             auto actkey  = section->get_option("next_output", "<super> KEY_K");
             auto withwin = section->get_option("next_output_with_win", "<super> <shift> KEY_K");
 
-            switch_output = [=] () {
+            switch_output = [=] (wf_activator_source, uint32_t)
+            {
                 /* when we switch the output, the oswitch keybinding
                  * may be activated for the next output, which we don't want,
                  * so we postpone the switch */
@@ -36,13 +37,14 @@ class wayfire_output_manager : public wayfire_plugin_t
                 wl_event_loop_add_idle(core->ev_loop, next_output_idle_cb, next);
             };
 
-            switch_output_with_window = [=] () {
+            switch_output_with_window = [=] (wf_activator_source, uint32_t)
+            {
                 auto next = core->get_next_output(output);
                 auto view = output->get_active_view();
 
                 if (!view)
                 {
-                    switch_output();
+                    switch_output(ACTIVATOR_SOURCE_KEYBINDING, 0);
                     return;
                 }
 

--- a/plugins/single_plugins/rotator.cpp
+++ b/plugins/single_plugins/rotator.cpp
@@ -18,10 +18,10 @@ class wayfire_rotator : public wayfire_plugin_t
         auto left_key  = section->get_option("rotate_left", "<alt> <ctrl> <shift> KEY_LEFT");
         auto right_key = section->get_option("rotate_right","<alt> <ctrl> <shift> KEY_RIGHT");
 
-        up    = [=] () { output->set_transform(WL_OUTPUT_TRANSFORM_NORMAL); };
-        down  = [=] () { output->set_transform(WL_OUTPUT_TRANSFORM_180); };
-        left  = [=] () { output->set_transform(WL_OUTPUT_TRANSFORM_270); };
-        right = [=] () { output->set_transform(WL_OUTPUT_TRANSFORM_90); };
+        up    = [=] (wf_activator_source, uint32_t) { output->set_transform(WL_OUTPUT_TRANSFORM_NORMAL); };
+        down  = [=] (wf_activator_source, uint32_t) { output->set_transform(WL_OUTPUT_TRANSFORM_180); };
+        left  = [=] (wf_activator_source, uint32_t) { output->set_transform(WL_OUTPUT_TRANSFORM_270); };
+        right = [=] (wf_activator_source, uint32_t) { output->set_transform(WL_OUTPUT_TRANSFORM_90); };
 
         output->add_activator(up_key,    &up);
         output->add_activator(down_key,  &down);

--- a/plugins/single_plugins/vswitch.cpp
+++ b/plugins/single_plugins/vswitch.cpp
@@ -61,15 +61,15 @@ class vswitch : public wayfire_plugin_t
         grab_interface->name = "vswitch";
         grab_interface->abilities_mask = WF_ABILITY_CONTROL_WM;
 
-        callback_left  = [=] () { add_direction(-1,  0); };
-        callback_right = [=] () { add_direction( 1,  0); };
-        callback_up    = [=] () { add_direction( 0, -1); };
-        callback_down  = [=] () { add_direction( 0,  1); };
+        callback_left  = [=] (wf_activator_source, uint32_t) { add_direction(-1,  0); };
+        callback_right = [=] (wf_activator_source, uint32_t) { add_direction( 1,  0); };
+        callback_up    = [=] (wf_activator_source, uint32_t) { add_direction( 0, -1); };
+        callback_down  = [=] (wf_activator_source, uint32_t) { add_direction( 0,  1); };
 
-        callback_win_left  = [=] () { add_direction(-1,  0, get_top_view()); };
-        callback_win_right = [=] () { add_direction( 1,  0, get_top_view()); };
-        callback_win_up    = [=] () { add_direction( 0, -1, get_top_view()); };
-        callback_win_down  = [=] () { add_direction( 0,  1, get_top_view()); };
+        callback_win_left  = [=] (wf_activator_source, uint32_t) { add_direction(-1,  0, get_top_view()); };
+        callback_win_right = [=] (wf_activator_source, uint32_t) { add_direction( 1,  0, get_top_view()); };
+        callback_win_up    = [=] (wf_activator_source, uint32_t) { add_direction( 0, -1, get_top_view()); };
+        callback_win_down  = [=] (wf_activator_source, uint32_t) { add_direction( 0,  1, get_top_view()); };
 
         auto section   = config->get_section("vswitch");
 

--- a/src/api/plugin.hpp
+++ b/src/api/plugin.hpp
@@ -22,7 +22,20 @@ using button_callback = std::function<void(uint32_t, int32_t, int32_t)>; // butt
 using axis_callback = std::function<void(wlr_event_pointer_axis*)>;
 using touch_callback = std::function<void(int32_t, int32_t)>; // x, y
 using gesture_callback = std::function<void(wf_touch_gesture*)>;
-using activator_callback = std::function<void()>;
+
+enum wf_activator_source
+{
+    ACTIVATOR_SOURCE_KEYBINDING,
+    ACTIVATOR_SOURCE_BUTTONBINDING,
+    ACTIVATOR_SOURCE_GESTURE,
+};
+
+/* First argument is the source which was used to activate, the second one is
+ * the key or button which triggered it, if applicable.
+ *
+ * Special case: modifier bindings. In that case, the source is a keybinding,
+ * but the second argument is 0 */
+using activator_callback = std::function<void(wf_activator_source, uint32_t)>;
 
 class wayfire_output;
 class wayfire_config;

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -57,6 +57,8 @@ void input_manager::handle_pointer_button(wlr_event_pointer_button *ev)
                 binding->value->as_cached_button().matches(
                     {mod_state, ev->button}))
             {
+                /* We must be careful because the callback might be erased,
+                 * so force copy the callback into the lambda */
                 auto callback = binding->call.button;
                 callbacks.push_back([=] () {(*callback) (ev->button, ox, oy);});
             }
@@ -67,7 +69,12 @@ void input_manager::handle_pointer_button(wlr_event_pointer_button *ev)
             if (binding->output == core->get_active_output() &&
                 binding->value->matches_button({mod_state, ev->button}))
             {
-                callbacks.push_back(*binding->call.activator);
+                /* We must be careful because the callback might be erased,
+                 * so force copy the callback into the lambda */
+                auto callback = binding->call.activator;
+                callbacks.push_back([=] () {
+                    (*callback) (ACTIVATOR_SOURCE_BUTTONBINDING, ev->button);
+                });
             }
         }
 

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -390,6 +390,8 @@ void input_manager::handle_gesture(wf_touch_gesture g)
         if (binding->output == core->get_active_output() &&
             binding->value->as_cached_gesture().matches(g))
         {
+            /* We must be careful because the callback might be erased,
+             * so force copy the callback into the lambda */
             auto call = binding->call.gesture;
             callbacks.push_back([=, &g] () {
                 (*call) (&g);
@@ -402,7 +404,12 @@ void input_manager::handle_gesture(wf_touch_gesture g)
         if (binding->output == core->get_active_output() &&
             binding->value->matches_gesture(g))
         {
-            callbacks.push_back(*binding->call.activator);
+            /* We must be careful because the callback might be erased,
+             * so force copy the callback into the lambda */
+            auto call = binding->call.activator;
+            callbacks.push_back([=] () {
+                (*call) (ACTIVATOR_SOURCE_GESTURE, 0);
+            });
         }
     }
 

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -23,7 +23,7 @@ void wayfire_close::init(wayfire_config *config)
     auto key = config->get_section("core")
         ->get_option("close_top_view", "<super> KEY_Q | <alt> KEY_FN_F4");
 
-    callback = [=] ()
+    callback = [=] (wf_activator_source, uint32_t)
     {
         if (!output->activate_plugin(grab_interface))
             return;

--- a/wayfire.ini.default
+++ b/wayfire.ini.default
@@ -36,7 +36,10 @@ command_5 = amixer -q sset Master toggle
 
 binding_lock = <super> KEY_L
 command_lock = swaylock
-
+# Repeatable bindings allow the user to repeat the given command by holding the
+# key or button with which the binding was activated.
+repeatable_binding_echo = <ctrl> <alt> <super> <shift> KEY_E
+command_echo = echo "Test"
 
 # input options
 [input]


### PR DESCRIPTION
Command now supports a new kind of binding, with the prefix `repeatable_`. This will make the command to be executed repeatedly after a certain delay. Works for key- and button activated commands.

Still TODO: enable the user to configure the repeat rate and delay. Do we reuse core options? Or do we add specific options for the command plugin?