### PR TITLE
view: add always-on-top state

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -14,6 +14,11 @@
 			<_long>Closes the currently focused window with the specified key.</_long>
 			<default>&lt;super&gt; KEY_Q | &lt;alt&gt; KEY_F4</default>
 		</option>
+		<option name="toggle_always_on_top" type="activator">
+			<_short>Toggle always-on-top</_short>
+			<_long>Toggles the always-on-top state of the currently focused window with the specified key.</_long>
+			<default>&lt;super&gt; &lt;shift&gt; KEY_F</default>
+		</option>
 		<!-- Horizontal/Vertical workspaces -->
 		<option name="vwidth" type="int">
 			<_short>Horizontal virtual size</_short>

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -218,14 +218,19 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
      * set_activated() or focus_request() */
     bool activated = false;
     /** Whether the view is in minimized state, usually you want to use either
-     * set_minizied() or minimize_request() */
+     * set_minimized() or minimize_request() */
     bool minimized = false;
+    /** Whether the view is in always-on-top state, usually you want to use either
+     * set_on_top() or on_top_request() */
+    bool on_top = false;
     /** The tiled edges of the view, usually you want to use set_tiled().
      * If the view is tiled to all edges, it is considered maximized. */
     uint32_t tiled_edges = 0;
 
     /** Set the minimized state of the view. */
     virtual void set_minimized(bool minimized);
+    /** Set the always-on-top state of the view. */
+    virtual void set_on_top(bool on_top);
     /** Set the tiled edges of the view */
     virtual void set_tiled(uint32_t edges);
     /** Set the fullscreen state of the view */
@@ -429,7 +434,7 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
     virtual void destruct() override;
 
     /**
-     * Called whenever the minimized, tiled, fullscreened
+     * Called whenever the minimized, tiled, fullscreened, always-on-topped
      * or activated state changes */
     virtual void desktop_state_updated();
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -618,7 +618,8 @@ void wf::compositor_core_impl_t::move_view_to_output(wayfire_view v,
     assert(new_output);
     v->set_output(new_output);
     new_output->workspace->add_view(v,
-        v->minimized ? wf::LAYER_MINIMIZED : wf::LAYER_WORKSPACE);
+        v->minimized ? wf::LAYER_MINIMIZED : (
+            v->on_top ? wf::LAYER_TOP : wf::LAYER_WORKSPACE));
     new_output->focus_view(v);
 }
 

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -56,6 +56,31 @@ void wayfire_close::fini()
     output->rem_binding(&callback);
 }
 
+void wayfire_on_top::init()
+{
+    grab_interface->capabilities = wf::CAPABILITY_GRAB_INPUT;
+    wf::option_wrapper_t<wf::activatorbinding_t> key("core/toggle_always_on_top");
+    callback = [=] (wf::activator_source_t, uint32_t)
+    {
+        if (!output->activate_plugin(grab_interface))
+            return false;
+
+        output->deactivate_plugin(grab_interface);
+        auto view = output->get_active_view();
+        if (view && view->role == wf::VIEW_ROLE_TOPLEVEL)
+            view->set_on_top(!view->on_top);
+
+        return true;
+    };
+
+    output->add_activator(key, &callback);
+}
+
+void wayfire_on_top::fini()
+{
+    output->rem_binding(&callback);
+}
+
 void wayfire_focus::init()
 {
     grab_interface->name = "_wf_focus";

--- a/src/core/wm.hpp
+++ b/src/core/wm.hpp
@@ -17,6 +17,13 @@ class wayfire_close : public wf::plugin_interface_t {
         void fini() override;
 };
 
+class wayfire_on_top : public wf::plugin_interface_t {
+    wf::activator_callback callback;
+    public:
+        void init() override;
+        void fini() override;
+};
+
 class wayfire_focus : public wf::plugin_interface_t {
     wf::button_callback on_button;
     wf::touch_callback on_touch;

--- a/src/output/plugin-loader.cpp
+++ b/src/output/plugin-loader.cpp
@@ -210,8 +210,10 @@ void plugin_manager::load_static_plugins()
     loaded_plugins["_exit"]         = create_plugin<wayfire_exit>();
     loaded_plugins["_focus"]        = create_plugin<wayfire_focus>();
     loaded_plugins["_close"]        = create_plugin<wayfire_close>();
+    loaded_plugins["_on_top"]       = create_plugin<wayfire_on_top>();
 
     init_plugin(loaded_plugins["_exit"]);
     init_plugin(loaded_plugins["_focus"]);
     init_plugin(loaded_plugins["_close"]);
+    init_plugin(loaded_plugins["_on_top"]);
 }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -356,6 +356,20 @@ void wf::view_interface_t::set_minimized(bool minim)
     desktop_state_updated();
 }
 
+void wf::view_interface_t::set_on_top(bool top)
+{
+    on_top = top;
+    if (on_top)
+    {
+        get_output()->workspace->add_view(self(), wf::LAYER_TOP);
+    } else
+    {
+        get_output()->workspace->add_view(self(), wf::LAYER_WORKSPACE);
+    }
+
+    desktop_state_updated();
+}
+
 void wf::view_interface_t::set_tiled(uint32_t edges)
 {
     // store last unmaximized geometry for restoring


### PR DESCRIPTION
This adds a state that keeps the view on `LAYER_TOP` and a hotkey to toggle that.

Eventually this is also going to be used for a protocol that would allow apps to control this (e.g. Firefox picture-in-picture).. fun fact, gtk-shell seems to actually have a request for this, but no one wants to use gtk-shell.

Not tested:
- [ ] multiple outputs
- [ ] interaction with minimize (???)
- [ ] interaction with fullscreen