### PR TITLE
Send workspace with stream pre and post signals

### DIFF
--- a/src/api/wayfire/workspace-stream.hpp
+++ b/src/api/wayfire/workspace-stream.hpp
@@ -31,10 +31,11 @@ struct workspace_stream_t
 /** Emitted whenever a workspace stream is being started or stopped */
 struct stream_signal_t : public wf::signal_data_t
 {
-    stream_signal_t(wf::region_t& damage, const wf::framebuffer_t& _fb)
-        : raw_damage(damage), fb(_fb) { }
+    stream_signal_t(wf::point_t _ws, wf::region_t& damage, const wf::framebuffer_t& _fb)
+        : ws(_ws), raw_damage(damage), fb(_fb) { }
 
     /* Raw damage, can be adjusted by the signal handlers. */
+    wf::point_t ws;
     wf::region_t& raw_damage;
     const wf::framebuffer_t& fb;
 };

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -874,7 +874,7 @@ class wf::render_manager::impl
             return;
 
         {
-            stream_signal_t data(repaint.ws_damage, repaint.fb);
+            stream_signal_t data(stream.ws, repaint.ws_damage, repaint.fb);
             output->render->emit_signal("workspace-stream-pre", &data);
         }
 
@@ -891,7 +891,7 @@ class wf::render_manager::impl
 
         unschedule_drag_icon();
         {
-            stream_signal_t data(repaint.ws_damage, repaint.fb);
+            stream_signal_t data(stream.ws, repaint.ws_damage, repaint.fb);
             output->render->emit_signal("workspace-stream-post", &data);
         }
     }


### PR DESCRIPTION
This allows plugins to know for which workspace the signal was called.
Plugins can use this to associate objects with workspaces.