### PR TITLE
Low latency stuff: render delay, presentation time protocol

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -48,5 +48,10 @@
 			<_long>Enables or disables XWayland support, which allows X11 applications to be used.</_long>
 			<default>true</default>
 		</option>
+		<option name="max_render_time" type="int">
+			<_short>Maximum render time</_short>
+			<_long>Sets the compositor render delay in milliseconds, which allows applications to render with low latency.</_long>
+			<default>7</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -35,6 +35,7 @@ extern "C"
     struct wlr_relative_pointer_manager_v1;
     struct wlr_pointer_constraints_v1;
     struct wlr_tablet_manager_v2;
+    struct wlr_presentation;
 
 #include <wayland-server.h>
 }
@@ -100,6 +101,7 @@ class compositor_core_t : public wf::object_base_t
         wlr_relative_pointer_manager_v1 *relative_pointer;
         wlr_pointer_constraints_v1 *pointer_constraints;
         wlr_tablet_manager_v2 *tablet_v2;
+        wlr_presentation *presentation;
     } protocols;
 
     std::string to_string() const { return "wayfire-core"; }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -20,6 +20,7 @@ extern "C"
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_tablet_v2.h>
+#include <wlr/types/wlr_presentation_time.h>
 
 #define static
 #include <wlr/render/wlr_renderer.h>
@@ -250,6 +251,8 @@ void wf::compositor_core_impl_t::init()
     });
     pointer_constraint_added.connect(
         &protocols.pointer_constraints->events.new_constraint);
+
+    protocols.presentation = wlr_presentation_create(display, backend);
 
     wf_shell = wayfire_shell_create(display);
     gtk_shell = wf_gtk_shell_create(display);

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -368,11 +368,19 @@ class wf::render_manager::impl
             if (total <= 0 || max_render_time <= 0 || this->renderer)
                 total = 0;
 
-            output->handle->frame_pending = true;
-            repaint_timer.set_timeout(total, [=] () {
-                output->handle->frame_pending = false;
+            // We cannot really wait less than 1ms, render right away in that case
+            if (total < 1)
+            {
                 paint();
-            });
+            }
+            else
+            {
+                output->handle->frame_pending = true;
+                repaint_timer.set_timeout(total, [=] () {
+                    output->handle->frame_pending = false;
+                    paint();
+                });
+            }
         });
         on_frame.connect(&output_damage->damage_manager->events.frame);
 

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -342,6 +342,7 @@ class wf::render_manager::impl
     std::unique_ptr<postprocessing_manager_t> postprocessing;
 
     wf::option_wrapper_t<wf::color_t> background_color_opt;
+    wf::option_wrapper_t<int> max_render_time_opt;
 
     impl(output_t *o)
         : output(o)
@@ -358,14 +359,14 @@ class wf::render_manager::impl
         });
         on_present.connect(&output->handle->events.present);
 
+        max_render_time_opt.load_option("core/max_render_time");
         on_frame.set_callback([&] (void*) {
             /*
              * Leave a bit of time for clients to render, see
              * https://github.com/swaywm/sway/pull/4588
              */
-            const uint64_t max_render_time = 7;
-            uint64_t total = this->refresh_nsec / 1000000 - max_render_time;
-            if (total <= 0 || max_render_time <= 0 || this->renderer)
+            uint64_t total = this->refresh_nsec / 1000000 - max_render_time_opt;
+            if (total <= 0 || max_render_time_opt <= 0 || this->renderer)
                 total = 0;
 
             // We cannot really wait less than 1ms, render right away in that case

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -538,7 +538,9 @@ class wf::render_manager::impl
     {
         /* Part 1: frame setup: query damage, etc. */
         timespec repaint_started;
-        clock_gettime(CLOCK_MONOTONIC, &repaint_started);
+        clockid_t presentation_clock =
+            wlr_backend_get_presentation_clock(wf::get_core_impl().backend);
+        clock_gettime(presentation_clock, &repaint_started);
 
         effects->run_effects(OUTPUT_EFFECT_PRE);
 
@@ -630,7 +632,9 @@ class wf::render_manager::impl
         }
 
         timespec repaint_ended;
-        clock_gettime(CLOCK_MONOTONIC, &repaint_ended);
+        clockid_t presentation_clock =
+            wlr_backend_get_presentation_clock(wf::get_core_impl().backend);
+        clock_gettime(presentation_clock, &repaint_ended);
         for (auto& v : visible_views)
         {
             for (auto& view : v->enumerate_views())

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -333,7 +333,7 @@ class wf::render_manager::impl
     wf::wl_listener_wrapper on_frame;
     wf::wl_listener_wrapper on_present;
     wf::wl_timer repaint_timer;
-    uint64_t refresh_nsec;
+    int64_t refresh_nsec;
 
     output_t *output;
     wf::region_t swap_damage;
@@ -365,7 +365,7 @@ class wf::render_manager::impl
              * Leave a bit of time for clients to render, see
              * https://github.com/swaywm/sway/pull/4588
              */
-            uint64_t total = this->refresh_nsec / 1000000 - max_render_time_opt;
+            int64_t total = this->refresh_nsec / 1000000 - max_render_time_opt;
             if (total <= 0 || max_render_time_opt <= 0 || this->renderer)
                 total = 0;
 


### PR DESCRIPTION
[presentation-time](https://github.com/wayland-project/wayland-protocols/blob/master/stable/presentation-time/presentation-time.xml) can be used by e.g. `weston-presentation-shm` from Weston, which is suggested for [testing wlroots adaptive sync support](https://github.com/swaywm/sway/pull/5063) among other things.

I think `render_views` is the right (and only) place for this? Sway has another call in an optimized fullscreen scanout path, but we don't have that yet, right?

(Seems like we don't have a [repaint delay](https://ppaalanen.blogspot.com/2015/02/weston-repaint-scheduling.html) yet btw.. I'll look into that)