### PR TITLE
Add input-method/text-input support

### DIFF
--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -34,6 +34,8 @@ extern "C"
     struct wlr_relative_pointer_manager_v1;
     struct wlr_pointer_constraints_v1;
     struct wlr_tablet_manager_v2;
+    struct wlr_input_method_manager_v2;
+    struct wlr_text_input_manager_v3;
     struct wlr_presentation;
     struct wlr_gtk_primary_selection_device_manager;
     struct wlr_primary_selection_v1_device_manager;
@@ -102,6 +104,8 @@ class compositor_core_t : public wf::object_base_t
         wlr_relative_pointer_manager_v1 *relative_pointer;
         wlr_pointer_constraints_v1 *pointer_constraints;
         wlr_tablet_manager_v2 *tablet_v2;
+        wlr_input_method_manager_v2 *input_method;
+        wlr_text_input_manager_v3 *text_input;
         wlr_presentation *presentation;
         wlr_gtk_primary_selection_device_manager *gtk_primary_selection;
         wlr_primary_selection_v1_device_manager *primary_selection_v1;

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -112,6 +112,17 @@ struct surface_map_state_changed_signal : public wf::signal_data_t
  * argument: unused
  */
 
+/**
+ * name: keyboard-focus-changed
+ * on: core
+ * when: Keyboard focus is changed (may change to nullptr).
+ */
+struct keyboard_focus_changed_signal : public wf::signal_data_t
+{
+    wayfire_view view;
+    wlr_surface *surface;
+};
+
 /* ----------------------------------------------------------------------------/
  * Output signals
  * -------------------------------------------------------------------------- */

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -15,6 +15,7 @@ extern "C"
 }
 
 class input_manager;
+class input_method_relay;
 struct wayfire_shell;
 struct wf_gtk_shell;
 
@@ -34,6 +35,7 @@ class compositor_core_impl_t : public compositor_core_t
     wlr_compositor *compositor;
 
     std::unique_ptr<input_manager> input;
+    std::unique_ptr<input_method_relay> im_relay;
 
     /**
      * Initialize the compositor core. Called only by main()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -19,9 +19,14 @@ extern "C"
 #include <wlr/types/wlr_relative_pointer_v1.h>
 #include <wlr/types/wlr_pointer_constraints_v1.h>
 #include <wlr/types/wlr_tablet_v2.h>
+#include <wlr/types/wlr_text_input_v3.h>
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/types/wlr_gtk_primary_selection.h>
 #include <wlr/types/wlr_primary_selection_v1.h>
+
+#define delete delete_
+#include <wlr/types/wlr_input_method_v2.h>
+#undef delete
 
 #define static
 #include <wlr/render/wlr_renderer.h>
@@ -47,6 +52,7 @@ extern "C"
 
 #include "opengl-priv.hpp"
 #include "seat/input-manager.hpp"
+#include "seat/input-method-relay.hpp"
 #include "seat/touch.hpp"
 #include "../view/view-impl.hpp"
 #include "../output/wayfire-shell.hpp"
@@ -289,6 +295,10 @@ void wf::compositor_core_impl_t::init()
     });
     pointer_constraint_added.connect(
         &protocols.pointer_constraints->events.new_constraint);
+
+    protocols.input_method = wlr_input_method_manager_v2_create(display);
+    protocols.text_input   = wlr_text_input_manager_v3_create(display);
+    im_relay = std::make_unique<input_method_relay>();
 
     protocols.presentation = wlr_presentation_create(display, backend);
 

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -180,6 +180,7 @@ input_manager::input_manager()
     input_device_created.connect(&wf::get_core().backend->events.new_input);
 
     create_seat();
+
     surface_map_state_changed = [=] (wf::signal_data_t *data)
     {
         auto ev = static_cast<wf::surface_map_state_changed_signal*>(data);

--- a/src/core/seat/input-method-relay.cpp
+++ b/src/core/seat/input-method-relay.cpp
@@ -1,0 +1,309 @@
+#include <wayfire/util/log.hpp>
+#include "input-method-relay.hpp"
+#include "../core-impl.hpp"
+#include "../../output/output-impl.hpp"
+
+#include <algorithm>
+
+wf::input_method_relay::input_method_relay()
+{
+    on_text_input_new.set_callback([&] (void *data)
+    {
+        auto wlr_text_input = static_cast<wlr_text_input_v3*>(data);
+        text_inputs.push_back(std::make_unique<wf::text_input>(this,
+            wlr_text_input));
+    });
+
+    on_input_method_new.set_callback([&] (void *data)
+    {
+        auto new_input_method = static_cast<wlr_input_method_v2*>(data);
+
+        if (input_method != nullptr)
+        {
+            LOGI("Attempted to connect second input method");
+            wlr_input_method_v2_send_unavailable(new_input_method);
+
+            return;
+        }
+
+        input_method = new_input_method;
+        on_input_method_commit.connect(&input_method->events.commit);
+        on_input_method_destroy.connect(&input_method->events.destroy);
+
+        auto *text_input = find_focusable_text_input();
+        if (text_input)
+        {
+            wlr_text_input_v3_send_enter(
+                text_input->input,
+                text_input->pending_focused_surface);
+            text_input->set_pending_focused_surface(nullptr);
+        }
+    });
+
+    on_input_method_commit.set_callback([&] (void *data)
+    {
+        auto evt_input_method = static_cast<wlr_input_method_v2*>(data);
+        assert(evt_input_method == input_method);
+
+        auto *text_input = find_focused_text_input();
+        if (text_input == nullptr)
+        {
+            return;
+        }
+
+        if (input_method->current.preedit.text)
+        {
+            wlr_text_input_v3_send_preedit_string(text_input->input,
+                input_method->current.preedit.text,
+                input_method->current.preedit.cursor_begin,
+                input_method->current.preedit.cursor_end);
+        }
+
+        if (input_method->current.commit_text)
+        {
+            wlr_text_input_v3_send_commit_string(text_input->input,
+                input_method->current.commit_text);
+        }
+
+        if (input_method->current.delete_.before_length ||
+            input_method->current.delete_.after_length)
+        {
+            wlr_text_input_v3_send_delete_surrounding_text(text_input->input,
+                input_method->current.delete_.before_length,
+                input_method->current.delete_.after_length);
+        }
+
+        wlr_text_input_v3_send_done(text_input->input);
+    });
+
+    on_input_method_destroy.set_callback([&] (void *data)
+    {
+        auto evt_input_method = static_cast<wlr_input_method_v2*>(data);
+        assert(evt_input_method == input_method);
+
+        on_input_method_commit.disconnect();
+        on_input_method_destroy.disconnect();
+        input_method = nullptr;
+
+        auto *text_input = find_focused_text_input();
+        if (text_input != nullptr)
+        {
+            /* keyboard focus is still there, keep the surface at hand in case the IM
+             * returns */
+            text_input->set_pending_focused_surface(text_input->input->
+                focused_surface);
+            wlr_text_input_v3_send_leave(text_input->input);
+        }
+    });
+
+    on_text_input_new.connect(&wf::get_core().protocols.text_input->events.text_input);
+    on_input_method_new.connect(
+        &wf::get_core().protocols.input_method->events.input_method);
+
+    wf::get_core().connect_signal("keyboard-focus-changed", &keyboard_focus_changed);
+}
+
+void wf::input_method_relay::send_im_state(wlr_text_input_v3 *input)
+{
+    wlr_input_method_v2_send_surrounding_text(
+        input_method,
+        input->current.surrounding.text,
+        input->current.surrounding.cursor,
+        input->current.surrounding.anchor);
+    wlr_input_method_v2_send_text_change_cause(
+        input_method,
+        input->current.text_change_cause);
+    wlr_input_method_v2_send_content_type(input_method,
+        input->current.content_type.hint,
+        input->current.content_type.purpose);
+    wlr_input_method_v2_send_done(input_method);
+}
+
+void wf::input_method_relay::disable_text_input(wlr_text_input_v3 *input)
+{
+    if (input_method == nullptr)
+    {
+        LOGI("Disabling text input, but input method is gone");
+
+        return;
+    }
+
+    wlr_input_method_v2_send_deactivate(input_method);
+    send_im_state(input);
+}
+
+wf::text_input*wf::input_method_relay::find_focusable_text_input()
+{
+    auto it = std::find_if(text_inputs.begin(), text_inputs.end(),
+        [&] (const auto & text_input)
+    {
+        return text_input->pending_focused_surface != nullptr;
+    });
+    if (it != text_inputs.end())
+    {
+        return it->get();
+    }
+
+    return nullptr;
+}
+
+wf::text_input*wf::input_method_relay::find_focused_text_input()
+{
+    auto it = std::find_if(text_inputs.begin(), text_inputs.end(),
+        [&] (const auto & text_input)
+    {
+        return text_input->input->focused_surface != nullptr;
+    });
+    if (it != text_inputs.end())
+    {
+        return it->get();
+    }
+
+    return nullptr;
+}
+
+void wf::input_method_relay::set_focus(wlr_surface *surface)
+{
+    for (auto & text_input : text_inputs)
+    {
+        if (text_input->pending_focused_surface != nullptr)
+        {
+            assert(text_input->input->focused_surface == nullptr);
+            if (surface != text_input->pending_focused_surface)
+            {
+                text_input->set_pending_focused_surface(nullptr);
+            }
+        } else if (text_input->input->focused_surface != nullptr)
+        {
+            assert(text_input->pending_focused_surface == nullptr);
+            if (surface != text_input->input->focused_surface)
+            {
+                disable_text_input(text_input->input);
+                wlr_text_input_v3_send_leave(text_input->input);
+            } else
+            {
+                LOGD("set_focus an already focused surface");
+                continue;
+            }
+        }
+
+        if (surface && (wl_resource_get_client(text_input->input->resource) ==
+                        wl_resource_get_client(surface->resource)))
+        {
+            if (input_method)
+            {
+                wlr_text_input_v3_send_enter(text_input->input, surface);
+            } else
+            {
+                text_input->set_pending_focused_surface(surface);
+            }
+        }
+    }
+}
+
+wf::input_method_relay::~input_method_relay()
+{}
+
+wf::text_input::text_input(wf::input_method_relay *rel, wlr_text_input_v3 *in) :
+    relay(rel), input(in), pending_focused_surface(nullptr)
+{
+    on_text_input_enable.set_callback([&] (void *data)
+    {
+        auto wlr_text_input = static_cast<wlr_text_input_v3*>(data);
+        assert(input == wlr_text_input);
+
+        if (relay->input_method == nullptr)
+        {
+            LOGI("Enabling text input, but input method is gone");
+
+            return;
+        }
+
+        wlr_input_method_v2_send_activate(relay->input_method);
+        relay->send_im_state(input);
+    });
+
+    on_text_input_commit.set_callback([&] (void *data)
+    {
+        auto wlr_text_input = static_cast<wlr_text_input_v3*>(data);
+        assert(input == wlr_text_input);
+
+        if (!input->current_enabled)
+        {
+            LOGI("Inactive text input tried to commit");
+
+            return;
+        }
+
+        if (relay->input_method == nullptr)
+        {
+            LOGI("Committing text input, but input method is gone");
+
+            return;
+        }
+
+        relay->send_im_state(input);
+    });
+
+    on_text_input_disable.set_callback([&] (void *data)
+    {
+        auto wlr_text_input = static_cast<wlr_text_input_v3*>(data);
+        assert(input == wlr_text_input);
+
+        relay->disable_text_input(input);
+    });
+
+    on_text_input_destroy.set_callback([&] (void *data)
+    {
+        auto wlr_text_input = static_cast<wlr_text_input_v3*>(data);
+        assert(input == wlr_text_input);
+
+        if (input->current_enabled)
+        {
+            relay->disable_text_input(input);
+        }
+
+        set_pending_focused_surface(nullptr);
+        on_text_input_enable.disconnect();
+        on_text_input_commit.disconnect();
+        on_text_input_disable.disconnect();
+        on_text_input_destroy.disconnect();
+
+        auto it = std::remove_if(relay->text_inputs.begin(),
+            relay->text_inputs.end(),
+            [&] (const auto & inp)
+        {
+            return inp->input == input;
+        });
+        relay->text_inputs.erase(it, relay->text_inputs.end());
+    });
+
+    on_pending_focused_surface_destroy.set_callback([&] (void *data)
+    {
+        auto surface = static_cast<wlr_surface*>(data);
+        assert(pending_focused_surface == surface);
+        pending_focused_surface = nullptr;
+        on_pending_focused_surface_destroy.disconnect();
+    });
+
+    on_text_input_enable.connect(&input->events.enable);
+    on_text_input_commit.connect(&input->events.commit);
+    on_text_input_disable.connect(&input->events.disable);
+    on_text_input_destroy.connect(&input->events.destroy);
+}
+
+void wf::text_input::set_pending_focused_surface(wlr_surface *surface)
+{
+    pending_focused_surface = surface;
+
+    if (surface == nullptr)
+    {
+        on_pending_focused_surface_destroy.disconnect();
+    } else
+    {
+        on_pending_focused_surface_destroy.connect(&surface->events.destroy);
+    }
+}
+
+wf::text_input::~text_input()
+{}

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -1,0 +1,65 @@
+#pragma once
+#include "seat.hpp"
+#include "wayfire/util.hpp"
+#include "wayfire/signal-definitions.hpp"
+
+extern "C" {
+#include <wlr/types/wlr_text_input_v3.h>
+#include <wlr/types/wlr_surface.h>
+
+#define delete delete_
+#include <wlr/types/wlr_input_method_v2.h>
+#undef delete
+}
+
+#include <vector>
+#include <memory>
+
+namespace wf
+{
+struct text_input;
+
+class input_method_relay
+{
+  private:
+
+    wf::wl_listener_wrapper on_text_input_new,
+        on_input_method_new, on_input_method_commit, on_input_method_destroy;
+    text_input *find_focusable_text_input();
+    text_input *find_focused_text_input();
+    void set_focus(wlr_surface*);
+
+    wf::signal_connection_t keyboard_focus_changed{[this] (wf::signal_data_t *data)
+        {
+            auto ev = static_cast<wf::keyboard_focus_changed_signal*>(data);
+            set_focus(ev->surface);
+        }
+    };
+
+  public:
+
+    wlr_input_method_v2 *input_method = nullptr;
+    std::vector<std::unique_ptr<text_input>> text_inputs;
+
+    input_method_relay();
+    void send_im_state(wlr_text_input_v3*);
+    void disable_text_input(wlr_text_input_v3*);
+    ~input_method_relay();
+};
+
+struct text_input
+{
+    input_method_relay *relay = nullptr;
+    wlr_text_input_v3 *input  = nullptr;
+    /* A place to keep the focused surface when no input method exists
+     * (when the IM returns, it would get that surface instantly) */
+    wlr_surface *pending_focused_surface = nullptr;
+    wf::wl_listener_wrapper on_pending_focused_surface_destroy,
+        on_text_input_enable, on_text_input_commit,
+        on_text_input_disable, on_text_input_destroy;
+
+    text_input(input_method_relay*, wlr_text_input_v3*);
+    void set_pending_focused_surface(wlr_surface*);
+    ~text_input();
+};
+}

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -147,6 +147,11 @@ void input_manager::set_keyboard_focus(wayfire_view view, wlr_seat *seat)
         wlr_seat_keyboard_notify_clear_focus(seat);
         keyboard_focus = nullptr;
     }
+
+    wf::keyboard_focus_changed_signal data;
+    data.view    = view;
+    data.surface = surface;
+    wf::get_core().emit_signal("keyboard-focus-changed", &data);
 }
 
 static bool check_vt_switch(wlr_session *session, uint32_t key, uint32_t mods)

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,7 @@ wayfire_sources = ['main.cpp',
 
                    'core/seat/pointing-device.cpp',
                    'core/seat/input-manager.cpp',
+                   'core/seat/input-method-relay.cpp',
                    'core/seat/keyboard.cpp',
                    'core/seat/pointer.cpp',
                    'core/seat/cursor.cpp',


### PR DESCRIPTION
This is a port of https://github.com/swaywm/sway/pull/4740

- seems to work the same as sway with squeekboard and the wlroots input-method example
- looks like no crashes anymore after I added all the `disconnect`s on listeners..
- [ ] cleanup blank constructors
- style: `input->im_relay->setup_listeners()` called after the protocols are added is meh..
- too many `std::unique_ptr`?