### PR TITLE
layer-shell: actually check for anchoring to 0 edges

### DIFF
--- a/src/view/layer-shell.cpp
+++ b/src/view/layer-shell.cpp
@@ -135,7 +135,7 @@ struct wf_layer_shell_manager
                 edges ^= both_vert;
         }
 
-        if (__builtin_popcount(edges) > 1)
+        if (edges == 0 || __builtin_popcount(edges) > 1)
         {
             log_error ("Unsupported: layer-shell exclusive zone for surfaces anchored to 0, 2 or 4 edges");
             return;


### PR DESCRIPTION
Instead of tripping assert(false):

```
    frame #3: 0x0000000800c853b1 libc.so.7`__assert(func=<unavailable>, file=<unavailable>, line=<unavailable>, failedexpr=<unavailable>) at assert.c:51
    frame #4: 0x00000000005664fb wayfire`anchor_to_edge(edges=0) at layer-shell.cpp:74
    frame #5: 0x000000000056eb9c wayfire`wf_layer_shell_manager::set_exclusive_zone(this=0x00000000005d0730, v=0x000000081173ce00) at layer-shell.cpp:155
    frame #6: 0x000000000056dc46 wayfire`wf_layer_shell_manager::arrange_unmapped_view(this=0x00000000005d0730, view=0x000000081173ce00) at layer-shell.cpp:250
    frame #7: 0x0000000000566b08 wayfire`wayfire_layer_shell_view::wayfire_layer_shell_view(this=0x000000081173ce00, lsurf=0x000000080b919c00) at layer-shell.cpp:314
…
```