### PR TITLE
build: Add sysconfdir to generated .pc file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,8 @@ conf_data.set('INSTALL_PREFIX', get_option('prefix'))
 conf_data.set('PLUGIN_PATH', join_paths(get_option('prefix'), get_option('libdir'), 'wayfire'))
 metadata_dir_suffix = 'share/wayfire/metadata'
 conf_data.set('PLUGIN_XML_DIR', join_paths(get_option('prefix'), metadata_dir_suffix))
-conf_data.set('SYSCONFDIR', join_paths(get_option('prefix'), get_option('sysconfdir')))
+sysconfdir = join_paths(get_option('prefix'), get_option('sysconfdir'))
+conf_data.set('SYSCONFDIR', sysconfdir)
 
 # needed to dlopen() plugins
 # -E is for RTTI/dynamic_cast across plugins

--- a/src/meson.build
+++ b/src/meson.build
@@ -89,6 +89,7 @@ pkgconfig.generate(
     name:         meson.project_name(),
     description: 'A Wayland Compositor',
     variables:    ['metadatadir=${prefix}/' + metadata_dir_suffix,
+                   'sysconfdir=' + sysconfdir,
                    'plugindir=${libdir}/wayfire',
                    'icondir=${prefix}/share/wayfire/icons']
     )


### PR DESCRIPTION
This is so programs like wcm can know where wayfire is looking for defaults. The file is $sysconfdir/wayfire/defaults.ini. Settings in this file will override the defaults found in the plugin xml files.