### PR TITLE
Implement foreign toplevel close handler

### DIFF
--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -226,7 +226,8 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
         wl_listener toplevel_handle_v1_maximize_request,
                     toplevel_handle_v1_activate_request,
                     toplevel_handle_v1_minimize_request,
-                    toplevel_handle_v1_set_rectangle_request;
+                    toplevel_handle_v1_set_rectangle_request,
+                    toplevel_handle_v1_close_request;
 
         wlr_box minimize_hint;
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -94,6 +94,14 @@ static void handle_toplevel_handle_v1_set_rectangle_request(wl_listener*, void *
     view->handle_minimize_hint(box);
 }
 
+static void handle_toplevel_handle_v1_close_request(wl_listener*, void *data)
+{
+    auto toplevel = static_cast<wlr_foreign_toplevel_handle_v1*> (data);
+    auto view = wf_view_from_void(toplevel->data);
+
+    view->close();
+}
+
 void wayfire_view_t::create_toplevel()
 {
     if (toplevel_handle)
@@ -115,6 +123,8 @@ void wayfire_view_t::create_toplevel()
         handle_toplevel_handle_v1_activate_request;
     toplevel_handle_v1_set_rectangle_request.notify =
         handle_toplevel_handle_v1_set_rectangle_request;
+    toplevel_handle_v1_close_request.notify =
+        handle_toplevel_handle_v1_close_request;
     wl_signal_add(&toplevel_handle->events.request_maximize,
         &toplevel_handle_v1_maximize_request);
     wl_signal_add(&toplevel_handle->events.request_minimize,
@@ -123,6 +133,8 @@ void wayfire_view_t::create_toplevel()
         &toplevel_handle_v1_activate_request);
     wl_signal_add(&toplevel_handle->events.set_rectangle,
         &toplevel_handle_v1_set_rectangle_request);
+    wl_signal_add(&toplevel_handle->events.request_close,
+        &toplevel_handle_v1_close_request);
 
     toplevel_send_title();
     toplevel_send_app_id();
@@ -140,6 +152,7 @@ void wayfire_view_t::destroy_toplevel()
     wl_list_remove(&toplevel_handle_v1_activate_request.link);
     wl_list_remove(&toplevel_handle_v1_minimize_request.link);
     wl_list_remove(&toplevel_handle_v1_set_rectangle_request.link);
+    wl_list_remove(&toplevel_handle_v1_close_request.link);
 
     wlr_foreign_toplevel_handle_v1_destroy(toplevel_handle);
     toplevel_handle = NULL;


### PR DESCRIPTION
Calling zwlr_foreign_toplevel_handle_v1_close() from a client using
the foreign toplevel protocol did not work because it was not
implemented. Now clients can request toplevels be closed and it
will actually work. Fixes #174.