### PR TITLE
CI: fix the names used for the CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
     - 'proto/**'
 
 jobs:
-  test_gnu:
+  test_musl_gcc:
     name: "Test with GCC/musl/libstdc++/BFD on Alpine Linux"
     runs-on: ubuntu-latest
     container: alpine:edge
@@ -22,7 +22,7 @@ jobs:
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
     - run: meson build
     - run: ninja -v -Cbuild
-  test_musl_llvm:
+  test_glibc_llvm:
     name: "Test with clang/glibc/libc++/lld on Arch Linux"
     runs-on: ubuntu-latest
     container: archlinux:latest


### PR DESCRIPTION
The previous naming scheme didn't accurately describe the jobs being run.

Would this impact any of the CI currently running in the project? It's just that the naming scheme bothered me. If you don't think it's necessary to fix, no problem, I can close the PR.