### PR TITLE
Improve modifier bindings

### DIFF
--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -88,7 +88,7 @@ static void handle_pointer_frame_cb(wl_listener*, void *data)
 
 bool input_manager::handle_pointer_button(wlr_event_pointer_button *ev)
 {
-    in_mod_binding = false;
+    mod_binding_key = 0;
 
     std::vector<std::function<void()>> callbacks;
     if (ev->state == WLR_BUTTON_PRESSED)
@@ -241,7 +241,7 @@ void input_manager::handle_pointer_axis(wlr_event_pointer_axis *ev)
         (*call) (ev);
 
     /* reset modifier bindings */
-    in_mod_binding = false;
+    mod_binding_key = 0;
     if (active_grab)
     {
         if (active_grab->callbacks.pointer.axis)

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -93,9 +93,10 @@ class input_manager
         /* TODO: move this in a wf_keyboard struct,
          * This might not work with multiple keyboards */
         bool in_mod_binding = false;
+        uint32_t mod_binding_key = 0; /* e.g. whether L or R Shift caused a <shift> binding */
         std::chrono::steady_clock::time_point mod_binding_start;
         int count_other_inputs = 0;
-        std::vector<std::function<void()>> match_keys(uint32_t mods, uint32_t key);
+        std::vector<std::function<void()>> match_keys(uint32_t mods, uint32_t key, uint32_t mod_binding_key = 0);
 
         wayfire_view keyboard_focus;
 

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -92,8 +92,7 @@ class input_manager
 
         /* TODO: move this in a wf_keyboard struct,
          * This might not work with multiple keyboards */
-        bool in_mod_binding = false;
-        uint32_t mod_binding_key = 0; /* e.g. whether L or R Shift caused a <shift> binding */
+        uint32_t mod_binding_key = 0; /* The keycode which triggered the modifier binding */
         std::chrono::steady_clock::time_point mod_binding_start;
         int count_other_inputs = 0;
         std::vector<std::function<void()>> match_keys(uint32_t mods, uint32_t key, uint32_t mod_binding_key = 0);

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -4,6 +4,7 @@
 #include <unordered_set>
 #include <map>
 #include <vector>
+#include <chrono>
 
 #include "seat.hpp"
 #include "cursor.hpp"
@@ -92,6 +93,7 @@ class input_manager
         /* TODO: move this in a wf_keyboard struct,
          * This might not work with multiple keyboards */
         bool in_mod_binding = false;
+        std::chrono::steady_clock::time_point mod_binding_start;
         int count_other_inputs = 0;
         std::vector<std::function<void()>> match_keys(uint32_t mods, uint32_t key);
 

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -239,9 +239,15 @@ bool input_manager::handle_keyboard_key(uint32_t key, uint32_t state)
         callbacks = match_keys(get_modifiers(), key);
     } else
     {
-        if (in_mod_binding && duration_cast<milliseconds>(
-                    steady_clock::now() - mod_binding_start) < milliseconds(400))
-            callbacks = match_keys(get_modifiers() | mod, 0, mod_binding_key);
+        if (in_mod_binding)
+        {
+            auto section = core->config->get_section("input");
+            auto timeout = section->get_option("modifier_binding_timeout", "0")->as_int();
+            if (timeout <= 0 ||
+                    duration_cast<milliseconds>(steady_clock::now() - mod_binding_start)
+                    <= milliseconds(timeout))
+                callbacks = match_keys(get_modifiers() | mod, 0, mod_binding_key);
+        }
 
         in_mod_binding = false;
     }

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -222,10 +222,7 @@ bool input_manager::handle_keyboard_key(uint32_t key, uint32_t state)
                 if (!mod_from_key(kbd->keycodes[i]))
                     modifiers_only = false;
 
-            if (modifiers_only)
-                in_mod_binding = true;
-            else
-                in_mod_binding = false;
+            in_mod_binding = modifiers_only;
         } else
         {
             in_mod_binding = false;

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -199,6 +199,8 @@ std::vector<std::function<void()>> input_manager::match_keys(uint32_t mod_state,
 
 bool input_manager::handle_keyboard_key(uint32_t key, uint32_t state)
 {
+    using namespace std::chrono;
+
     if (active_grab && active_grab->callbacks.keyboard.key)
         active_grab->callbacks.keyboard.key(key, state);
 
@@ -223,6 +225,9 @@ bool input_manager::handle_keyboard_key(uint32_t key, uint32_t state)
                     modifiers_only = false;
 
             in_mod_binding = modifiers_only;
+
+            if (in_mod_binding)
+                mod_binding_start = steady_clock::now();
         } else
         {
             in_mod_binding = false;
@@ -231,7 +236,8 @@ bool input_manager::handle_keyboard_key(uint32_t key, uint32_t state)
         callbacks = match_keys(get_modifiers(), key);
     } else
     {
-        if (in_mod_binding)
+        if (in_mod_binding && duration_cast<milliseconds>(
+                    steady_clock::now() - mod_binding_start) < milliseconds(400))
             callbacks = match_keys(get_modifiers() | mod, 0);
 
         in_mod_binding = false;

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -300,7 +300,7 @@ void input_manager::set_touch_focus(wayfire_surface_t *surface, uint32_t time, i
 
 void input_manager::handle_touch_down(uint32_t time, int32_t id, int32_t x, int32_t y)
 {
-    in_mod_binding = false;
+    mod_binding_key = 0;
     auto wo = core->get_output_at(x, y);
     core->focus_output(wo);
 

--- a/wayfire.ini.default
+++ b/wayfire.ini.default
@@ -67,6 +67,9 @@ cursor_theme = default
 kb_repeat_rate = 40
 kb_repeat_delay = 400
 
+# cancel modifier actions (like <super> for expo) when held for this long, 0 to never cancel
+modifier_binding_timeout = 0
+
 # output configuration
 # overlapping outputs are not supported
 [eDP-1]


### PR DESCRIPTION
- remember which actual key activated a modifier binding (so that an [xcape](https://github.com/alols/xcape)-style plugin would be able to distinguish between left and right shift to do shifts-as-parens)
- add a configurable timeout for modifier bindings (nothing happens when a modifier is held for too long)
- use xkbcommon to apply the keymap to the modifier keys (so any xkb_options like swapping Ctrl and Caps Lock or the choice of Super would apply) (note: rootston uses xkbcommon for *everything* in bindings)