### PR TITLE
xwayland: Use configure request mask to position surfaces

### DIFF
--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -49,7 +49,7 @@ class wf_move_mirror_view : public wf::mirror_view_t
     virtual void close()
     {
         if (show_animation)
-            emit_view_pre_unmap(self());
+            emit_view_pre_unmap();
 
         wf::mirror_view_t::close();
     }

--- a/plugins/single_plugins/place.cpp
+++ b/plugins/single_plugins/place.cpp
@@ -20,14 +20,16 @@ class wayfire_place_window : public wf::plugin_interface_t
 
         created_cb = [=] (wf::signal_data_t *data)
         {
+            auto ev = (map_view_signal*) (data);
             auto view = get_signaled_view(data);
 
             if (view->role != wf::VIEW_ROLE_TOPLEVEL || view->parent ||
-                view->fullscreen || view->tiled_edges)
+                view->fullscreen || view->tiled_edges || ev->is_positioned)
             {
                 return;
             }
 
+            ev->is_positioned = true;
             auto workarea = output->workspace->get_workarea();
             auto mode = placement_mode->as_string();
 

--- a/src/api/signal-definitions.hpp
+++ b/src/api/signal-definitions.hpp
@@ -14,9 +14,14 @@ wayfire_view get_signaled_view(wf::signal_data_t *data);
 
 using create_view_signal     = _view_signal;
 using destroy_view_signal    = _view_signal;
-using map_view_signal        = _view_signal;
 using unmap_view_signal      = _view_signal;
 using pre_unmap_view_signal  = _view_signal;
+
+struct map_view_signal : public _view_signal
+{
+    /* Indicates whether the position already has its initial posittion */
+    bool is_positioned = false;
+};
 
 /* Indicates the view is no longer available, for ex. it has been minimized
  * or unmapped */

--- a/src/api/view.hpp
+++ b/src/api/view.hpp
@@ -401,28 +401,29 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
      * Called whenever the minimized, tiled, fullscreened
      * or activated state changes */
     virtual void desktop_state_updated();
+
+    /**
+     * Emit the view map signal. It indicates that a view has been mapped, i.e.
+     * plugins can now "work" with it. Note that not all views will emit the map
+     * event.
+     */
+    virtual void emit_view_map();
+
+    /**
+     * Emit the view unmap signal. It indicates that the view is in the process of
+     * being destroyed. Most plugins should stop any actions they have on the view.
+     */
+    virtual void emit_view_unmap();
+
+    /**
+     * Emit the view pre-unmap signal. It is emitted right before the view
+     * destruction start. At this moment a plugin can still take a snapshot of the
+     * view. Note that not all views emit the pre-unmap signal, however the unmap
+     * signal is mandatory for all views.
+     */
+    virtual void emit_view_pre_unmap();
 };
 
-/**
- * Emit the view map signal. It indicates that a view has been mapped, i.e.
- * plugins can now "work" with it. Note that not all views will emit the map
- * event.
- */
-void emit_view_map(wayfire_view view);
-
-/**
- * Emit the view unmap signal. It indicates that the view is in the process of
- * being destroyed. Most plugins should stop any actions they have on the view.
- */
-void emit_view_unmap(wayfire_view view);
-
-/**
- * Emit the view pre-unmap signal. It is emitted right before the view
- * destruction start. At this moment a plugin can still take a snapshot of the
- * view. Note that not all views emit the pre-unmap signal, however the unmap
- * signal is mandatory for all views.
- */
-void emit_view_pre_unmap(wayfire_view view);
 wayfire_view wl_surface_to_wayfire_view(wl_resource *surface);
 }
 

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -41,14 +41,14 @@ void wf::mirror_view_t::close()
     if (!base_view)
         return;
 
-    emit_view_pre_unmap(self());
+    emit_view_pre_unmap();
 
     base_view->disconnect_signal("unmap", &base_view_unmapped);
     base_view->disconnect_signal("damaged-region", &base_view_damaged);
     base_view = nullptr;
 
     emit_map_state_change(this);
-    emit_view_unmap(self());
+    emit_view_unmap();
 
     unref();
 }
@@ -138,7 +138,7 @@ void wf::color_rect_view_t::close()
 {
     this->_is_mapped = false;
 
-    emit_view_unmap(self());
+    emit_view_unmap();
     emit_map_state_change(this);
 
     unref();

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -183,6 +183,9 @@ class wlr_view_t :
     }
 };
 
+/** Emit the map signal for the given view */
+void emit_view_map_signal(wayfire_view view, bool has_position);
+
 wf::surface_interface_t* wf_surface_from_void(void *handle);
 wf::view_interface_t* wf_view_from_void(void *handle);
 


### PR DESCRIPTION
The mask contains information about whether or not to use the
position and size fields. Since size is determined by commit,
we only concern ourselves with the position here. This requires
[wlroots #1843](https://github.com/swaywm/wlroots/pull/1843). This fixes bugs with positioning xwayland surfaces
with and without place plugin enabled. Fixes #307.