### PR TITLE
render-manager: Add get_swap_damage function

### DIFF
--- a/src/api/wayfire/render-manager.hpp
+++ b/src/api/wayfire/render-manager.hpp
@@ -123,6 +123,14 @@ class render_manager : public wf::signal_provider_t
 
     /**
      * @return The damaged region on the current output for the current
+     * frame that is used when swapping buffers. This function should
+     * only be called from overlay or postprocessing effect callbacks.
+     * Otherwise it will return an empty region.
+     */
+    wf::region_t get_swap_damage();
+
+    /**
+     * @return The damaged region on the current output for the current
      * frame. Note that a larger region might actually be repainted due to
      * double buffering
      */


### PR DESCRIPTION
There are at least two damage regions for a frame. We have client damage
which is the region of all surface damage for the output and the swap
damage which is the region passed to swap buffers. Typically we are
only interested in client damage but for purposes of plugins like
showrepaint, we need the swap damage to have a comprehensive view of
all damage happening on the output.