### PR TITLE
View fullscreen

### DIFF
--- a/metadata/idle.xml
+++ b/metadata/idle.xml
@@ -15,10 +15,10 @@
 		<_short>DPMS Timeout</_short>
 		<default>-1</default>
 	</option>
-  <option name="disable_dpms_on_fullscreen" type="bool">
-    <_short>Disable DPMS when fullscreen</_short>
-    <default>true</default>
-  </option>
+	<option name="disable_on_fullscreen" type="bool">
+		<_short>Disable when fullscreen</_short>
+		<default>true</default>
+	</option>
 	<option name="cube_zoom_speed" type="int">
 		<_short>Cube Zoom Speed</_short>
 		<default>1000</default>

--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -353,8 +353,7 @@ class wayfire_idle
             LOGE("idle_inhibit_ref < 0: ", idle_inhibit_ref);
         }
 
-        if (idle_inhibit_ref == 0 &&
-            !idle_enabled)
+        if (idle_inhibit_ref == 0 && !idle_enabled)
         {
             toggle_idle();
         }
@@ -369,8 +368,7 @@ class wayfire_idle
             return;
         }
 
-        if (idle_inhibit_ref == 1 &&
-            idle_enabled)
+        if (idle_inhibit_ref == 1 && idle_enabled)
         {
             toggle_idle();
         }

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -67,6 +67,13 @@ struct view_tiled_signal : public _view_signal
     wf::geometry_t desired_size;
 };
 
+/* sent when the view fullscreen state changes.
+ * state is true if the view is fullscreen and false otherwise.
+ * carried_out should be set by the listener if it handles the signal,
+ * by setting the view fullscreen.
+ * desired_size is the intended size for the fullscreen view
+ * but may be undefined (0,0 0x0).
+ */
 struct view_fullscreen_signal : public _view_signal
 {
     bool state;

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -67,7 +67,10 @@ struct view_tiled_signal : public _view_signal
     wf::geometry_t desired_size;
 };
 
-/* sent when the view fullscreen state changes.
+/**
+ * The view-fullscreen-request and view-fullscreen signals are emitted on the view's output when the view's fullscreen state changes.
+ * view-fullscreen-request is emitted when the view needs to be fullscreened, but has not been fullscreened yet.
+ * view-fullscreen is emitted whenever the view's fullscreen state actually changes.
  * state is true if the view is fullscreen and false otherwise.
  * carried_out should be set by the listener if it handles the signal,
  * by setting the view fullscreen.
@@ -180,4 +183,3 @@ namespace wf
 }
 
 #endif
-

--- a/src/output/wayfire-shell.cpp
+++ b/src/output/wayfire-shell.cpp
@@ -189,7 +189,7 @@ class wfs_output : public noncopyable_t
     {
         wf::get_core().output_layout->disconnect_signal("output-removed",
             &on_output_removed);
-        output->disconnect_signal("autohide-panels", &on_autohide_panels);
+        output->disconnect_signal("fullscreen-layer-focused", &on_fullscreen_layer_focused);
         this->output = nullptr;
     }
 
@@ -200,7 +200,7 @@ class wfs_output : public noncopyable_t
             disconnect_from_output();
        };
 
-    wf::signal_callback_t on_autohide_panels = [=] (wf::signal_data_t *data)
+    wf::signal_callback_t on_fullscreen_layer_focused = [=] (wf::signal_data_t *data)
     {
         if (data != nullptr) {
             zwf_output_v2_send_enter_fullscreen(resource);
@@ -218,7 +218,7 @@ class wfs_output : public noncopyable_t
         wl_resource_set_implementation(resource, &zwf_output_impl,
             this, handle_output_destroy);
 
-        output->connect_signal("autohide-panels", &on_autohide_panels);
+        output->connect_signal("fullscreen-layer-focused", &on_fullscreen_layer_focused);
         wf::get_core().output_layout->connect_signal("output-removed",
             &on_output_removed);
     }

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -484,13 +484,13 @@ class workspace_manager::impl
         if (fs_views.size() && !sent_autohide)
         {
             sent_autohide = 1;
-            output->emit_signal("autohide-panels", reinterpret_cast<signal_data_t*> (1));
+            output->emit_signal("fullscreen-layer-focused", reinterpret_cast<signal_data_t*> (1));
             LOGD("autohide panels");
         }
         else if (fs_views.empty() && sent_autohide)
         {
             sent_autohide = 0;
-            output->emit_signal("autohide-panels", reinterpret_cast<signal_data_t*> (0));
+            output->emit_signal("fullscreen-layer-focused", reinterpret_cast<signal_data_t*> (0));
             LOGD("restore panels");
         }
     }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -409,7 +409,7 @@ void wf::view_interface_t::set_fullscreen(bool full)
     data.desired_size = get_output()->get_relative_geometry();
 
     get_output()->emit_signal("view-fullscreen", &data);
-    this->emit_signal("fullscreen", nullptr);
+    this->emit_signal("fullscreen", &data);
     desktop_state_updated();
 }
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -403,6 +403,12 @@ void wf::view_interface_t::set_fullscreen(bool full)
     if (!fullscreen && get_output() && needs_lowering)
         get_output()->workspace->add_view(self(), wf::LAYER_WORKSPACE);
 
+    view_fullscreen_signal data;
+    data.view = self();
+    data.state = full;
+    data.desired_size = get_output()->get_relative_geometry();
+
+    get_output()->emit_signal("view-fullscreen", &data);
     this->emit_signal("fullscreen", nullptr);
     desktop_state_updated();
 }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -406,7 +406,7 @@ void wf::view_interface_t::set_fullscreen(bool full)
     view_fullscreen_signal data;
     data.view = self();
     data.state = full;
-    data.desired_size = get_output()->get_relative_geometry();
+    data.desired_size = {0, 0, 0, 0};
 
     get_output()->emit_signal("view-fullscreen", &data);
     this->emit_signal("fullscreen", &data);


### PR DESCRIPTION
This PR emits a view-fullscreen signal for the output and adds state to the view fullscreen signal. In addition, it renames autohide-panels signal to fullscreen-layer-focused, disable_dpms_on_fullscreen to disable_on_fullscreen and makes idle plugin listen for the fullscreen-layer-focused signal to disable idle completely if disable_on_fullscreen is enabled.