### PR TITLE
view: fix wlr_surface usage due to upstream change

### DIFF
--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -322,7 +322,7 @@ void wf::wlr_surface_base_t::unmap()
 wlr_buffer* wf::wlr_surface_base_t::get_buffer()
 {
     if (surface && wlr_surface_has_buffer(surface))
-        return surface->buffer;
+        return &surface->buffer->base;
 
     return nullptr;
 }


### PR DESCRIPTION
The wlroots changed the organization of the wlr_surface struct, which
led to breakage in the surface.cpp code. This commit fixes the
issue in wlr_surface_base_t::get_buffer(), which was the only place
affected (at least in regards to compile-time errors).

Fixes issue #432 

I have tested it on my machine, and wf-background and wf-panel both launched and worked perfectly.

EDIT: btw, this fix is only necessary in wlroots git, for now. I'd guess wlroots will make it necessary either in some 0.10.x revision or the 0.11.0 version. I don't know how that influences what you merge to master. And the CI builds seem to have failed because their version of wlroots isn't as recent.