### PR TITLE
Fix crash on closing wireshark

### DIFF
--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -115,6 +115,9 @@ void wayfire_focus::check_focus_surface(wf::surface_interface_t* focus)
     while (view->parent)
         view = view->parent.get();
 
+    if (!view->is_mapped())    /* check again */
+        return;
+
     view->get_output()->focus_view(view->self(), true);
     set_last_focus(view->self());
 }


### PR DESCRIPTION
Sorry for no crash dump.

1. open gnome-terminal.
2. open wireshark from the terminal.
3. start capture.
4. wait for a packet to be displayed.
5. close by `Ctrl+Q`.
6. click `Stop and Quit without Saving`.
7. click the gnome-terminal window.
8. wayfire crashes.

I fixed this problem.

In `src/core/wm.cpp`:

Here, view is checked whether it is mapped. Otherwise return.
```
    if (!view || !view->is_mapped() || !view->get_keyboard_focus_surface()
        || !output->activate_plugin(grab_interface))
    {
        return;
    }
```

Here, get the root of the view.
```
    /* Raise the base view. Modal views will be raised to the top by
     * wayfire_handle_focus_parent */
    while (view->parent)
        view = view->parent.get();
```

Here, the view is focused.
```
    set_last_focus(view->self());
```

However, root view may not be mapped even if child view is mapped.

Here, in `set_last_focus()`, `last_focus` hold the view.
```
    last_focus = view;
```

`last_focus` is cleared when the view is disappeared, not when it is destroyed.

Totally, if the view is created, the child view gets focused (i.e. `last_focus` becomes the view), and the view is destroyed, then last_focus holds the destroyed view, and may be passed to `send_done()`.

So the view needs check again whether it is mapped.

(I don't know why the child view get focused even if the view is not mapped.
But I confirmed that occurs by inserting `printf()`.)
