### PR TITLE
fisheye: Initialize activate variable

### DIFF
--- a/plugins/single_plugins/fisheye.cpp
+++ b/plugins/single_plugins/fisheye.cpp
@@ -137,6 +137,7 @@ class wayfire_fisheye : public wf::plugin_interface_t
                 render(source, dest);
             };
 
+            active = false;
             toggle_cb = [=] (wf_activator_source, uint32_t)
             {
                     if (active)


### PR DESCRIPTION
This was causing fisheye to not activate until the second time
the binding is pressed after loading the plugin.