### PR TITLE
plugin-loader: Call fini before ungrabbing

### DIFF
--- a/src/output/plugin-loader.cpp
+++ b/src/output/plugin-loader.cpp
@@ -69,10 +69,10 @@ void plugin_manager::init_plugin(wayfire_plugin& p)
 
 void plugin_manager::destroy_plugin(wayfire_plugin& p)
 {
+    p->fini();
+
     p->grab_interface->ungrab();
     output->deactivate_plugin(p->grab_interface);
-
-    p->fini();
 
     auto handle = p->handle;
     p.reset();


### PR DESCRIPTION
Plugins might depend on the grabbed state to clean up, so call fini
before ungrabbing.