### PR TITLE
input-manager: do not crash when the keyboard is gone

### DIFF
--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -181,9 +181,12 @@ bool input_manager::grab_input(wf::plugin_grab_interface_t* iface)
     active_grab = iface;
 
     auto kbd = wlr_seat_get_keyboard(seat);
-    auto mods = kbd->modifiers;
-    mods.depressed = 0;
-    wlr_seat_keyboard_send_modifiers(seat, &mods);
+    if (kbd)
+    {
+        auto mods = kbd->modifiers;
+        mods.depressed = 0;
+        wlr_seat_keyboard_send_modifiers(seat, &mods);
+    }
 
     set_keyboard_focus(NULL, seat);
     update_cursor_focus(nullptr, 0, 0);


### PR DESCRIPTION
Found by using a remote keyboard via [netevent](https://github.com/Blub/netevent) and quitting that at the "right" moment after dragging a window (lucky!).