### PR TITLE
place: Fix window placement using cascade when place is loaded after wayfire starts

### DIFF
--- a/plugins/single_plugins/place.cpp
+++ b/plugins/single_plugins/place.cpp
@@ -14,7 +14,9 @@ class wayfire_place_window : public wf::plugin_interface_t
     public:
     void init(wayfire_config *config)
     {
-        cascade_x = cascade_y = 0;
+        auto workarea = output->workspace->get_workarea();
+        cascade_x = workarea.x;
+        cascade_y = workarea.y;
 
         created_cb = [=] (wf::signal_data_t *data)
         {


### PR DESCRIPTION
This was happening because cascade_x/y are initialized to 0 on plugin init
and rely on workarea change signal to update. However, this only happens if
place is loaded when wayfire starts. Fix this by initializing cascade_x/y
with the workarea.x/y on init. Fixes #304.