### PR TITLE
Fix crash introduced by transformer optimizations merge

### DIFF
--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -164,8 +164,11 @@ void wf::surface_interface_t::impl::scale_opaque_region(
      * different scales, we just shrink by 1 to compensate for the ceil/floor
      * discrepancy */
     int ceil_factor = 0;
-    if (output->handle->scale != (float)wsurface->current.scale)
+    if ((wsurface && output->handle->scale != (float)wsurface->current.scale) ||
+        (!wsurface && output->handle->scale != std::round(output->handle->scale)))
+    {
         ceil_factor = 1;
+    }
 
     region.expand_edges(-shrink - ceil_factor);
 }


### PR DESCRIPTION
This can be triggered when moving a view to another output
with keycolor enabled or trying to move a compositor view,
such as in magnifier.