### PR TITLE
screensaver: Add ease deformation to cube control

### DIFF
--- a/plugins/cube/cube-control-signal.hpp
+++ b/plugins/cube/cube-control-signal.hpp
@@ -10,8 +10,9 @@
 struct cube_control_signal : public wf::signal_data_t
 {
     double angle; // cube rotation in radians
-    double zoom; // 1.0 means 100%, increase to zoom
-    bool last_frame; // disables cube if true
+    double zoom; // 1.0 means 100%; increase value to zoom
+    double ease; // for cube deformation; range 0.0-1.0
+    bool last_frame; // ends cube animation if true
     bool carried_out; // false if cube is disabled
 };
 

--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -230,11 +230,11 @@ class wayfire_cube : public wf::plugin_interface_t
     wf::signal_callback_t on_cube_control = [=] (wf::signal_data_t *data)
     {
         cube_control_signal *d = dynamic_cast<cube_control_signal*>(data);
-        rotate_and_zoom_cube(d->angle, d->zoom, d->last_frame);
+        rotate_and_zoom_cube(d->angle, d->zoom, d->ease, d->last_frame);
         d->carried_out = true;
     };
 
-    void rotate_and_zoom_cube(double angle, double zoom, bool last_frame)
+    void rotate_and_zoom_cube(double angle, double zoom, double ease, bool last_frame)
     {
         if (last_frame)
         {
@@ -248,11 +248,11 @@ class wayfire_cube : public wf::plugin_interface_t
         float offset_z = identity_z_offset + Z_OFFSET_NEAR;
 
         animation.cube_animation.rotation.set(angle, angle);
+        animation.cube_animation.zoom.set(zoom, zoom);
+        animation.cube_animation.ease_deformation.set(ease, ease);
 
         animation.cube_animation.offset_y.set(0, 0);
         animation.cube_animation.offset_z.set(offset_z, offset_z);
-
-        animation.cube_animation.zoom.set(zoom, zoom);
 
         animation.cube_animation.start();
         update_view_matrix();

--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -30,6 +30,7 @@ class screensaver_animation_t : public duration_t
     using duration_t::duration_t;
     timed_transition_t rot{*this};
     timed_transition_t zoom{*this};
+    timed_transition_t ease{*this};
 };
 
 class wayfire_idle
@@ -160,6 +161,7 @@ class wayfire_idle
         cube_control_signal data;
         data.angle = 0.0;
         data.zoom = ZOOM_BASE;
+        data.ease = 0.0;
         data.last_frame = true;
         for (auto& output : wf::get_core().output_layout->get_outputs())
         {
@@ -205,6 +207,7 @@ class wayfire_idle
 
         data.angle = rotation;
         data.zoom = screensaver_animation.zoom;
+        data.ease = screensaver_animation.ease;
         data.last_frame = false;
 
         for (auto& output : wf::get_core().output_layout->get_outputs())
@@ -236,6 +239,7 @@ class wayfire_idle
         cube_control_signal data;
         data.angle = 0.0;
         data.zoom = ZOOM_BASE;
+        data.ease = 0.0;
         data.last_frame = false;
         bool all_outputs_active = true;
         bool hook_set = false;
@@ -274,6 +278,7 @@ class wayfire_idle
 
         rotation = 0.0;
         screensaver_animation.zoom.set(ZOOM_BASE, cube_max_zoom);
+        screensaver_animation.ease.set(0.0, 1.0);
         screensaver_animation.start();
         last_time = get_current_time();
     }
@@ -298,6 +303,7 @@ class wayfire_idle
         double end = rotation > M_PI ? M_PI * 2 : 0.0;
         screensaver_animation.rot.set(rotation, end);
         screensaver_animation.zoom.restart_with_end(ZOOM_BASE);
+        screensaver_animation.ease.restart_with_end(0.0);
         screensaver_animation.start();
     }
 


### PR DESCRIPTION
This allows a way for the idle plugin to set cube ease value
so deformation is included in the duration. Without this, the
deformation is enabled and disabled without a transition,
which isn't very pretty. This also fixes glitches every second
when the cube is rotating and seconds are enabled in the panel
clock.