### PR TITLE
vswitch: do not create dangling pointer by moving raw_option out of the wrapper

### DIFF
--- a/plugins/single_plugins/vswitch.cpp
+++ b/plugins/single_plugins/vswitch.cpp
@@ -90,7 +90,7 @@ class vswitch : public wf::plugin_interface_t
         output->add_activator(binding_win_down,  &callback_win_down);
 
         animation = vswitch_animation_t{
-            wf::option_wrapper_t<int> {"vswitch/duration"}.raw_option};
+            wf::option_wrapper_t<int> {"vswitch/duration"}};
         output->connect_signal("set-workspace-request", &on_set_workspace_request);
     }
 


### PR DESCRIPTION
`~base_option_wrapper_t()` is supposed to deregister the wrapper's listener from the updated handler list. But if the raw_option is moved out like that, the destructor doesn't do its job and boom we have a dangling pointer. And my gsettings plugin applying the duration tripped that.

IMO the option_wrapper should be safer — the zero-arg constructor should not exist, the destructor should throw if the raw option is zero, the raw option field should not be public…