### PR TITLE
Set core xwayland_display string

### DIFF
--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -222,8 +222,13 @@ class compositor_core_t : public wf::object_base_t
 
     /** The wayland socket name of Wayfire */
     std::string wayland_display;
-    /** The xwayland display name */
-    std::string xwayland_display;
+
+    /**
+     * Return the xwayland display number.
+     *
+     * This returns -1 if xwayland is not available
+     */
+    virtual int get_xwayland_display() = 0;
 
     /**
      * Execute the given command in a bash shell.

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -75,6 +75,7 @@ class compositor_core_impl_t : public compositor_core_t
     int focus_layer(uint32_t layer, int request) override;
     void unfocus_layer(int request) override;
     uint32_t get_focused_layer() override;
+    int get_xwayland_display() override;
     void run(std::string command) override;
 
   private:

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -499,6 +499,11 @@ void wf::compositor_core_impl_t::run(std::string command)
     }
 }
 
+int wf::compositor_core_impl_t::get_xwayland_display()
+{
+    return xwayland_get_display();
+}
+
 void wf::compositor_core_impl_t::move_view_to_output(wayfire_view v,
     wf::output_t *new_output)
 {


### PR DESCRIPTION
This was previously an unused variable. It allows external
plugins to get the display string, since xwayland_get_display()
is not exported.