### PR TITLE
Send bound events when input is inhibited

### DIFF
--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -152,15 +152,20 @@ class wayfire_blur : public wf::plugin_interface_t
         /* Toggles the blur state of the view the user clicked on */
         button_toggle = [=] (uint32_t, int, int)
         {
+            if (!output->can_activate_plugin(grab_interface))
+                return false;
+
             auto view = wf::get_core().get_cursor_focus_view();
             if (!view)
-                return;
+                return false;
 
             if (view->get_transformer(transformer_name)) {
                 view->pop_transformer(transformer_name);
             } else {
                 add_transformer(view);
             }
+
+            return true;
         };
         output->add_button(section->get_option("toggle", "<super> <alt> BTN_LEFT"),
             &button_toggle);

--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -103,17 +103,17 @@ class wayfire_cube : public wf::plugin_interface_t
 
         auto button = section->get_option("activate", "<alt> <ctrl> BTN_LEFT");
         activate_binding = [=] (uint32_t, int32_t, int32_t) {
-            input_grabbed();
+            return input_grabbed();
         };
 
         auto key_left = section->get_option("rotate_left", "<alt> <ctrl> KEY_LEFT");
         rotate_left = [=] (wf_activator_source, uint32_t) {
-            move_vp(-1);
+            return move_vp(-1);
         };
 
         auto key_right = section->get_option("rotate_right", "<alt> <ctrl> KEY_RIGHT");
         rotate_right = [=] (wf_activator_source, uint32_t) {
-            move_vp(1);
+            return move_vp(1);
         };
 
         output->add_button(button, &activate_binding);
@@ -290,10 +290,10 @@ class wayfire_cube : public wf::plugin_interface_t
     }
 
     /* Start moving to a workspace to the left/right using the keyboard */
-    void move_vp(int dir)
+    bool move_vp(int dir)
     {
         if (!activate())
-            return;
+            return false;
 
         /* After the rotation is done, we want to exit cube and focus the target workspace */
         animation.in_exit = true;
@@ -307,13 +307,15 @@ class wayfire_cube : public wf::plugin_interface_t
         animation.duration.start();
         update_view_matrix();
         output->render->schedule_redraw();
+
+        return true;
     }
 
     /* Initiate with an button grab. */
-    void input_grabbed()
+    bool input_grabbed()
     {
         if (!activate())
-            return;
+            return false;
 
         saved_pointer_position = wf::get_core().get_cursor_position();
         wf::get_core().hide_cursor();
@@ -339,6 +341,8 @@ class wayfire_cube : public wf::plugin_interface_t
 
         update_view_matrix();
         output->render->schedule_redraw();
+
+        return true;
     }
 
     /* Mouse grab was released */

--- a/plugins/single_plugins/alpha.cpp
+++ b/plugins/single_plugins/alpha.cpp
@@ -79,21 +79,25 @@ class wayfire_alpha : public wf::plugin_interface_t
     axis_callback axis_cb = [=] (wlr_event_pointer_axis* ev)
     {
         if (!output->activate_plugin(grab_interface))
-            return;
+            return false;
 
         output->deactivate_plugin(grab_interface);
 
         auto view = wf::get_core().get_cursor_focus_view();
         if (!view)
-            return;
+            return false;
 
         auto layer = output->workspace->get_view_layer(view);
 
         if (layer == wf::LAYER_BACKGROUND)
-            return;
+            return false;
 
-        if (ev->orientation == WLR_AXIS_ORIENTATION_VERTICAL)
+        if (ev->orientation == WLR_AXIS_ORIENTATION_VERTICAL) {
             update_alpha(view, ev->delta);
+            return true;
+        }
+
+        return false;
     };
 
     wf_option_callback min_value_changed = [=] ()

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -58,15 +58,15 @@ class wayfire_command : public wf::plugin_interface_t
         BINDING_REPEAT,
         BINDING_ALWAYS,
     };
-    void on_binding(std::string command, binding_mode mode, wf_activator_source source,
+    bool on_binding(std::string command, binding_mode mode, wf_activator_source source,
         uint32_t value)
     {
         /* We already have a repeatable command, do not accept further bindings */
         if (repeat.pressed_key || repeat.pressed_button)
-            return;
+            return false;
 
         if (!output->activate_plugin(grab_interface, mode == BINDING_ALWAYS))
-            return;
+            return false;
 
         wf::get_core().run(command.c_str());
 
@@ -75,7 +75,7 @@ class wayfire_command : public wf::plugin_interface_t
             value == 0)
         {
             output->deactivate_plugin(grab_interface);
-            return;
+            return false;
         }
 
         repeat.repeat_command = command;
@@ -94,6 +94,8 @@ class wayfire_command : public wf::plugin_interface_t
 
         wf::get_core().connect_signal("pointer_button", &on_button_event);
         wf::get_core().connect_signal("keyboard_key", &on_key_event);
+
+        return true;
     }
 
     std::function<void()> on_repeat_delay_timeout = [=] ()

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -23,11 +23,15 @@ class wayfire_expo : public wf::plugin_interface_t
     activator_callback toggle_cb = [=] (wf_activator_source, uint32_t)
     {
         if (!state.active) {
-            activate();
+            return activate();
         } else {
-            if (!zoom_animation.running() || state.zoom_in)
+            if (!zoom_animation.running() || state.zoom_in) {
                 deactivate();
+                return true;
+            }
         }
+
+        return false;
     };
 
     wf_option action_button;
@@ -123,10 +127,10 @@ class wayfire_expo : public wf::plugin_interface_t
         output->connect_signal("view-disappeared", &view_removed);
     }
 
-    void activate()
+    bool activate()
     {
         if (!output->activate_plugin(grab_interface))
-            return;
+            return false;
 
         grab_interface->grab();
 
@@ -141,6 +145,8 @@ class wayfire_expo : public wf::plugin_interface_t
 
         output->render->set_renderer(renderer);
         output->render->set_redraw_always();
+
+        return true;
     }
 
     void deactivate()

--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -33,7 +33,7 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
         activate_key = section->get_option("activate", "<alt> KEY_TAB");
         init_binding = [=] (uint32_t key)
         {
-            fast_switch();
+            return fast_switch();
         };
 
         output->add_key(activate_key, &init_binding);
@@ -135,20 +135,20 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
         view->damage();
     }
 
-    void fast_switch()
+    bool fast_switch()
     {
         if (active)
-            return;
+            return false;
 
         if (!output->activate_plugin(grab_interface))
-            return;
+            return false;
 
         update_views();
 
         if (views.size() < 1)
         {
             output->deactivate_plugin(grab_interface);
-            return;
+            return false;
         }
 
         current_view_index = 0;
@@ -163,6 +163,8 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
 
         output->connect_signal("view-disappeared", &destroyed);
         output->connect_signal("detach-view", &destroyed);
+
+        return true;
     }
 
     void switch_terminate()

--- a/plugins/single_plugins/fisheye.cpp
+++ b/plugins/single_plugins/fisheye.cpp
@@ -125,6 +125,9 @@ class wayfire_fisheye : public wf::plugin_interface_t
     public:
         void init(wayfire_config *config)
         {
+            grab_interface->name = "fisheye";
+            grab_interface->capabilities = 0;
+
             auto section = config->get_section("fisheye");
             auto toggle_key = section->get_option("toggle", "<super> KEY_F");
             radius = section->get_option("radius", "300");
@@ -139,22 +142,27 @@ class wayfire_fisheye : public wf::plugin_interface_t
             hook_set = active = false;
             toggle_cb = [=] (wf_activator_source, uint32_t)
             {
-                    if (active)
-                    {
-                        active = false;
-                        duration.start(duration.progress(), 0);
-                    } else
-                    {
-                        active = true;
-                        duration.start(duration.progress(), target_zoom);
+                if (!output->can_activate_plugin(grab_interface))
+                    return false;
 
-                        if (!hook_set)
-                        {
-                            hook_set = true;
-                            output->render->add_post(&hook);
-                            output->render->set_redraw_always();
-                        }
+                if (active)
+                {
+                    active = false;
+                    duration.start(duration.progress(), 0);
+                } else
+                {
+                    active = true;
+                    duration.start(duration.progress(), target_zoom);
+
+                    if (!hook_set)
+                    {
+                        hook_set = true;
+                        output->render->add_post(&hook);
+                        output->render->set_redraw_always();
                     }
+                }
+
+                return true;
             };
             output->add_activator(toggle_key, &toggle_cb);
 

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -240,8 +240,11 @@ class wayfire_grid : public wf::plugin_interface_t
 
     activator_callback restore = [=] (wf_activator_source, uint32_t)
     {
+        if (!output->can_activate_plugin(grab_interface))
+            return false;
         auto view = output->get_active_view();
         view->tile_request(0);
+        return true;
     };
     wf_option_callback restore_opt_changed = [=] ()
     {
@@ -276,9 +279,11 @@ class wayfire_grid : public wf::plugin_interface_t
             {
                 auto view = output->get_active_view();
                 if (!view || view->role != wf::VIEW_ROLE_TOPLEVEL)
-                    return;
+                    return false;
 
                 handle_slot(view, i);
+
+                return true;
             };
 
             output->add_activator(keys[i], &bindings[i]);

--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -101,10 +101,18 @@ class wayfire_idle_singleton : public wf::singleton_plugin_t<wayfire_idle>
     {
         singleton_plugin_t::init(config);
 
+        grab_interface->name = "idle";
+        grab_interface->capabilities = 0;
+
         auto binding = config->get_section("idle")
             ->get_option("toggle", "<super> <shift> KEY_I");
         toggle = [=] (wf_activator_source, uint32_t) {
+            if (!output->can_activate_plugin(grab_interface))
+                return false;
+
             get_instance().toggle_idle();
+
+            return true;
         };
 
         output->add_activator(binding, &toggle);

--- a/plugins/single_plugins/invert.cpp
+++ b/plugins/single_plugins/invert.cpp
@@ -61,6 +61,9 @@ class wayfire_invert_screen : public wf::plugin_interface_t
         auto section = config->get_section("invert");
         auto toggle_key = section->get_option("toggle", "<super> KEY_I");
 
+        grab_interface->name = "invert";
+        grab_interface->capabilities = 0;
+
         hook = [=] (const wf_framebuffer_base& source,
             const wf_framebuffer_base& destination) {
             render(source, destination);
@@ -68,6 +71,9 @@ class wayfire_invert_screen : public wf::plugin_interface_t
 
 
         toggle_cb = [=] (wf_activator_source, uint32_t) {
+            if (!output->can_activate_plugin(grab_interface))
+                return false;
+
             if (active)
             {
                 output->render->rem_post(&hook);
@@ -77,6 +83,8 @@ class wayfire_invert_screen : public wf::plugin_interface_t
             }
 
             active = !active;
+
+            return true;
         };
 
         load_program();

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -24,6 +24,9 @@ class wayfire_output_manager : public wf::plugin_interface_t
 
             switch_output = [=] (wf_activator_source, uint32_t)
             {
+                if (!output->activate_plugin(grab_interface))
+                    return false;
+
                 /* when we switch the output, the oswitch keybinding
                  * may be activated for the next output, which we don't want,
                  * so we postpone the switch */
@@ -32,10 +35,15 @@ class wayfire_output_manager : public wf::plugin_interface_t
                 idle_next_output.run_once([=] () {
                     wf::get_core().focus_output(next);
                 });
+
+                return true;
             };
 
             switch_output_with_window = [=] (wf_activator_source, uint32_t)
             {
+                if (!output->can_activate_plugin(grab_interface))
+                    return false;
+
                 auto next =
                     wf::get_core().output_layout->get_next_output(output);
                 auto view = output->get_active_view();
@@ -43,13 +51,15 @@ class wayfire_output_manager : public wf::plugin_interface_t
                 if (!view)
                 {
                     switch_output(ACTIVATOR_SOURCE_KEYBINDING, 0);
-                    return;
+                    return true;
                 }
 
                 wf::get_core().move_view_to_output(view, next);
                 idle_next_output.run_once([=] () {
                     wf::get_core().focus_output(next);
                 });
+
+                return true;
             };
 
             output->add_activator(actkey, &switch_output);

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -47,8 +47,9 @@ class wayfire_resize : public wf::plugin_interface_t
             {
                 is_using_touch = false;
                 was_client_request = false;
-                initiate(view);
+                return initiate(view);
             }
+            return false;
         };
 
         touch_activate_binding = [=] (int32_t sx, int32_t sy)
@@ -58,8 +59,9 @@ class wayfire_resize : public wf::plugin_interface_t
             {
                 is_using_touch = true;
                 was_client_request = false;
-                initiate(view);
+                return initiate(view);
             }
+            return false;
         };
 
         output->add_button(button, &activate_binding);
@@ -177,21 +179,21 @@ class wayfire_resize : public wf::plugin_interface_t
         return edges;
     }
 
-    void initiate(wayfire_view view, uint32_t forced_edges = 0)
+    bool initiate(wayfire_view view, uint32_t forced_edges = 0)
     {
         if (!view || view->role == wf::VIEW_ROLE_SHELL_VIEW || !view->is_mapped())
-            return;
+            return false;
 
         auto current_ws_impl =
             output->workspace->get_workspace_implementation();
         if (!current_ws_impl->view_resizable(view))
-            return;
+            return false;
 
         if (!output->activate_plugin(grab_interface))
-            return;
+            return false;
         if (!grab_interface->grab()) {
             output->deactivate_plugin(grab_interface);
-            return;
+            return false;
         }
 
         grab_start = get_input_coords();
@@ -226,6 +228,8 @@ class wayfire_resize : public wf::plugin_interface_t
 
         start_wobbly(view, anchor_x, anchor_y);
         wf::get_core().set_cursor(wlr_xcursor_get_resize_name((wlr_edges)edges));
+
+        return true;
     }
 
     void input_pressed(uint32_t state)

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -111,8 +111,8 @@ class WayfireSwitcher : public wf::plugin_interface_t
         duration = wf_duration{speed, wf_animation::circle};
         background_dim_duration = wf_duration{speed, wf_animation::circle};
 
-        next_view_binding = [=] (uint32_t) { handle_switch_request(-1); };
-        prev_view_binding = [=] (uint32_t) { handle_switch_request(1); };
+        next_view_binding = [=] (uint32_t) { return handle_switch_request(-1); };
+        prev_view_binding = [=] (uint32_t) { return handle_switch_request(1); };
 
         output->add_key(section->get_option("next_view", "<super> KEY_TAB"),
             &next_view_binding);
@@ -130,10 +130,12 @@ class WayfireSwitcher : public wf::plugin_interface_t
             {
                 /* We set it to -1 to indicate that the user hasn't done anything yet */
                 touch_total_dx = -1;
-                handle_switch_request(0);
+                return handle_switch_request(0);
             } else {
                 handle_done();
             }
+
+            return true;
         };
 
         auto gesture_activator = section->get_option("gesture_toggle", "edge-swipe down 3");
@@ -182,16 +184,16 @@ class WayfireSwitcher : public wf::plugin_interface_t
         }
     }
 
-    void handle_switch_request(int dir)
+    bool handle_switch_request(int dir)
     {
         if (get_workspace_views().empty())
-            return;
+            return false;
 
         /* If we haven't grabbed, then we haven't setup anything */
         if (!output->is_plugin_active(grab_interface->name))
         {
             if (!init_switcher())
-                return;
+                return false;
         }
 
         /* Maybe we're still animating the exit animation from a previous
@@ -210,6 +212,8 @@ class WayfireSwitcher : public wf::plugin_interface_t
         {
             next_view(dir);
         }
+
+        return true;
     }
 
     /* When switcher is done and starts animating towards end */

--- a/plugins/single_plugins/vswitch.cpp
+++ b/plugins/single_plugins/vswitch.cpp
@@ -54,15 +54,15 @@ class vswitch : public wf::plugin_interface_t
         grab_interface->capabilities = wf::CAPABILITY_MANAGE_DESKTOP;
         grab_interface->callbacks.cancel = [=] () {stop_switch();};
 
-        callback_left  = [=] (wf_activator_source, uint32_t) { add_direction(-1,  0); };
-        callback_right = [=] (wf_activator_source, uint32_t) { add_direction( 1,  0); };
-        callback_up    = [=] (wf_activator_source, uint32_t) { add_direction( 0, -1); };
-        callback_down  = [=] (wf_activator_source, uint32_t) { add_direction( 0,  1); };
+        callback_left  = [=] (wf_activator_source, uint32_t) { return add_direction(-1,  0); };
+        callback_right = [=] (wf_activator_source, uint32_t) { return add_direction( 1,  0); };
+        callback_up    = [=] (wf_activator_source, uint32_t) { return add_direction( 0, -1); };
+        callback_down  = [=] (wf_activator_source, uint32_t) { return add_direction( 0,  1); };
 
-        callback_win_left  = [=] (wf_activator_source, uint32_t) { add_direction(-1,  0, get_top_view()); };
-        callback_win_right = [=] (wf_activator_source, uint32_t) { add_direction( 1,  0, get_top_view()); };
-        callback_win_up    = [=] (wf_activator_source, uint32_t) { add_direction( 0, -1, get_top_view()); };
-        callback_win_down  = [=] (wf_activator_source, uint32_t) { add_direction( 0,  1, get_top_view()); };
+        callback_win_left  = [=] (wf_activator_source, uint32_t) { return add_direction(-1,  0, get_top_view()); };
+        callback_win_right = [=] (wf_activator_source, uint32_t) { return add_direction( 1,  0, get_top_view()); };
+        callback_win_up    = [=] (wf_activator_source, uint32_t) { return add_direction( 0, -1, get_top_view()); };
+        callback_win_down  = [=] (wf_activator_source, uint32_t) { return add_direction( 0,  1, get_top_view()); };
 
         auto section   = config->get_section("vswitch");
 
@@ -97,13 +97,13 @@ class vswitch : public wf::plugin_interface_t
         return output->is_plugin_active(grab_interface->name);
     }
 
-    void add_direction(int x, int y, wayfire_view view = nullptr)
+    bool add_direction(int x, int y, wayfire_view view = nullptr)
     {
         if (!x && !y)
-            return;
+            return false;
 
-        if (!is_active())
-            start_switch();
+        if (!is_active() && !start_switch())
+            return false;
 
         if (view && view->role != wf::VIEW_ROLE_TOPLEVEL)
             view = nullptr;
@@ -122,6 +122,8 @@ class vswitch : public wf::plugin_interface_t
         dy = {duration.progress(dy), 1.0 * tvy - cws.y};
 
         duration.start();
+
+        return true;
     }
 
     wf::signal_callback_t on_set_workspace_request = [=] (wf::signal_data_t *data)

--- a/plugins/single_plugins/wrot.cpp
+++ b/plugins/single_plugins/wrot.cpp
@@ -31,13 +31,13 @@ class wf_wrot : public wf::plugin_interface_t
             call = [=] (uint32_t, int x, int y)
             {
                 if (!output->activate_plugin(grab_interface))
-                    return;
+                    return false;
 
                 current_view = wf::get_core().get_cursor_focus_view();
                 if (!current_view || current_view->role != wf::VIEW_ROLE_TOPLEVEL)
                 {
                     output->deactivate_plugin(grab_interface);
-                    return;
+                    return false;
                 }
 
                 output->focus_view(current_view, true);
@@ -45,6 +45,8 @@ class wf_wrot : public wf::plugin_interface_t
 
                 last_x = x;
                 last_y = y;
+
+                return true;
             };
 
             auto button = (*config)["wrot"]->get_option("activate", "<alt> BTN_RIGHT");

--- a/plugins/single_plugins/zoom.cpp
+++ b/plugins/single_plugins/zoom.cpp
@@ -20,14 +20,22 @@ class wayfire_zoom_screen : public wf::plugin_interface_t
     public:
         void init(wayfire_config *config)
         {
+            grab_interface->name = "zoom";
+            grab_interface->capabilities = 0;
+
             hook = [=] (const wf_framebuffer_base& source, const wf_framebuffer_base& dest) {
                 render(source, dest);
             };
 
             axis = [=] (wlr_event_pointer_axis* ev)
             {
-                if (ev->orientation == WLR_AXIS_ORIENTATION_VERTICAL)
-                    update_zoom_target(ev->delta);
+                if (!output->can_activate_plugin(grab_interface))
+                    return false;
+                if (ev->orientation != WLR_AXIS_ORIENTATION_VERTICAL)
+                    return false;
+
+                update_zoom_target(ev->delta);
+                return true;
             };
 
             auto section = config->get_section("zoom");

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -134,24 +134,26 @@ class tile_plugin_t : public wf::plugin_interface_t
     }
 
     template<class Controller>
-    void start_controller(wf_point grab)
+    bool start_controller(wf_point grab)
     {
         /* No action possible in this case */
         if (has_fullscreen_view() || !has_tiled_focus())
-            return;
+            return false;
 
-        if (output->activate_plugin(grab_interface))
+        if (!output->activate_plugin(grab_interface))
+            return false;
+
+        if (grab_interface->grab())
         {
-            if (grab_interface->grab())
-            {
-                auto vp = output->workspace->get_current_workspace();
-                controller = std::make_unique<Controller> (
-                    roots[vp.x][vp.y], get_global_coordinates(grab));
-            } else
-            {
-                output->deactivate_plugin(grab_interface);
-            }
+            auto vp = output->workspace->get_current_workspace();
+            controller = std::make_unique<Controller> (
+                roots[vp.x][vp.y], get_global_coordinates(grab));
+        } else
+        {
+            output->deactivate_plugin(grab_interface);
         }
+
+        return true;
     }
 
     void stop_controller(bool force_stop)
@@ -303,26 +305,30 @@ class tile_plugin_t : public wf::plugin_interface_t
      *
      * @param need_tiled Whether the view needs to be tiled
      */
-    void conditioned_view_execute(bool need_tiled,
+    bool conditioned_view_execute(bool need_tiled,
         std::function<void(wayfire_view)> func)
     {
         auto view = output->get_active_view();
         if (!view)
-            return;
+            return false;
 
         if (need_tiled && !tile::view_node_t::get_node(view))
-            return;
+            return false;
 
         if (output->activate_plugin(grab_interface))
         {
             func(view);
             output->deactivate_plugin(grab_interface);
+
+            return true;
         }
+
+        return false;
     }
 
     key_callback on_toggle_fullscreen = [=] (uint32_t key)
     {
-        conditioned_view_execute(true, [=] (wayfire_view view)
+        return conditioned_view_execute(true, [=] (wayfire_view view)
         {
             stop_controller(true);
             set_view_fullscreen(view, !view->fullscreen);
@@ -331,7 +337,7 @@ class tile_plugin_t : public wf::plugin_interface_t
 
     key_callback on_toggle_tiled_state = [=] (uint32_t key)
     {
-        conditioned_view_execute(false, [=] (wayfire_view view)
+        return conditioned_view_execute(false, [=] (wayfire_view view)
         {
             auto existing_node = tile::view_node_t::get_node(view);
             if (existing_node) {
@@ -343,9 +349,9 @@ class tile_plugin_t : public wf::plugin_interface_t
         });
     };
 
-    void focus_adjacent(tile::split_insertion_t direction)
+    bool focus_adjacent(tile::split_insertion_t direction)
     {
-        conditioned_view_execute(true, [=] (wayfire_view view)
+        return conditioned_view_execute(true, [=] (wayfire_view view)
         {
             auto adjacent = tile::find_first_view_in_direction(
                 tile::view_node_t::get_node(view), direction);
@@ -365,23 +371,25 @@ class tile_plugin_t : public wf::plugin_interface_t
     key_callback on_focus_adjacent = [=] (uint32_t key)
     {
         if (key == key_focus_left->as_cached_key().keyval)
-            focus_adjacent(tile::INSERT_LEFT);
+            return focus_adjacent(tile::INSERT_LEFT);
         if (key == key_focus_right->as_cached_key().keyval)
-            focus_adjacent(tile::INSERT_RIGHT);
+            return focus_adjacent(tile::INSERT_RIGHT);
         if (key == key_focus_above->as_cached_key().keyval)
-            focus_adjacent(tile::INSERT_ABOVE);
+            return focus_adjacent(tile::INSERT_ABOVE);
         if (key == key_focus_below->as_cached_key().keyval)
-            focus_adjacent(tile::INSERT_BELOW);
+            return focus_adjacent(tile::INSERT_BELOW);
+
+        return false;
     };
 
     button_callback on_move_view = [=] (uint32_t button, int32_t x, int32_t y)
     {
-        start_controller<tile::move_view_controller_t> ({x, y});
+        return start_controller<tile::move_view_controller_t> ({x, y});
     };
 
     button_callback on_resize_view = [=] (uint32_t button, int32_t x, int32_t y)
     {
-        start_controller<tile::resize_view_controller_t> ({x, y});
+        return start_controller<tile::resize_view_controller_t> ({x, y});
     };
 
     void load_options(wayfire_config *config)

--- a/src/api/bindings.hpp
+++ b/src/api/bindings.hpp
@@ -9,11 +9,11 @@ extern "C"
 
 struct wf_touch_gesture;
 struct wf_binding; // opaque handle to a binding, can be used to remove it
-using key_callback = std::function<void(uint32_t)>;
-using button_callback = std::function<void(uint32_t, int32_t, int32_t)>; // button, x, y
-using axis_callback = std::function<void(wlr_event_pointer_axis*)>;
-using touch_callback = std::function<void(int32_t, int32_t)>; // x, y
-using gesture_callback = std::function<void(wf_touch_gesture*)>;
+using key_callback = std::function<bool(uint32_t)>;
+using button_callback = std::function<bool(uint32_t, int32_t, int32_t)>; // button, x, y
+using axis_callback = std::function<bool(wlr_event_pointer_axis*)>;
+using touch_callback = std::function<bool(int32_t, int32_t)>; // x, y
+using gesture_callback = std::function<bool(wf_touch_gesture*)>;
 
 enum wf_activator_source
 {
@@ -27,7 +27,7 @@ enum wf_activator_source
  *
  * Special case: modifier bindings. In that case, the source is a keybinding,
  * but the second argument is 0 */
-using activator_callback = std::function<void(wf_activator_source, uint32_t)>;
+using activator_callback = std::function<bool(wf_activator_source, uint32_t)>;
 
 
 #endif /* end of include guard: WF_BINDINGS_HPP */

--- a/src/api/output.hpp
+++ b/src/api/output.hpp
@@ -77,6 +77,15 @@ class output_t : public wf::object_base_t
     wf_pointf get_cursor_position() const;
 
     /**
+     * Checks if a plugin can activate. This may not succeed if a plugin
+     * with the same abilities is already active or if input is inhibited.
+     *
+     * @return true if the plugin is able to be activated, false otherwise.
+     */
+    virtual bool can_activate_plugin(const plugin_grab_interface_uptr& owner,
+        bool ignore_input_inhibit = false) = 0;
+
+    /**
      * Activates a plugin. Note that this may not succeed, if a plugin with the
      * same abilities is already active. However the same plugin might be
      * activated twice.

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -367,7 +367,7 @@ void input_manager::free_output_bindings(wf::output_t *output)
 
 bool input_manager::check_button_bindings(uint32_t button)
 {
-    std::vector<std::function<void()>> callbacks;
+    std::vector<std::function<bool()>> callbacks;
 
     auto oc = wf::get_core().get_active_output()->get_cursor_position();
     auto mod_state = get_modifiers();
@@ -381,7 +381,7 @@ bool input_manager::check_button_bindings(uint32_t button)
              * so force copy the callback into the lambda */
             auto callback = binding->call.button;
             callbacks.push_back([=] () {
-                (*callback) (button, oc.x, oc.y);
+                return (*callback) (button, oc.x, oc.y);
             });
         }
     }
@@ -395,15 +395,16 @@ bool input_manager::check_button_bindings(uint32_t button)
              * so force copy the callback into the lambda */
             auto callback = binding->call.activator;
             callbacks.push_back([=] () {
-                (*callback) (ACTIVATOR_SOURCE_BUTTONBINDING, button);
+                return (*callback) (ACTIVATOR_SOURCE_BUTTONBINDING, button);
             });
         }
     }
 
+    bool binding_handled = false;
     for (auto call : callbacks)
-        call();
+        binding_handled |= call();
 
-    return !callbacks.empty();
+    return !callbacks.empty() && binding_handled;
 }
 
 bool input_manager::check_axis_bindings(wlr_event_pointer_axis *ev)

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -80,7 +80,7 @@ class input_manager
 
         void validate_drag_request(wlr_seat_request_start_drag_event *ev);
         std::chrono::steady_clock::time_point mod_binding_start;
-        std::vector<std::function<void()>> match_keys(uint32_t mods, uint32_t key, uint32_t mod_binding_key = 0);
+        std::vector<std::function<bool()>> match_keys(uint32_t mods, uint32_t key, uint32_t mod_binding_key = 0);
 
         wf::signal_callback_t surface_map_state_changed;
         wf::signal_callback_t output_added;

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -16,10 +16,12 @@ void wayfire_exit::init(wayfire_config*)
         auto output_impl =
             static_cast<wf::output_impl_t*> (wf::get_core().get_active_output());
         if (output_impl->is_inhibited())
-            return;
+            return false;
 
         wf::get_core().emit_signal("shutdown", nullptr);
         wl_display_terminate(wf::get_core().display);
+
+        return true;
     };
 
     output->add_key(new_static_option("<ctrl> <alt> KEY_BACKSPACE"), &key);
@@ -39,11 +41,13 @@ void wayfire_close::init(wayfire_config *config)
     callback = [=] (wf_activator_source, uint32_t)
     {
         if (!output->activate_plugin(grab_interface))
-            return;
+            return false;
 
         output->deactivate_plugin(grab_interface);
         auto view = output->get_active_view();
         if (view && view->role == wf::VIEW_ROLE_TOPLEVEL) view->close();
+
+        return true;
     };
 
     output->add_activator(key, &callback);
@@ -67,11 +71,13 @@ void wayfire_focus::init(wayfire_config *)
 
     on_button = [=] (uint32_t button, int x, int y) {
         this->check_focus_surface(wf::get_core().get_cursor_focus());
+        return true;
     };
     output->add_button(new_static_option("BTN_LEFT"), &on_button);
 
     on_touch = [=] (int x, int y) {
         this->check_focus_surface(wf::get_core().get_touch_focus());
+        return true;
     };
     output->add_touch(new_static_option(""), &on_touch);
 

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -29,6 +29,8 @@ class output_impl_t : public output_t
     /**
      * Implementations of the public APIs
      */
+    bool can_activate_plugin(const plugin_grab_interface_uptr& owner,
+        bool ignore_inhibit) override;
     bool activate_plugin(const plugin_grab_interface_uptr& owner,
         bool ignore_inhibit) override;
     bool deactivate_plugin(const plugin_grab_interface_uptr& owner) override;

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -242,7 +242,7 @@ wayfire_view wf::output_impl_t::get_active_view() const
     return active_view;
 }
 
-bool wf::output_impl_t::activate_plugin(const plugin_grab_interface_uptr& owner,
+bool wf::output_impl_t::can_activate_plugin(const plugin_grab_interface_uptr& owner,
     bool ignore_inhibit)
 {
     if (!owner)
@@ -255,11 +255,7 @@ bool wf::output_impl_t::activate_plugin(const plugin_grab_interface_uptr& owner,
         return false;
 
     if (active_plugins.find(owner.get()) != active_plugins.end())
-    {
-        log_debug("output %s: activate plugin %s again", handle->name, owner->name.c_str());
-        active_plugins.insert(owner.get());
         return true;
-    }
 
     for(auto act_owner : active_plugins)
     {
@@ -269,8 +265,21 @@ bool wf::output_impl_t::activate_plugin(const plugin_grab_interface_uptr& owner,
             return false;
     }
 
+    return true;
+}
+
+bool wf::output_impl_t::activate_plugin(const plugin_grab_interface_uptr& owner,
+    bool ignore_inhibit)
+{
+    if (!can_activate_plugin(owner, ignore_inhibit))
+        return false;
+
+    if (active_plugins.find(owner.get()) != active_plugins.end())
+        log_debug("output %s: activate plugin %s again", handle->name, owner->name.c_str());
+    else
+        log_debug("output %s: activate plugin %s", handle->name, owner->name.c_str());
+
     active_plugins.insert(owner.get());
-    log_debug("output %s: activate plugin %s", handle->name, owner->name.c_str());
     return true;
 }
 


### PR DESCRIPTION
When a client inhibits input, the compositor should send all
events, even those that match a binding.