### PR TITLE
Added install instructions for gentoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ dnf install wayfire
 pkg install wayfire
 ```
 
+###### Gentoo
+Available from either of the two overlays [Guru](https://wiki.gentoo.org/wiki/Project:GURU) or [wayfire-desktop](https://github.com/epsilon-0/wayfire-desktop).  
+Look at [wayfire-desktop](https://github.com/epsilon-0/wayfire-desktop) to get full list of options and available wayfire packages.  
+
 ###### NixOS
 
 See [nixpkgs-wayland].


### PR DESCRIPTION
Currently wayfire is in the unofficial overlays but a request has been made to add it to the official tree.

Until it is accepted, I've added the two unofficial lists, wayfire-desktop (my personal managed overlay) and Guru (community managed overlay similar to AUR, but more reviewed, where wayfire is managed by me, and is kept up to date with my personal overlay, though with a bit of lag).

Thanks a lot for the amazing software :)