### PR TITLE
cursor: send button events back to wlroots even with an active grab

### DIFF
--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -117,6 +117,10 @@ class wayfire_surface_t
 
         float alpha = 1.0;
 
+        /* transform arg from output-local point to a point relative to the surface,
+         * after applying all the surface's parents' transforms */
+        virtual wf_point get_relative_position(const wf_point& arg);
+
         /* returns top-left corner in output coordinates */
         virtual wf_point get_output_position();
 
@@ -286,6 +290,7 @@ class wayfire_view_t : public wayfire_surface_t, public wf_object_base
         /* return geometry as should be used for all WM purposes */
         virtual wf_geometry get_wm_geometry();
 
+        virtual wf_point get_relative_position(const wf_point& arg);
         virtual wf_point get_output_position();
 
         /* return the output-local transformed coordinates of the view

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -380,7 +380,6 @@ void wayfire_core::focus_output(wayfire_output *wo)
     }
 
     wayfire_grab_interface iface = wo->get_input_grab_interface();
-
     /* this cannot be recursion as active_output will be equal to wo,
      * and wo->active_view->output == wo */
     if (!iface)

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -33,7 +33,8 @@ void wayfire_grab_interface_t::ungrab()
         return;
 
     grabbed = false;
-    core->input->ungrab_input();
+    if (output == core->get_active_output())
+        core->input->ungrab_input();
 }
 
 bool wayfire_grab_interface_t::is_grabbed()

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -141,9 +141,7 @@ bool input_manager::handle_pointer_button(wlr_event_pointer_button *ev)
     {
         if (active_grab->callbacks.pointer.button)
             active_grab->callbacks.pointer.button(ev->button, ev->state);
-        return true;
-    }
-    else if (cursor_focus)
+    } else if (cursor_focus)
     {
         auto custom = wf_compositor_surface_from_surface(cursor_focus);
         if (custom)

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -18,6 +18,11 @@ static void handle_pointer_button_cb(wl_listener*, void *data)
 
         wlr_seat_pointer_notify_button(core->input->seat, ev->time_msec,
             ev->button, ev->state);
+
+        /* end the button held grab. We need to to this here after we have send
+         * the last button release event, so that buttons don't get stuck in clients */
+        if (core->input->cursor->count_pressed_buttons == 0)
+            core->input->cursor->end_held_grab();
     }
 
     wlr_idle_notify_activity(core->protocols.idle, core->get_current_seat());
@@ -143,8 +148,6 @@ bool input_manager::handle_pointer_button(wlr_event_pointer_button *ev)
     else
     {
         cursor->count_pressed_buttons--;
-        if (cursor->count_pressed_buttons == 0)
-            cursor->end_held_grab();
     }
 
     if (active_grab)

--- a/src/core/seat/cursor.hpp
+++ b/src/core/seat/cursor.hpp
@@ -40,7 +40,6 @@ struct wf_cursor
     wf_option mouse_scroll_speed;
     wf_option touchpad_scroll_speed;
 
-    wlr_seat_pointer_grab wlr_grab;
     wayfire_surface_t *grabbed_surface = nullptr;
     void start_held_grab(wayfire_surface_t *surface);
     void end_held_grab();

--- a/src/core/seat/cursor.hpp
+++ b/src/core/seat/cursor.hpp
@@ -2,6 +2,7 @@
 #define CURSOR_HPP
 
 #include "seat.hpp"
+#include "plugin.hpp"
 
 extern "C"
 {
@@ -34,9 +35,15 @@ struct wf_cursor
 
     wlr_cursor *cursor = NULL;
     wlr_xcursor_manager *xcursor = NULL;
+    int count_pressed_buttons = 0;
 
     wf_option mouse_scroll_speed;
     wf_option touchpad_scroll_speed;
+
+    wlr_seat_pointer_grab wlr_grab;
+    wayfire_surface_t *grabbed_surface = nullptr;
+    void start_held_grab(wayfire_surface_t *surface);
+    void end_held_grab();
 };
 
 #endif /* end of include guard: CURSOR_HPP */

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -120,7 +120,7 @@ input_manager::input_manager()
     surface_map_state_changed = [=] (signal_data *data)
     {
         auto ev = static_cast<_surface_map_state_changed_signal*> (data);
-        if (cursor->grabbed_surface == ev->surface && !ev->surface->is_mapped())
+        if (ev && cursor->grabbed_surface == ev->surface && !ev->surface->is_mapped())
         {
             cursor->end_held_grab();
         } else
@@ -130,7 +130,7 @@ input_manager::input_manager()
 
         if (our_touch)
         {
-            if (our_touch->grabbed_surface == ev->surface && !ev->surface->is_mapped())
+            if (ev && our_touch->grabbed_surface == ev->surface && !ev->surface->is_mapped())
                 our_touch->end_touch_down_grab();
 
             for (auto f : our_touch->gesture_recognizer.current)

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -130,6 +130,9 @@ input_manager::input_manager()
 
         if (our_touch)
         {
+            if (our_touch->grabbed_surface == ev->surface && !ev->surface->is_mapped())
+                our_touch->end_touch_down_grab();
+
             for (auto f : our_touch->gesture_recognizer.current)
                 handle_touch_motion(get_current_time(), f.first, f.second.sx, f.second.sy);
         }

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -119,7 +119,14 @@ input_manager::input_manager()
 
     surface_map_state_changed = [=] (signal_data *data)
     {
-        update_cursor_position(get_current_time(), false);
+        auto ev = static_cast<_surface_map_state_changed_signal*> (data);
+        if (cursor->grabbed_surface == ev->surface && !ev->surface->is_mapped())
+        {
+            cursor->end_held_grab();
+        } else
+        {
+            update_cursor_position(get_current_time(), false);
+        }
 
         if (our_touch)
         {
@@ -168,8 +175,10 @@ bool input_manager::grab_input(wayfire_grab_interface iface)
     assert(!active_grab); // cannot have two active input grabs!
 
     if (our_touch)
+    {
         for (const auto& f : our_touch->gesture_recognizer.current)
             handle_touch_up(0, f.first);
+    }
 
     active_grab = iface;
 

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -178,10 +178,7 @@ bool input_manager::grab_input(wayfire_grab_interface iface)
     assert(!active_grab); // cannot have two active input grabs!
 
     if (our_touch)
-    {
-        for (const auto& f : our_touch->gesture_recognizer.current)
-            handle_touch_up(0, f.first);
-    }
+        our_touch->input_grabbed();
 
     active_grab = iface;
 

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -86,7 +86,7 @@ class input_manager
 
         void set_touch_focus(wayfire_surface_t *surface, uint32_t time, int id, int lx, int ly);
 
-        void update_drag_icons();
+        void update_drag_icon();
 
         std::vector<std::unique_ptr<wf_keyboard>> keyboards;
         std::vector<std::unique_ptr<wf_input_device>> input_devices;
@@ -95,7 +95,6 @@ class input_manager
          * This might not work with multiple keyboards */
         uint32_t mod_binding_key = 0; /* The keycode which triggered the modifier binding */
         std::chrono::steady_clock::time_point mod_binding_start;
-        int count_other_inputs = 0;
         std::vector<std::function<void()>> match_keys(uint32_t mods, uint32_t key, uint32_t mod_binding_key = 0);
 
         wayfire_view keyboard_focus;
@@ -120,7 +119,7 @@ class input_manager
         signal_callback_t surface_map_state_changed;
 
         std::unique_ptr<wf_touch> our_touch;
-        std::vector<std::unique_ptr<wf_drag_icon>> drag_icons;
+        std::unique_ptr<wf_drag_icon> drag_icon;
 
         int pointer_count = 0, touch_count = 0;
         void update_capabilities();

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -84,8 +84,6 @@ class input_manager
         wayfire_surface_t* input_surface_at(int x, int y,
             int& lx, int& ly);
 
-        void set_touch_focus(wayfire_surface_t *surface, uint32_t time, int id, int lx, int ly);
-
         void update_drag_icon();
 
         std::vector<std::unique_ptr<wf_keyboard>> keyboards;
@@ -109,6 +107,7 @@ class input_manager
 
         void update_cursor_position(uint32_t time_msec, bool real_update = true);
         void update_cursor_focus(wayfire_surface_t *surface, int lx, int ly);
+        void set_touch_focus(wayfire_surface_t *surface, uint32_t time, int id, int lx, int ly);
 
         wl_client *exclusive_client = NULL;
 

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -10,6 +10,8 @@ extern "C"
 
 #include "keyboard.hpp"
 #include "core.hpp"
+#include "cursor.hpp"
+#include "touch.hpp"
 #include "input-manager.hpp"
 #include "compositor-view.hpp"
 #include "input-inhibit.hpp"
@@ -231,7 +233,9 @@ bool input_manager::handle_keyboard_key(uint32_t key, uint32_t state)
         /* as long as we have pressed only modifiers, we should check for modifier bindings on release */
         if (mod)
         {
-            bool modifiers_only = !count_other_inputs;
+            bool modifiers_only = !cursor->count_pressed_buttons
+                && (!our_touch || our_touch->gesture_recognizer.current.empty());
+
             for (size_t i = 0; i < kbd->num_keycodes; i++)
                 if (!mod_from_key(seat, kbd->keycodes[i]))
                     modifiers_only = false;

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -29,7 +29,7 @@ static void handle_drag_icon_destroy(wl_listener*, void *)
     /* we don't dec_keep_count() because the surface memory is
      * managed by the unique_ptr */
     core->input->drag_icon = nullptr;
-    core->emit_signal("stop-drag", nullptr);
+    core->emit_signal("drag-stopped", nullptr);
 }
 
 wf_drag_icon::wf_drag_icon(wlr_drag_icon *ic)

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -24,20 +24,12 @@ static void handle_drag_icon_unmap(wl_listener* listener, void *data)
     icon->unmap();
 }
 
-static void handle_drag_icon_destroy(wl_listener* listener, void *data)
+static void handle_drag_icon_destroy(wl_listener*, void *)
 {
-    auto wlr_icon = (wlr_drag_icon*) data;
-    auto icon = (wf_drag_icon*) wlr_icon->data;
-
-    auto it = std::find_if(core->input->drag_icons.begin(),
-                           core->input->drag_icons.end(),
-                           [=] (const std::unique_ptr<wf_drag_icon>& ptr)
-                                {return ptr.get() == icon;});
-
     /* we don't dec_keep_count() because the surface memory is
      * managed by the unique_ptr */
-    assert(it != core->input->drag_icons.end());
-    core->input->drag_icons.erase(it);
+    core->input->drag_icon = nullptr;
+    core->emit_signal("stop-drag", nullptr);
 }
 
 wf_drag_icon::wf_drag_icon(wlr_drag_icon *ic)
@@ -121,9 +113,8 @@ static void handle_request_start_drag_cb(wl_listener*, void *data)
 static void handle_start_drag_cb(wl_listener*, void *data)
 {
     auto d = static_cast<wlr_drag*> (data);
-
-    auto icon = std::unique_ptr<wf_drag_icon>(new wf_drag_icon(d->icon));
-    core->input->drag_icons.push_back(std::move(icon));
+    core->input->drag_icon = std::make_unique<wf_drag_icon> (d->icon);
+    core->emit_signal("drag-started", nullptr);
 }
 
 static void handle_request_set_cursor(wl_listener*, void *data)
@@ -144,13 +135,10 @@ static void handle_request_set_primary_selection_cb(wl_listener*, void *data)
     wlr_seat_set_primary_selection(core->get_current_seat(), ev->source, ev->serial);
 }
 
-void input_manager::update_drag_icons()
+void input_manager::update_drag_icon()
 {
-    for (auto& icon : drag_icons)
-    {
-        if (icon->is_mapped())
-            icon->update_output_position();
-    }
+    if (drag_icon && drag_icon->is_mapped())
+        drag_icon->update_output_position();
 }
 
 void input_manager::create_seat()

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -323,7 +323,7 @@ void input_manager::handle_touch_down(uint32_t time, int32_t id, int32_t x, int3
     int lx, ly;
     auto focus = input_surface_at(x, y, lx, ly);
     set_touch_focus(focus, time, id, lx, ly);
-    update_drag_icons();
+    update_drag_icon();
 
     check_touch_bindings(ox, oy);
 }
@@ -358,7 +358,7 @@ void input_manager::handle_touch_motion(uint32_t time, int32_t id, int32_t x, in
     set_touch_focus(surface, time, id, lx, ly);
     wlr_seat_touch_notify_motion(seat, time, id, lx, ly);
 
-    update_drag_icons();
+    update_drag_icon();
 
     auto compositor_surface = wf_compositor_surface_from_surface(touch_focus);
     if (id == 0 && compositor_surface)

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -362,18 +362,15 @@ void input_manager::handle_touch_down(uint32_t time, int32_t id, int32_t x, int3
 void input_manager::handle_touch_up(uint32_t time, int32_t id)
 {
     --our_touch->count_touch_down;
-    if (our_touch->count_touch_down == 0)
-        our_touch->end_touch_down_grab();
-
     if (active_grab)
     {
         if (active_grab->callbacks.touch.up)
             active_grab->callbacks.touch.up(id);
-
-        return;
     }
 
     set_touch_focus(nullptr, time, id, 0, 0);
+    if (our_touch->count_touch_down == 0)
+        our_touch->end_touch_down_grab();
 }
 
 void input_manager::handle_touch_motion(uint32_t time, int32_t id, int32_t x, int32_t y)

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -63,7 +63,6 @@ void wf_gesture_recognizer::continue_gesture(int id, int sx, int sy)
 
     /* first case - consider swipe, we go through each
      * of the directions and check whether such swipe has occured */
-
     bool is_left_swipe = true, is_right_swipe = true,
          is_up_swipe = true, is_down_swipe = true;
 
@@ -265,6 +264,20 @@ void wf_touch::add_device(wlr_input_device *device)
     wlr_cursor_attach_input_device(cursor, device);
 }
 
+void wf_touch::start_touch_down_grab(wayfire_surface_t *surface)
+{
+    grabbed_surface = surface;
+}
+
+void wf_touch::end_touch_down_grab()
+{
+    if (grabbed_surface)
+    {
+        grabbed_surface = nullptr;
+        core->input->update_cursor_position(get_current_time(), false);
+    }
+}
+
 /* input_manager touch functions */
 void input_manager::set_touch_focus(wayfire_surface_t *surface, uint32_t time, int id, int x, int y)
 {
@@ -302,9 +315,12 @@ void input_manager::set_touch_focus(wayfire_surface_t *surface, uint32_t time, i
 void input_manager::handle_touch_down(uint32_t time, int32_t id, int32_t x, int32_t y)
 {
     mod_binding_key = 0;
-    auto wo = core->get_output_at(x, y);
-    core->focus_output(wo);
+    ++our_touch->count_touch_down;
 
+    if (our_touch->count_touch_down == 1)
+        core->focus_output(core->get_output_at(x, y));
+
+    auto wo = core->get_active_output();
     auto og = wo->get_layout_geometry();
     int ox = x - og.x;
     int oy = y - og.y;
@@ -322,14 +338,26 @@ void input_manager::handle_touch_down(uint32_t time, int32_t id, int32_t x, int3
 
     int lx, ly;
     auto focus = input_surface_at(x, y, lx, ly);
+    if (our_touch->count_touch_down == 1)
+    {
+        our_touch->start_touch_down_grab(focus);
+    } else if (our_touch->grabbed_surface && !drag_icon)
+    {
+        focus = our_touch->grabbed_surface;
+        /* XXX: we assume the output won't change ever since grab started */
+        auto local = our_touch->grabbed_surface->get_relative_position({ox, oy});
+        lx = local.x;
+        ly = local.y;
+    }
+
     set_touch_focus(focus, time, id, lx, ly);
     update_drag_icon();
-
     check_touch_bindings(ox, oy);
 }
 
 void input_manager::handle_touch_up(uint32_t time, int32_t id)
 {
+    --our_touch->count_touch_down;
     if (active_grab)
     {
         if (active_grab->callbacks.touch.up)
@@ -354,8 +382,24 @@ void input_manager::handle_touch_motion(uint32_t time, int32_t id, int32_t x, in
     }
 
     int lx, ly;
-    auto surface = input_surface_at(x, y, lx, ly);
-    set_touch_focus(surface, time, id, lx, ly);
+    wayfire_surface_t *surface = nullptr;
+
+    /* Same as cursor motion handling: make sure we send to the grabbed surface,
+     * except if we need this for DnD */
+    if (our_touch->grabbed_surface && !drag_icon)
+    {
+        surface = our_touch->grabbed_surface;
+        auto og = surface->get_output()->get_layout_geometry();
+        auto local = surface->get_relative_position({x - og.x, y - og.y});
+
+        lx = local.x;
+        ly = local.y;
+    } else
+    {
+        surface = input_surface_at(x, y, lx, ly);
+        set_touch_focus(surface, time, id, lx, ly);
+    }
+
     wlr_seat_touch_notify_motion(seat, time, id, lx, ly);
 
     update_drag_icon();

--- a/src/core/seat/touch.hpp
+++ b/src/core/seat/touch.hpp
@@ -16,6 +16,8 @@ struct wf_gesture_recognizer
         int id;
         int sx, sy;
         int ix, iy;
+
+        bool sent_to_client = false;
     };
 
     std::map<int, finger> current;
@@ -30,7 +32,7 @@ private:
     bool in_gesture = false, gesture_emitted = false;
     int start_sum_dist;
 
-    void start_new_gesture(int reason_id, int time);
+    void start_new_gesture();
     void continue_gesture(int id, int sx, int sy);
     void stop_gesture();
     void reset_gesture();
@@ -44,6 +46,7 @@ struct wf_touch
 
     wf_touch(wlr_cursor *cursor);
     void add_device(wlr_input_device *device);
+    void input_grabbed();
 
     int count_touch_down = 0;
     wayfire_surface_t *grabbed_surface = nullptr;

--- a/src/core/seat/touch.hpp
+++ b/src/core/seat/touch.hpp
@@ -2,6 +2,7 @@
 #define TOUCH_HPP
 
 #include <map>
+#include "view.hpp"
 
 extern "C"
 {
@@ -43,6 +44,11 @@ struct wf_touch
 
     wf_touch(wlr_cursor *cursor);
     void add_device(wlr_input_device *device);
+
+    int count_touch_down = 0;
+    wayfire_surface_t *grabbed_surface = nullptr;
+    void start_touch_down_grab(wayfire_surface_t *surface);
+    void end_touch_down_grab();
 };
 
 #endif /* end of include guard: TOUCH_HPP */

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -631,16 +631,14 @@ void render_manager::workspace_stream_update(wf_workspace_stream *stream,
     /* we "move" all icons to the current output */
     if (!renderer)
     {
-        for (auto& icon : core->input->drag_icons)
+        if (core->input->drag_icon && core->input->drag_icon->is_mapped())
         {
-            if (!icon->is_mapped())
-                continue;
-
-            icon->set_output(output);
-            icon->for_each_surface([&] (wayfire_surface_t *surface, int x, int y)
-                                   {
-                                       schedule_render_surface(surface, x, y, 0, 0);
-                                   });
+            core->input->drag_icon->set_output(output);
+            core->input->drag_icon->for_each_surface(
+                [&] (wayfire_surface_t *surface, int x, int y)
+                {
+                    schedule_render_surface(surface, x, y, 0, 0);
+                });
         }
     }
 
@@ -710,11 +708,8 @@ void render_manager::workspace_stream_update(wf_workspace_stream *stream,
 
     if (!renderer)
     {
-        for (auto& icon : core->input->drag_icons)
-        {
-            if (icon->is_mapped())
-                icon->set_output(nullptr);
-        }
+        if (core->input->drag_icon && core->input->drag_icon->is_mapped())
+            core->input->drag_icon->set_output(nullptr);
     }
 
     {

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -185,6 +185,26 @@ bool wayfire_surface_t::is_mapped()
     return !destroyed && surface;
 }
 
+wf_point wayfire_surface_t::get_relative_position(const wf_point& arg)
+{
+    if (!is_mapped())
+        return arg;
+
+    wf_point result = arg;
+
+    /* The root of each surface tree is a view */
+    auto view = dynamic_cast<wayfire_view_t*> (get_main_surface());
+    assert(view);
+
+    auto transformed = view->get_relative_position(result);
+
+    auto output_position = get_output_position();
+    auto view_position = view->get_output_position();
+
+    return {transformed.x + view_position.x - output_position.x,
+        transformed.y + view_position.y - output_position.y};
+}
+
 wf_point wayfire_surface_t::get_output_position()
 {
     auto pos = parent_surface->get_output_position();

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -374,12 +374,11 @@ wayfire_surface_t *wayfire_view_t::map_input_coordinates(int cx, int cy, int& sx
 
     if (transforms.size())
     {
-        auto box = get_untransformed_bounding_box();
-        transforms.for_each_reverse([&] (auto& transform)
-        {
-            auto p = transform->transform->transformed_to_local_point(box, {cx, cy});
-            cx = p.x; cy = p.y;
-        });
+        auto relative = get_relative_position({cx, cy});
+        auto og = get_output_geometry();
+
+        cx = relative.x + og.x;
+        cy = relative.y + og.y;
     }
 
     for_each_surface(
@@ -689,6 +688,36 @@ void wayfire_view_t::set_decoration(wayfire_surface_t *deco)
         set_geometry(output->workspace->get_workarea());
     if (fullscreen)
         set_geometry(output->get_relative_geometry());
+}
+
+#define INVALID_COORDS(p) (p.x == WF_INVALID_INPUT_COORDINATES || p.y == WF_INVALID_INPUT_COORDINATES)
+wf_point wayfire_view_t::get_relative_position(const wf_point& arg)
+{
+    if (!_is_mapped)
+        return arg;
+
+    wf_point result = arg;
+    if (transforms.size())
+    {
+        auto box = get_untransformed_bounding_box();
+        transforms.for_each_reverse([&] (auto& transform)
+        {
+            if (INVALID_COORDS(result))
+                return;
+
+            result = transform->transform->transformed_to_local_point(box, result);
+            box = transform->transform->get_bounding_box(box, box);
+        });
+
+        if (INVALID_COORDS(result))
+            return result;
+    }
+
+    auto og = get_output_geometry();
+    result.x -= og.x;
+    result.y -= og.y;
+
+    return result;
 }
 
 wf_point wayfire_view_t::get_output_position()


### PR DESCRIPTION
We need this so that wlroots doesn't think we have a pressed button while there isn't (needed for DnD). Nevertheless, the patch here might still cause wlroots button counter to get corrupted, this time making it
go negative. We'd need wlroots to track pressed buttons, so that we can avoid sending events in that case.

Needs https://github.com/swaywm/wlroots/issues/1593

TODO:

- [x] Fix touch up events - currently the touch counter gets corrupted if we drag a window by the titlebar
- [x] Fix wf-shell - autohide is now broken again