### PR TITLE
api: add missing include <algorithm> for std::min/max

### DIFF
--- a/src/api/util.hpp
+++ b/src/api/util.hpp
@@ -1,6 +1,7 @@
 #ifndef WF_UTIL_HPP
 #define WF_UTIL_HPP
 
+#include <algorithm>
 #include <functional>
 #include <pixman.h>
 extern "C"


### PR DESCRIPTION
Looks like this problem might have been hidden by gnu libstdc++ including it somewhere, with llvm libc++ std::min/max are not found w/o `<algorithm>`