### PR TITLE
fast-switcher: fix SIGFPE (modulo by zero) when last window is destroyed

### DIFF
--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -97,6 +97,13 @@ class wayfire_fast_switcher : public wayfire_plugin_t
 
         views.erase(views.begin() + i);
 
+        if (views.size() < 1)
+        {
+            // last view got destroyed, nothing left to choose
+            output->deactivate_plugin(grab_interface);
+            return;
+        }
+
         if (i <= current_view_index)
         {
             current_view_index =


### PR DESCRIPTION
Modulo by zero exception (views.size is zero): https://gist.github.com/myfreeweb/b6365b31dc3b0b416243c6b291221e57

> how i got that is by fast-switching on an output where the only window was from a hanging client, which could've crashed or something

I *guess* deactivating makes sense but idk.