### PR TITLE
Enable screensaver

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -7,7 +7,7 @@
 		<option name="plugins" type="string">
 			<_short>Plugins</_short>
 			<_long>Loads the specified plugins, space-separated list.</_long>
-			<default>alpha animate autostart command decoration expo fast-switcher fisheye grid idle invert move oswitch place resize switcher vswitch window-rules wobbly wrot zoom</default>
+			<default>alpha animate autostart command cube decoration expo fast-switcher fisheye grid idle invert move oswitch place resize switcher vswitch window-rules wobbly wrot zoom</default>
 		</option>
 		<option name="close_top_view" type="activator">
 			<_short>Close view</_short>

--- a/metadata/idle.xml
+++ b/metadata/idle.xml
@@ -14,7 +14,7 @@
 		<option name="screensaver_timeout" type="int">
 			<_short>Screensaver timeout</_short>
 			<_long>Displays the screensaver after the specified seconds of inactivity.  Setting the value to **-1** disables the screensaver.</_long>
-			<default>-1</default>
+			<default>3600</default>
 		</option>
 		<!-- DPMS -->
 		<option name="dpms_timeout" type="int">

--- a/wayfire.ini
+++ b/wayfire.ini
@@ -49,6 +49,7 @@ plugins = \
   animate \
   autostart \
   command \
+  cube \
   decoration \
   expo \
   fast-switcher \


### PR DESCRIPTION
This enables cube plugin by default and sets idle screensaver timeout.