### PR TITLE
blur: Implement some optimizations

### DIFF
--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -13,12 +13,14 @@ class wf_blur_transformer : public wf::view_transformer_t
 {
     blur_algorithm_provider provider;
     wf::output_t *output;
+    wayfire_view view;
   public:
     wf_blur_transformer(blur_algorithm_provider blur_algorithm_provider,
-        wf::output_t *output)
+        wf::output_t *output, wayfire_view view)
     {
         provider = blur_algorithm_provider;
         this->output = output;
+        this->view = view;
     }
 
     wf::pointf_t transform_point(wf::geometry_t view,
@@ -45,11 +47,43 @@ class wf_blur_transformer : public wf::view_transformer_t
     }
 
     uint32_t get_z_order() override { return wf::TRANSFORMER_BLUR; }
+
     void render_with_damage(wf::texture_t src_tex, wlr_box src_box,
         const wf::region_t& damage, const wf::framebuffer_t& target_fb) override
     {
         wf::region_t clip_damage = damage & src_box;
-        provider()->pre_render(src_tex, src_box, clip_damage, target_fb);
+
+        /* We want to check if the opaque region completely occludes
+         * the bounding box. If this is the case, we can skip blurring
+         * altogether and just render the surface. First we disable
+         * shrinking and get the opaque region without padding */
+        wf::surface_interface_t::set_opaque_shrink_constraint("blur", 0);
+        wf::region_t full_opaque = view->get_transformed_opaque_region();
+
+        /* Shrink the opaque region by the padding amount since the render
+         * chain expects this, as we have applied padding to damage in
+         * frame_pre_paint for this frame already */
+        int padding = std::ceil(provider()->calculate_blur_radius() /
+            output->render->get_target_framebuffer().scale);
+        wf::surface_interface_t::set_opaque_shrink_constraint("blur", padding);
+
+        wf::region_t bbox_region{src_box};
+        if ((bbox_region ^ full_opaque).empty())
+        {
+            /* In case the whole surface is opaque, we can simply skip blurring */
+            OpenGL::render_begin(target_fb);
+            for (auto& rect : damage)
+            {
+                target_fb.logic_scissor(wlr_box_from_pixman_box(rect));
+                OpenGL::render_texture(src_tex, target_fb, src_box);
+            }
+
+            OpenGL::render_end();
+            return;
+        }
+
+        wf::region_t opaque_region = view->get_transformed_opaque_region();
+        provider()->pre_render(src_tex, src_box, clip_damage ^ opaque_region, target_fb);
         wf::view_transformer_t::render_with_damage(src_tex, src_box, clip_damage, target_fb);
     }
 
@@ -89,7 +123,7 @@ class wayfire_blur : public wf::plugin_interface_t
 
         view->add_transformer(std::make_unique<wf_blur_transformer> (
                 [=] () {return nonstd::make_observer(blur_algorithm.get()); },
-                output),
+                output, view),
             transformer_name);
     }
 

--- a/plugins/blur/blur.hpp
+++ b/plugins/blur/blur.hpp
@@ -114,7 +114,8 @@ class wf_blur_base
 
     /* renders the in texture to the out framebuffer.
      * assumes a properly bound and initialized GL program */
-    void render_iteration(wf::framebuffer_base_t& in, wf::framebuffer_base_t& out,
+    void render_iteration(wf::region_t blur_region,
+        wf::framebuffer_base_t& in, wf::framebuffer_base_t& out,
         int width, int height);
 
     /* copy the source pixels from region, storing into result
@@ -125,7 +126,7 @@ class wf_blur_base
     /* blur fb[0]
      * width and height are the scaled dimensions of the buffer
      * returns the index of the fb where the result is stored (0 or 1) */
-    virtual int blur_fb0(int width, int height) = 0;
+    virtual int blur_fb0(const wf::region_t& blur_region, int width, int height) = 0;
 
     public:
     wf_blur_base(wf::output_t *output,

--- a/plugins/blur/bokeh.cpp
+++ b/plugins/blur/bokeh.cpp
@@ -73,7 +73,7 @@ class wf_bokeh_blur : public wf_blur_base
         OpenGL::render_end();
     }
 
-    int blur_fb0(int width, int height) override
+    int blur_fb0(const wf::region_t& blur_region, int width, int height) override
     {
         int iterations = iterations_opt;
         float offset = offset_opt;
@@ -94,7 +94,7 @@ class wf_bokeh_blur : public wf_blur_base
 
         program[0].attrib_pointer("position", 2, 0, vertexData);
         GL_CALL(glDisable(GL_BLEND));
-        render_iteration(fb[0], fb[1], width, height);
+        render_iteration(blur_region, fb[0], fb[1], width, height);
 
         /* Reset gl state */
         GL_CALL(glEnable(GL_BLEND));

--- a/plugins/blur/box.cpp
+++ b/plugins/blur/box.cpp
@@ -112,13 +112,13 @@ class wf_box_blur : public wf_blur_base
         program[i].attrib_pointer("position", 2, 0, vertexData);
     }
 
-    void blur(int i, int width, int height)
+    void blur(const wf::region_t& blur_region, int i, int width, int height)
     {
         program[i].use(wf::TEXTURE_TYPE_RGBA);
-        render_iteration(fb[i], fb[!i], width, height);
+        render_iteration(blur_region, fb[i], fb[!i], width, height);
     }
 
-    int blur_fb0(int width, int height) override
+    int blur_fb0(const wf::region_t& blur_region, int width, int height) override
     {
         int i, iterations = iterations_opt;
 
@@ -132,10 +132,10 @@ class wf_box_blur : public wf_blur_base
 
         for (i = 0; i < iterations; i++) {
             /* Blur horizontally */
-            blur(0, width, height);
+            blur(blur_region, 0, width, height);
 
             /* Blur vertically */
-            blur(1, width, height);
+            blur(blur_region, 1, width, height);
         }
 
         /* Reset gl state */

--- a/plugins/blur/gaussian.cpp
+++ b/plugins/blur/gaussian.cpp
@@ -115,13 +115,13 @@ class wf_gaussian_blur : public wf_blur_base
         program[i].attrib_pointer("position", 2, 0, vertexData);
     }
 
-    void blur(int i, int width, int height)
+    void blur(const wf::region_t& blur_region, int i, int width, int height)
     {
         program[i].use(wf::TEXTURE_TYPE_RGBA);
-        render_iteration(fb[i], fb[!i], width, height);
+        render_iteration(blur_region, fb[i], fb[!i], width, height);
     }
 
-    int blur_fb0(int width, int height) override
+    int blur_fb0(const wf::region_t& blur_region, int width, int height) override
     {
         int i, iterations = iterations_opt;
 
@@ -135,10 +135,10 @@ class wf_gaussian_blur : public wf_blur_base
 
         for (i = 0; i < iterations; i++) {
             /* Blur horizontally */
-            blur(0, width, height);
+            blur(blur_region, 0, width, height);
 
             /* Blur vertically */
-            blur(1, width, height);
+            blur(blur_region, 1, width, height);
         }
 
         /* Reset gl state */

--- a/plugins/blur/kawase.cpp
+++ b/plugins/blur/kawase.cpp
@@ -75,7 +75,7 @@ class wf_kawase_blur : public wf_blur_base
         OpenGL::render_end();
     }
 
-    int blur_fb0(int width, int height) override
+    int blur_fb0(const wf::region_t& blur_region, int width, int height) override
     {
         int iterations = iterations_opt;
         float offset = offset_opt;
@@ -104,9 +104,11 @@ class wf_kawase_blur : public wf_blur_base
             sampleWidth = width / (1 << i);
             sampleHeight = height / (1 << i);
 
+            auto region = blur_region * (1.0 / (1 << i));
+
             program[0].uniform2f("halfpixel",
                 0.5f / sampleWidth, 0.5f / sampleHeight);
-            render_iteration(fb[i % 2], fb[1 - i % 2], sampleWidth, sampleHeight);
+            render_iteration(region, fb[i % 2], fb[1 - i % 2], sampleWidth, sampleHeight);
         }
 
         program[0].deactivate();
@@ -120,9 +122,11 @@ class wf_kawase_blur : public wf_blur_base
             sampleWidth = width / (1 << i);
             sampleHeight = height / (1 << i);
 
+            auto region = blur_region * (1.0 / (1 << i));
+
             program[1].uniform2f("halfpixel",
                 0.5f / sampleWidth, 0.5f / sampleHeight);
-            render_iteration(fb[1 - i % 2], fb[i % 2], sampleWidth, sampleHeight);
+            render_iteration(region, fb[1 - i % 2], fb[i % 2], sampleWidth, sampleHeight);
         }
 
         /* Reset gl state */


### PR DESCRIPTION
- Don't blur if opaque region occludes the bounding box of the view
- Scissor out the opaque region when we are blurring
- Use damage region for scissor to avoid unneeded blurring