### PR TITLE
output-layout: Don't emit configuration changed signal when shutting down

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1085,7 +1085,8 @@ namespace wf
                 }
             }
 
-            get_core().output_layout->emit_signal("configuration-changed", nullptr);
+            if (!shutdown_received)
+                get_core().output_layout->emit_signal("configuration-changed", nullptr);
 
             if (count_enabled > 0)
             {


### PR DESCRIPTION
Doing so leads to a crash when using ctrl+alt+bkspc.

This is the backtrace:

II 20-03-20 00:43:25.763 - [src/main.cpp:312] running at server wayland-0
II 20-03-20 00:43:27.349 - [src/core/output-layout.cpp:928] remove output: HDMI-A-1
EE 20-03-20 00:43:27.349 - [src/core/output-layout.cpp:476] disable output: HDMI-A-1
II 20-03-20 00:43:27.349 - [src/core/output-layout.cpp:153] transfer views from HDMI-A-1 -> null
EE 20-03-20 00:43:27.349 - [src/output/render-manager.cpp:400] constant_redraw_counter got below 0!
EE 20-03-20 00:43:27.350 - [src/main.cpp:204] Fatal error: Segmentation fault
EE 20-03-20 00:43:27.402 - #1  signal_handler(int) ../src/main.cpp:206
EE 20-03-20 00:43:27.551 - #2  killpg ??:?
EE 20-03-20 00:43:27.595 - #3  std::__uniq_ptr_impl<wf::workspace_manager::impl, std::default_delete<wf::workspace_manager::impl> >::_M_ptr() const /usr/include/c++/7/bits/unique_ptr.h:147
EE 20-03-20 00:43:27.641 - #4  std::unique_ptr<wf::workspace_manager::impl, std::default_delete<wf::workspace_manager::impl> >::get() const /usr/include/c++/7/bits/unique_ptr.h:332
EE 20-03-20 00:43:27.689 - #5  std::unique_ptr<wf::workspace_manager::impl, std::default_delete<wf::workspace_manager::impl> >::operator->() const /usr/include/c++/7/bits/unique_ptr.h:327
EE 20-03-20 00:43:27.733 - #6  wf::workspace_manager::get_current_workspace() ../src/output/workspace-impl.cpp:673
EE 20-03-20 00:43:27.779 - #7  wf::output_t::refocus(nonstd::observer_ptr<wf::view_interface_t>) ../src/output/output.cpp:72 (discriminator 4)
EE 20-03-20 00:43:27.822 - #8  wf::compositor_core_impl_t::focus_layer(unsigned int, int) ../src/core/core.cpp:425 (discriminator 8)
EE 20-03-20 00:43:27.874 - #9  wf_layer_shell_manager::arrange_layers(wf::output_t*) ../src/view/layer-shell.cpp:285 (discriminator 1)
EE 20-03-20 00:43:27.920 - #10 wf_layer_shell_manager::on_output_layout_changed::{lambda(wf::signal_data_t*)#1}::operator()(wf::signal_data_t) const ../src/view/layer-shell.cpp:73 (discriminator 3)
EE 20-03-20 00:43:27.969 - #11 std::_Function_handler<void (wf::signal_data_t*), wf_layer_shell_manager::on_output_layout_changed::{lambda(wf::signal_data_t*)#1}>::_M_invoke(std::_Any_data const&, wf::signal_data_t*&&) /usr/include/c++/7/bits/std_function.h:318
EE 20-03-20 00:43:28.005 - #12 std::function<void (wf::signal_data_t*)>::operator()(wf::signal_data_t*) const /usr/include/c++/7/bits/std_function.h:706
EE 20-03-20 00:43:28.049 - #13 auto wf::signal_provider_t::emit_signal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, wf::signal_data_t*)::{lambda(auto:1)#2}::operator()<std::function<void (wf::signal_data_t*)>*>(std::function<void (wf::signal_data_t*)>*) const ../src/core/object.cpp:133
EE 20-03-20 00:43:28.089 - #14 std::_Function_handler<void (std::function<void (wf::signal_data_t*)>*&), wf::signal_provider_t::emit_signal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, wf::signal_data_t*)::{lambda(auto:1)#2}>::_M_invoke(std::_Any_data const&, std::function<void (wf::signal_data_t*)>*&) /usr/include/c++/7/bits/std_function.h:318
EE 20-03-20 00:43:28.128 - #15 std::function<void (std::function<void (wf::signal_data_t*)>*&)>::operator()(std::function<void (wf::signal_data_t*)>*&) const /usr/include/c++/7/bits/std_function.h:706
EE 20-03-20 00:43:28.171 - #16 wf::safe_list_t<std::function<void (wf::signal_data_t*)>*>::for_each(std::function<void (std::function<void (wf::signal_data_t*)>*&)>) const ../src/api/wayfire/nonstd/safe-list.hpp:177 (discriminator 2)
EE 20-03-20 00:43:28.214 - #17 wf::signal_provider_t::emit_signal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, wf::signal_data_t*) ../src/core/object.cpp:131 (discriminator 2)
EE 20-03-20 00:43:28.260 - #18 wf::output_layout_t::impl::apply_configuration(std::map<wlr_output*, wf::output_state_t, std::less<wlr_output*>, std::allocator<std::pair<wlr_output* const, wf::output_state_t> > > const&) ../src/core/output-layout.cpp:1089 (discriminator 5)
EE 20-03-20 00:43:28.306 - #19 wf::output_layout_t::impl::remove_output(wlr_output*) ../src/core/output-layout.cpp:935
EE 20-03-20 00:43:28.356 - #20 wf::output_layout_t::impl::add_output(wlr_output*)::{lambda(void*)#1}::operator()(void*) const ../src/core/output-layout.cpp:920
EE 20-03-20 00:43:28.397 - #21 std::_Function_handler<void (void*), wf::output_layout_t::impl::add_output(wlr_output*)::{lambda(void*)#1}>::_M_invoke(std::_Any_data const&, void*&&) /usr/include/c++/7/bits/std_function.h:318
EE 20-03-20 00:43:28.433 - #22 std::function<void (void*)>::operator()(void*) const /usr/include/c++/7/bits/std_function.h:706
EE 20-03-20 00:43:28.468 - #23 wf::wl_listener_wrapper::emit(void*) ../src/util.cpp:458
EE 20-03-20 00:43:28.501 - #24 handle_wrapped_listener(wl_listener*, void*) ../src/util.cpp:400
EE 20-03-20 00:43:28.522 - #25 wlr_signal_emit_safe ../util/signal.c:22
EE 20-03-20 00:43:28.544 - #26 wlr_output_destroy ../types/wlr_output.c:370
EE 20-03-20 00:43:28.561 - #27 backend_destroy ../backend/drm/backend.c:40 (discriminator 3)
EE 20-03-20 00:43:28.577 - #28 wlr_backend_destroy ../backend/backend.c:47
EE 20-03-20 00:43:28.594 - #29 multi_backend_destroy ../backend/multi/backend.c:53 (discriminator 3)
EE 20-03-20 00:43:28.611 - #30 handle_display_destroy ../backend/multi/backend.c:108
EE 20-03-20 00:43:28.626 - #31 wl_priv_signal_final_emit ../src/wayland-server.c:2150
EE 20-03-20 00:43:28.642 - #32 wl_display_destroy ../src/wayland-server.c:1136
EE 20-03-20 00:43:28.676 - #33 main ../src/main.cpp:321
EE 20-03-20 00:43:28.783 - #34 __libc_start_main ../csu/libc-start.c:344
EE 20-03-20 00:43:28.821 - #35 _start ??:?
