### PR TITLE
Add CI (GitHub Actions)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 
-[*.{build,xml}]
+[*.{build,xml,yaml}]
 indent_size = 2
 
 [metadata/**.xml]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+# "run when at least one file does not match paths-ignore"
+on:
+  push:
+    paths-ignore:
+    - 'metadata/**'
+    - 'proto/**'
+  pull_request:
+    paths-ignore:
+    - 'metadata/**'
+    - 'proto/**'
+
+jobs:
+  test_gnu:
+    name: "Test with GCC/musl/libstdc++/BFD on Alpine Linux"
+    runs-on: ubuntu-latest
+    container: alpine:edge
+    steps:
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev eudev-dev libxml2-dev libexecinfo-dev
+    - uses: actions/checkout@v1
+    - run: git submodule sync --recursive && git submodule update --init --force --recursive
+    - run: meson build
+    - run: ninja -v -Cbuild
+  test_musl_llvm:
+    name: "Test with clang/glibc/libc++/lld on Arch Linux"
+    runs-on: ubuntu-latest
+    container: archlinux:latest
+    steps:
+    - run: pacman-key --recv-key EA50C866329648EE && echo "[andontie-aur]" >> /etc/pacman.conf && echo "Server = https://aur.andontie.net/\$arch" >> /etc/pacman.conf && echo "SigLevel = Never" >> /etc/pacman.conf
+    - run: pacman --noconfirm --noprogressbar -Syyu
+    - run: pacman --noconfirm --noprogressbar -Sy git clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo
+    - uses: actions/checkout@v1
+    - run: git submodule sync --recursive && git submodule update --init --force --recursive
+    - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build
+    - run: ninja -v -Cbuild

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 [Wayfire]: https://wayfire.org
 
-![Version](https://img.shields.io/badge/version-alpha-important)
-[![IRC](https://img.shields.io/badge/irc-%23wayfire-informational)](https://webchat.freenode.net/#wayfire)
+![Version](https://img.shields.io/github/v/release/WayfireWM/wayfire)
+[![IRC: #wayfire on freenode](https://img.shields.io/badge/irc-%23wayfire-informational)](https://webchat.freenode.net/#wayfire)
+[![CI](https://github.com/WayfireWM/wayfire/workflows/CI/badge.svg)](https://github.com/WayfireWM/wayfire/actions)
+[![Packaging status](https://repology.org/badge/tiny-repos/wayfire.svg)](https://repology.org/project/wayfire/versions)
+[![License](https://img.shields.io/github/license/WayfireWM/wayfire)](LICENSE)
 
 ###### [Get started] | [Manual] | [Configuration]
 

--- a/meson.build
+++ b/meson.build
@@ -34,7 +34,7 @@ wfconfig       = dependency('wf-config', version: ['>=0.3', '<0.4'], required: g
 
 use_system_wlroots = not get_option('use_system_wlroots').disabled() and wlroots.found()
 if not use_system_wlroots
-  wlroots = subproject('wlroots').get_variable('wlroots')
+  wlroots = subproject('wlroots', default_options : ['examples=false']).get_variable('wlroots')
 endif
 
 use_system_wfconfig = not get_option('use_system_wfconfig').disabled() and wfconfig.found()


### PR DESCRIPTION
In order to reduce issues between different C/C++ stacks, let's continuously test on a couple different ones. A mostly-GNU-but-musl one and a mostly-LLVM-but-glibc one was the best I could come up with. Here's [an example run](https://github.com/myfreeweb/wayfire/actions/runs/41498661).

- DEPENDS ON https://github.com/WayfireWM/wf-config/pull/21
- would be cool to also run static analysis in CI I guess (but where would it upload the nice HTML results?)
- maybe also test [wf-gsettings](https://github.com/myfreeweb/wf-gsettings) xml conversion :D
- maybe also enforce clang-format (when that happens) in CI (like Mozilla does for Firefox)
- this PR also fix some things found by clang analyzer (not tested running with these yet.. I don't run anything using wayfire-shell anyway..), I should probably split that off