### PR TITLE
Fix race condition when forking child to background

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -418,9 +418,6 @@ void wayfire_core::run(const char *command)
         } else {
             exit(0);
         }
-    } else {
-        int status;
-        waitpid(pid, &status, 0);
     }
 }
 


### PR DESCRIPTION
Sometimes, calling waitpid() would wait forever in the case where exit(0)
was called first. This was the case on amd cpu when switching to another
workspace and attempting to launch an app with keybinding. Fixes #224