### PR TITLE
vswipe: touchpad swipe support for switching workspaces

### DIFF
--- a/plugins/single_plugins/meson.build
+++ b/plugins/single_plugins/meson.build
@@ -3,6 +3,7 @@ resize        = shared_module('resize',        'resize.cpp',        include_dire
 command       = shared_module('command',       'command.cpp',       include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 autostart     = shared_module('autostart',     'autostart.cpp',     include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 vswitch       = shared_module('vswitch',       'vswitch.cpp',       include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
+vswipe        = shared_module('vswipe',        'vswipe.cpp',        include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 grid          = shared_module('grid',          'grid.cpp',          include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 wrot          = shared_module('wrot',          'wrot.cpp',          include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')
 expo          = shared_module('expo',          'expo.cpp',          include_directories: [wayfire_api_inc, wayfire_conf_inc], dependencies: [wlroots, pixman, wfconfig], install: true, install_dir: 'lib/wayfire/')

--- a/plugins/single_plugins/vswipe-processing.hpp
+++ b/plugins/single_plugins/vswipe-processing.hpp
@@ -33,7 +33,7 @@ static inline int vswipe_finish_target(const double accumulated_dx,
         const double move_threshold = 0.35,
         const double fast_threshold = 24)
 {
-    double target_dx = 0;
+    int target_dx = 0;
 
     const bool too_left = vx == 0 && (accumulated_dx > 0.0 || last_deltas > 0.0);
     const bool too_right = vx == vw - 1 && (accumulated_dx < 0.0 || last_deltas < 0.0);

--- a/plugins/single_plugins/vswipe-processing.hpp
+++ b/plugins/single_plugins/vswipe-processing.hpp
@@ -1,0 +1,47 @@
+#include <util.hpp>
+
+#include <cmath>
+
+static inline double vswipe_process_delta(const double delta,
+        const double accumulated_dx,
+        const int vx, const int vw,
+        const double speed_cap = 0.5,
+        const double speed_factor = 256)
+{
+    // The slowdown below must be applied differently for going out of bounds.
+    double sdx_offset = accumulated_dx;
+    if (vx == 0 && accumulated_dx > 0.0)
+        sdx_offset = accumulated_dx + 1.0;
+    if (vx == vw - 1 && accumulated_dx < 0.0)
+        sdx_offset = accumulated_dx - 1.0;
+
+    // To achieve a "rubberband" resistance effect when going too far, ease-in
+    // of the whole swiped distance is used as a slowdown factor for the current delta.
+    const double ease = 1.0 - std::pow(std::abs(sdx_offset) - 0.025, 4.0);
+
+    // If we're moving further in the limit direction, slow down all the way
+    // to extremely slow, but reversing the direction should be easier.
+    const double slowdown = clamp(ease,
+            std::signbit(delta) == std::signbit(sdx_offset) ? 0.005 : 0.2, 1.0);
+
+    return clamp(delta / speed_factor, -speed_cap, speed_cap) * slowdown;
+}
+
+static inline int vswipe_finish_target(const double accumulated_dx,
+        const int vx, const int vw,
+        const double last_deltas = 0,
+        const double move_threshold = 0.35,
+        const double fast_threshold = 24)
+{
+    double target_dx = 0;
+
+    const bool too_left = vx == 0 && (accumulated_dx > 0.0 || last_deltas > 0.0);
+    const bool too_right = vx == vw - 1 && (accumulated_dx < 0.0 || last_deltas < 0.0);
+
+    if (!too_left && (accumulated_dx > move_threshold || last_deltas > fast_threshold))
+        target_dx = 1;
+    else if (!too_right && (accumulated_dx < -move_threshold || last_deltas < -fast_threshold))
+        target_dx = -1;
+
+    return target_dx;
+}

--- a/plugins/single_plugins/vswipe.cpp
+++ b/plugins/single_plugins/vswipe.cpp
@@ -1,0 +1,262 @@
+#include <plugin.hpp>
+#include <output.hpp>
+#include <core.hpp>
+#include <debug.hpp>
+#include <view.hpp>
+#include <view-transform.hpp>
+#include <render-manager.hpp>
+#include <workspace-stream.hpp>
+#include <workspace-manager.hpp>
+#include <signal-definitions.hpp>
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <animation.hpp>
+
+#include <cmath>
+#include <utility>
+#include <animation.hpp>
+
+#include "vswipe-processing.hpp"
+
+class vswipe : public wf::plugin_interface_t
+{
+    private:
+        struct {
+            wf::workspace_stream_t left, curr, right;
+        } streams;
+
+        struct {
+            bool swiping = false;
+            double dx = 0.0;
+            double gap = 0.0;
+
+            double delta_prev = 0.0;
+            double delta_last = 0.0;
+
+            int vx = 0;
+            int vy = 0;
+            int vw = 0;
+            int vh = 0;
+        } state;
+
+        wf::render_hook_t renderer;
+
+        wf_duration duration;
+        wf_transition transition;
+
+        wf_option animation_duration;
+        wf_option background_color;
+        wf_option enable;
+        wf_option ignore_cancel;
+        wf_option fingers;
+        wf_option gap;
+        wf_option threshold;
+        wf_option delta_threshold;
+        wf_option speed_factor;
+        wf_option speed_cap;
+
+    public:
+
+    void init(wayfire_config *config)
+    {
+        grab_interface->name = "vswipe";
+        grab_interface->capabilities = wf::CAPABILITY_MANAGE_COMPOSITOR;
+        grab_interface->callbacks.cancel = [=] () { finalize_and_exit(); };
+
+        auto section = config->get_section("vswipe");
+
+        animation_duration = section->get_option("duration", "180");
+        duration = wf_duration(animation_duration);
+
+        enable = section->get_option("enable", "1");
+        ignore_cancel = section->get_option("ignore_cancel", "1");
+        fingers = section->get_option("fingers", "4");
+        gap = section->get_option("gap", "32");
+        threshold = section->get_option("threshold", "0.35");
+        delta_threshold = section->get_option("delta_threshold", "24");
+        speed_factor = section->get_option("speed_factor", "256");
+        speed_cap = section->get_option("speed_cap", "0.05");
+        wf::get_core().connect_signal("pointer-swipe-begin", &on_swipe_begin);
+        wf::get_core().connect_signal("pointer-swipe-update", &on_swipe_update);
+        wf::get_core().connect_signal("pointer-swipe-end", &on_swipe_end);
+
+        background_color = section->get_option("background", "0 0 0 1");
+
+        renderer = [=] (const wf_framebuffer& buffer) { render(buffer); };
+    }
+
+    void render(const wf_framebuffer &fb)
+    {
+        if (!duration.running() && !state.swiping)
+            finalize_and_exit();
+
+        if (duration.running())
+            state.dx = duration.progress(transition);
+
+        if (state.vx > 0)
+            update_stream(streams.left);
+        update_stream(streams.curr);
+        if (state.vx < state.vw - 1)
+            update_stream(streams.right);
+
+        OpenGL::render_begin(fb);
+        OpenGL::clear(background_color->as_cached_color());
+        fb.scissor(fb.framebuffer_box_from_geometry_box(fb.geometry));
+
+        gl_geometry out_geometry = {
+            .x1 = -1,
+            .y1 = 1,
+            .x2 = 1,
+            .y2 = -1,
+        };
+
+        auto swipe = glm::translate(glm::mat4(1.0), glm::vec3(state.dx * 2, 0.0, 0.0));
+
+        if (state.vx > 0)
+        {
+            auto left = glm::translate(glm::mat4(1.0), glm::vec3(-2.0 - state.gap * 2.0, 0.0, 0.0));
+            OpenGL::render_transformed_texture(streams.left.buffer.tex,
+                out_geometry, {}, fb.transform * left * swipe);
+        }
+
+        OpenGL::render_transformed_texture(streams.curr.buffer.tex,
+            out_geometry, {}, fb.transform * swipe);
+
+        if (state.vx < state.vw - 1)
+        {
+            auto right = glm::translate(glm::mat4(1.0), glm::vec3(2.0 + state.gap * 2.0, 0.0, 0.0));
+            OpenGL::render_transformed_texture(streams.right.buffer.tex,
+                out_geometry, {}, fb.transform * right * swipe);
+        }
+
+        GL_CALL(glUseProgram(0));
+        OpenGL::render_end();
+    }
+
+    inline void update_stream(wf::workspace_stream_t& s)
+    {
+        if (!s.running)
+            output->render->workspace_stream_start(s);
+        else
+            output->render->workspace_stream_update(s);
+    }
+
+    wf::signal_callback_t on_swipe_begin = [=] (wf::signal_data_t *data)
+    {
+        if (!enable->as_cached_int())
+            return;
+
+        if (output->is_plugin_active(grab_interface->name))
+            return;
+
+        auto ev = static_cast<wf::swipe_begin_signal*> (data)->ev;
+        if (static_cast<int>(ev->fingers) != fingers->as_cached_int())
+            return;
+
+        // Plugins are per output, swipes are global, so we need to handle
+        // the swipe only when the cursor is on *our* (plugin instance's) output
+        if (!(output->get_relative_geometry() & output->get_cursor_position()))
+            return;
+
+        wf::get_core().focus_output(output);
+
+        if (!output->activate_plugin(grab_interface))
+            return;
+
+        grab_interface->grab();
+
+        state.swiping = true;
+        state.dx = 0;
+        state.delta_last = 0;
+        state.delta_prev = 0;
+
+        state.gap = gap->as_cached_double() / output->get_screen_size().width;
+
+        // We switch the actual workspace before the finishing animation,
+        // so the rendering of the animation cannot dynamically query current
+        // workspace again, so it's stored here
+        auto grid = output->workspace->get_workspace_grid_size();
+        auto ws = output->workspace->get_current_workspace();
+        state.vw = grid.width;
+        state.vh = grid.height;
+        state.vx = ws.x;
+        state.vy = ws.y;
+
+        // XXX: redundant checks, setting out-of-bounds here works fine
+        if (ws.x > 0)
+            streams.left.ws = wf_point {ws.x - 1, ws.y};
+        streams.curr.ws = wf_point {ws.x, ws.y};
+        if (ws.x < grid.width - 1)
+            streams.right.ws = wf_point {ws.x + 1, ws.y};
+
+        output->render->set_renderer(renderer);
+        output->render->damage_whole();
+    };
+
+    wf::signal_callback_t on_swipe_update = [=] (wf::signal_data_t *data)
+    {
+        if (!state.swiping)
+            return;
+
+        auto ev = static_cast<wf::swipe_update_signal*> (data)->ev;
+
+        const double cap = speed_cap->as_cached_double();
+        const double fac = speed_factor->as_cached_double();
+        state.dx += vswipe_process_delta(ev->dx, state.dx, state.vx, state.vw, cap, fac);
+
+        state.delta_prev = state.delta_last;
+        state.delta_last = ev->dx;
+
+        output->render->damage_whole();
+    };
+
+    wf::signal_callback_t on_swipe_end = [=] (wf::signal_data_t *data)
+    {
+        if (!state.swiping)
+            return;
+
+        state.swiping = false;
+
+        auto ev = static_cast<wf::swipe_end_signal*>(data)->ev;
+
+        const double move_threshold = clamp(threshold->as_cached_double(), 0.0, 1.0);
+        const double fast_threshold = clamp(delta_threshold->as_cached_double(), 0.0, 1000.0);
+        const double target_dx = (ev->cancelled && !ignore_cancel->as_cached_int()) ? 0
+            : vswipe_finish_target(state.dx, state.vx, state.vw,
+                    state.delta_prev + state.delta_last,
+                    move_threshold, fast_threshold);
+
+        transition = {state.dx, target_dx + state.gap * (target_dx == 0 ? 0 : std::copysign(1.0, target_dx))};
+        output->workspace->set_workspace(wf_point {state.vx - static_cast<int>(target_dx), state.vy});
+        output->render->set_redraw_always();
+        duration.start();
+    };
+
+    void finalize_and_exit()
+    {
+        state.swiping = false;
+        grab_interface->ungrab();
+        output->deactivate_plugin(grab_interface);
+
+        output->render->workspace_stream_stop(streams.left);
+        output->render->workspace_stream_stop(streams.curr);
+        output->render->workspace_stream_stop(streams.right);
+
+        output->render->set_renderer(nullptr);
+        output->render->set_redraw_always(false);
+    }
+
+    void fini()
+    {
+        if (state.swiping)
+            finalize_and_exit();
+
+        OpenGL::render_begin();
+        streams.left.buffer.release();
+        streams.curr.buffer.release();
+        streams.right.buffer.release();
+        OpenGL::render_end();
+    }
+};
+
+DECLARE_WAYFIRE_PLUGIN(vswipe);

--- a/plugins/single_plugins/vswipe.cpp
+++ b/plugins/single_plugins/vswipe.cpp
@@ -61,7 +61,6 @@ class vswipe : public wf::plugin_interface_t
         wf_option background_color;
         wf_option enable_horizontal;
         wf_option enable_vertical;
-        wf_option ignore_cancel;
         wf_option fingers;
         wf_option gap;
         wf_option threshold;
@@ -84,7 +83,6 @@ class vswipe : public wf::plugin_interface_t
 
         enable_horizontal = section->get_option("enable_horizontal", "1");
         enable_vertical = section->get_option("enable_vertical", "1");
-        ignore_cancel = section->get_option("ignore_cancel", "1");
         fingers = section->get_option("fingers", "4");
         gap = section->get_option("gap", "32");
         threshold = section->get_option("threshold", "0.35");
@@ -327,26 +325,23 @@ class vswipe : public wf::plugin_interface_t
         int target_delta = 0;
         wf_point target_workspace = {state.vx, state.vy};
 
-        if (!ev->cancelled || ignore_cancel->as_int())
+        switch (state.direction)
         {
-            switch (state.direction)
-            {
-                case UNKNOWN:
-                    target_delta = 0;
-                    break;
-                case HORIZONTAL:
-                    target_delta = vswipe_finish_target(state.delta_sum,
-                        state.vx, state.vw, state.delta_prev + state.delta_last,
-                        move_threshold, fast_threshold);
-                    target_workspace.x -= target_delta;
-                    break;
-                case VERTICAL:
-                    target_delta = vswipe_finish_target(state.delta_sum,
-                        state.vy, state.vh, state.delta_prev + state.delta_last,
-                        move_threshold, fast_threshold);
-                    target_workspace.y -= target_delta;
-                    break;
-            }
+            case UNKNOWN:
+                target_delta = 0;
+                break;
+            case HORIZONTAL:
+                target_delta = vswipe_finish_target(state.delta_sum,
+                    state.vx, state.vw, state.delta_prev + state.delta_last,
+                    move_threshold, fast_threshold);
+                target_workspace.x -= target_delta;
+                break;
+            case VERTICAL:
+                target_delta = vswipe_finish_target(state.delta_sum,
+                    state.vy, state.vh, state.delta_prev + state.delta_last,
+                    move_threshold, fast_threshold);
+                target_workspace.y -= target_delta;
+                break;
         }
 
         transition = {state.delta_sum, target_delta + state.gap * target_delta};

--- a/plugins/single_plugins/vswipe.cpp
+++ b/plugins/single_plugins/vswipe.cpp
@@ -193,13 +193,6 @@ class vswipe : public wf::plugin_interface_t
         if (!(output->get_relative_geometry() & output->get_cursor_position()))
             return;
 
-        wf::get_core().focus_output(output);
-
-        if (!output->activate_plugin(grab_interface))
-            return;
-
-        grab_interface->grab();
-
         state.swiping = true;
         state.direction = UNKNOWN;
         state.initial_deltas = {0.0, 0.0};
@@ -224,15 +217,21 @@ class vswipe : public wf::plugin_interface_t
         streams.prev.ws = {-1, -1};
         streams.next.ws = {-1, -1};
         streams.curr.ws = wf_point {ws.x, ws.y};
-
-        output->render->set_renderer(renderer);
-        output->render->damage_whole();
     };
 
     void start_swipe(swipe_direction_t direction)
     {
         assert(direction != UNKNOWN);
         state.direction = direction;
+
+        wf::get_core().focus_output(output);
+
+        if (!output->activate_plugin(grab_interface))
+            return;
+
+        grab_interface->grab();
+        output->render->set_renderer(renderer);
+        output->render->damage_whole();
 
         auto ws = output->workspace->get_current_workspace();
         auto grid = output->workspace->get_workspace_grid_size();

--- a/plugins/single_plugins/vswipe.cpp
+++ b/plugins/single_plugins/vswipe.cpp
@@ -58,7 +58,8 @@ class vswipe : public wf::plugin_interface_t
 
         wf_option animation_duration;
         wf_option background_color;
-        wf_option enable;
+        wf_option enable_horizontal;
+        wf_option enable_vertical;
         wf_option ignore_cancel;
         wf_option fingers;
         wf_option gap;
@@ -80,7 +81,8 @@ class vswipe : public wf::plugin_interface_t
         animation_duration = section->get_option("duration", "180");
         duration = wf_duration(animation_duration);
 
-        enable = section->get_option("enable", "1");
+        enable_horizontal = section->get_option("enable_horizontal", "1");
+        enable_vertical = section->get_option("enable_vertical", "1");
         ignore_cancel = section->get_option("ignore_cancel", "1");
         fingers = section->get_option("fingers", "4");
         gap = section->get_option("gap", "32");
@@ -176,7 +178,7 @@ class vswipe : public wf::plugin_interface_t
 
     wf::signal_callback_t on_swipe_begin = [=] (wf::signal_data_t *data)
     {
-        if (!enable->as_cached_int())
+        if (!enable_horizontal->as_cached_int() && !enable_vertical->as_cached_int())
             return;
 
         if (output->is_plugin_active(grab_interface->name))
@@ -276,11 +278,11 @@ class vswipe : public wf::plugin_interface_t
             horizontal &= state.initial_deltas.x > state.initial_deltas.y;
             vertical &= state.initial_deltas.y > state.initial_deltas.x;
 
-            if (horizontal || grid.height == 1)
+            if (horizontal && grid.width > 1 && enable_horizontal->as_cached_int())
             {
                 start_swipe(HORIZONTAL);
             }
-            else if (vertical || grid.width == 1)
+            else if (vertical && grid.height > 1 && enable_vertical->as_cached_int())
             {
                 start_swipe(VERTICAL);
             }

--- a/src/api/geometry.hpp
+++ b/src/api/geometry.hpp
@@ -46,6 +46,8 @@ wf_point    operator - (const wf_point& a);
 
 /* Returns true if point is inside rect */
 bool operator & (const wf_geometry& rect, const wf_point& point);
+/* Returns true if point is inside rect */
+bool operator & (const wf_geometry& rect, const wf_pointf& point);
 /* Returns true if the two geometries have a common point */
 bool operator & (const wf_geometry& r1, const wf_geometry& r2);
 

--- a/src/api/signal-definitions.hpp
+++ b/src/api/signal-definitions.hpp
@@ -95,6 +95,10 @@ wf::output_t *get_signaled_output(wf::signal_data_t *data);
 using output_added_signal = _output_signal;
 using output_removed_signal = _output_signal;
 
+struct wlr_event_pointer_swipe_begin;
+struct wlr_event_pointer_swipe_update;
+struct wlr_event_pointer_swipe_end;
+
 namespace wf
 {
     class input_device_t;
@@ -109,6 +113,21 @@ namespace wf
     struct input_device_signal : public signal_data_t
     {
         nonstd::observer_ptr<input_device_t> device;
+    };
+
+    struct swipe_begin_signal : public wf::signal_data_t
+    {
+        wlr_event_pointer_swipe_begin *ev;
+    };
+
+    struct swipe_update_signal : public wf::signal_data_t
+    {
+        wlr_event_pointer_swipe_update *ev;
+    };
+
+    struct swipe_end_signal : public wf::signal_data_t
+    {
+        wlr_event_pointer_swipe_end *ev;
     };
 }
 

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -1,5 +1,6 @@
 #include "pointer.hpp"
 #include "input-manager.hpp"
+#include "signal-definitions.hpp"
 
 #include <core.hpp>
 #include <debug.hpp>
@@ -471,6 +472,9 @@ void wf::LogicalPointer::handle_pointer_axis(wlr_event_pointer_axis *ev)
 void wf::LogicalPointer::handle_pointer_swipe_begin(
     wlr_event_pointer_swipe_begin *ev)
 {
+    wf::swipe_begin_signal data;
+    data.ev = ev;
+    wf::get_core().emit_signal("pointer-swipe-begin", &data);
     wlr_pointer_gestures_v1_send_swipe_begin(
         wf::get_core().protocols.pointer_gestures, input->seat,
         ev->time_msec, ev->fingers);
@@ -479,6 +483,9 @@ void wf::LogicalPointer::handle_pointer_swipe_begin(
 void wf::LogicalPointer::handle_pointer_swipe_update(
     wlr_event_pointer_swipe_update *ev)
 {
+    wf::swipe_update_signal data;
+    data.ev = ev;
+    wf::get_core().emit_signal("pointer-swipe-update", &data);
     wlr_pointer_gestures_v1_send_swipe_update(
         wf::get_core().protocols.pointer_gestures, input->seat,
         ev->time_msec, ev->dx, ev->dy);
@@ -487,6 +494,9 @@ void wf::LogicalPointer::handle_pointer_swipe_update(
 void wf::LogicalPointer::handle_pointer_swipe_end(
     wlr_event_pointer_swipe_end *ev)
 {
+    wf::swipe_end_signal data;
+    data.ev = ev;
+    wf::get_core().emit_signal("pointer-swipe-end", &data);
     wlr_pointer_gestures_v1_send_swipe_end(
         wf::get_core().protocols.pointer_gestures, input->seat,
         ev->time_msec, ev->cancelled);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -64,6 +64,11 @@ bool operator & (const wf_geometry& rect, const wf_point& point)
     return wlr_box_contains_point(&rect, point.x, point.y);
 }
 
+bool operator & (const wf_geometry& rect, const wf_pointf& point)
+{
+    return wlr_box_contains_point(&rect, point.x, point.y);
+}
+
 bool operator & (const wf_geometry& r1, const wf_geometry& r2)
 {
     wlr_box result;


### PR DESCRIPTION
This is the proper nice trackpad workspace switching, like on macOS, not the cheap fake discrete gesture thing many people settle for with external programs like libinput-gestures. With this, you can "play around", move the viewport left-right-left-right, which is very relaxing, at least for me :)

- [x] "rubberband" "soft limit" for swipe distance (is there a proper word for this?), if you go too far (more than one workspace) you're smoothly slowed to a crawl, but you can change direction and that is not slow
- [x] ultra fast jerky motion can change direction instantly (you could be very far into the workspace to the right, and a very sudden swipe to the left would go to the workspace to the left)
- [x] works properly with multiple outputs, respects their independence
- [x] the slowdown should begin instantly when going out of bounds, i.e. going to the left of the leftmost workspace should not pretend there's an extra `-1`st workspace there
- [ ] enqueue multiple super-quick swipes instead of ignoring when animation is still going. or have the swipe take over from the animation? (that one sounds hard)
- [x] these events should not go through to apps — update/end events should go through the grab? (grab does not work for me on an unfocused output!)
- [x] if this should be a separate plugin, how would it interact with vswitch? grabbing would prevent another plugin from doing its thing?
- [x] reduce copy-paste?
- [x] [EXTERNAL] libinput currently delays swipe events because it thinks that 3-4 finger gestures could be pinches. which doesn't make sense. feels so much better when this is patched out. I'll discuss that in the libinput issue tracker.
- [x] [FUTURE] only moving xdg surfaces looks awkward (moving between empty workspaces looks like nothing is happening at all), layer-shell panel/background should also move. that would need mirroring, right?
- [x] [FUTURE] when we have the above, I'd love to see gaps (black bars) between the workspaces