### PR TITLE
Respect --prefix when looking for wayfire/defaults.ini

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,7 +48,7 @@ conf_data.set('INSTALL_PREFIX', get_option('prefix'))
 conf_data.set('PLUGIN_PATH', join_paths(get_option('prefix'), get_option('libdir'), 'wayfire'))
 metadata_dir_suffix = 'share/wayfire/metadata'
 conf_data.set('PLUGIN_XML_DIR', join_paths(get_option('prefix'), metadata_dir_suffix))
-conf_data.set('SYSCONFDIR', join_paths('/', get_option('sysconfdir')))
+conf_data.set('SYSCONFDIR', join_paths(get_option('prefix'), get_option('sysconfdir')))
 
 # needed to dlopen() plugins
 # -E is for RTTI/dynamic_cast across plugins


### PR DESCRIPTION
By default on FreeBSD packages are installed under `/usr/local` and configuration is stored under `/usr/local/etc`.
This matches GNU autoconf default where `sysconfdir` under `prefix` by default.
