### PR TITLE
Support libinput acceleration profiles

### DIFF
--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -12,7 +12,9 @@ void wf::pointing_device_t::config_t::load(wayfire_config *config)
 {
     auto section = (*config)["input"];
     mouse_cursor_speed              = section->get_option("mouse_cursor_speed", "0");
+    mouse_accel_profile             = section->get_option("mouse_accel_profile", "default");
     touchpad_cursor_speed           = section->get_option("touchpad_cursor_speed", "0");
+    touchpad_accel_profile          = section->get_option("touchpad_accel_profile", "default");
     touchpad_tap_enabled            = section->get_option("tap_to_click", "1");
     touchpad_click_method           = section->get_option("click_method", "default");
     touchpad_scroll_method          = section->get_option("scroll_method", "default");
@@ -35,6 +37,20 @@ void wf::pointing_device_t::update_options()
     {
         libinput_device_config_accel_set_speed(dev,
             config.touchpad_cursor_speed->as_cached_double());
+
+        if (config.touchpad_accel_profile->as_string() == "default") {
+            libinput_device_config_accel_set_profile(dev,
+                libinput_device_config_accel_get_default_profile(dev));
+        } else if (config.touchpad_accel_profile->as_string() == "none") {
+            libinput_device_config_accel_set_profile(dev,
+                LIBINPUT_CONFIG_ACCEL_PROFILE_NONE);
+        } else if (config.touchpad_accel_profile->as_string() == "adaptive") {
+            libinput_device_config_accel_set_profile(dev,
+                LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE);
+        } else if (config.touchpad_accel_profile->as_string() == "flat") {
+            libinput_device_config_accel_set_profile(dev,
+                LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT);
+        }
 
         libinput_device_config_tap_set_enabled(dev,
             config.touchpad_tap_enabled->as_cached_int() ?
@@ -88,5 +104,19 @@ void wf::pointing_device_t::update_options()
     } else {
         libinput_device_config_accel_set_speed(dev,
             config.mouse_cursor_speed->as_cached_double());
+
+        if (config.mouse_accel_profile->as_string() == "default") {
+            libinput_device_config_accel_set_profile(dev,
+                libinput_device_config_accel_get_default_profile(dev));
+        } else if (config.mouse_accel_profile->as_string() == "none") {
+            libinput_device_config_accel_set_profile(dev,
+                LIBINPUT_CONFIG_ACCEL_PROFILE_NONE);
+        } else if (config.mouse_accel_profile->as_string() == "adaptive") {
+            libinput_device_config_accel_set_profile(dev,
+                LIBINPUT_CONFIG_ACCEL_PROFILE_ADAPTIVE);
+        } else if (config.mouse_accel_profile->as_string() == "flat") {
+            libinput_device_config_accel_set_profile(dev,
+                LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT);
+        }
     }
 }

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -16,8 +16,10 @@ struct pointing_device_t : public wf_input_device_internal
     {
         wf_option mouse_cursor_speed;
         wf_option mouse_scroll_speed;
+        wf_option mouse_accel_profile;
         wf_option touchpad_cursor_speed;
         wf_option touchpad_scroll_speed;
+        wf_option touchpad_accel_profile;
         wf_option touchpad_tap_enabled;
         wf_option touchpad_click_method;
         wf_option touchpad_scroll_method;

--- a/wayfire.ini.default
+++ b/wayfire.ini.default
@@ -57,6 +57,9 @@ touchpad_cursor_speed = 0
 mouse_scroll_speed = 1
 touchpad_scroll_speed = 1
 
+mouse_accel_profile = default    # none | adaptive | flat
+touchpad_accel_profile = default # none | adaptive | flat
+
 natural_scroll = 1
 tap_to_click = 1
 click_method = default  # none | button-areas | clickfinger


### PR DESCRIPTION
This adds support for libinput acceleration profiles (none, flat and adaptive) and sets it to the device default if none is set. This is mostly for an easy way to disable mouse acceleration, it's the same setting that is found in GNOME Tweaks for example.
There is a way to check if a device supports a profile before setting it but it doesn't seem necessary as it just seems to select the default in that case.