### PR TITLE
Erase views immediately

### DIFF
--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -33,7 +33,6 @@ struct view_transform_block_t : public noncopyable_t
 class view_interface_t::view_priv_impl
 {
   public:
-    wf::wl_idle_call idle_destruct;
     /**
      * A view is alive as long as it is possible for it to become mapped in the
      * future. For wlr views, this means that their role object hasn't been

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1061,6 +1061,5 @@ void wf::view_damage_raw(wayfire_view view, const wlr_box& box)
 void wf::view_interface_t::destruct()
 {
     view_impl->is_alive = false;
-    view_impl->idle_destruct.run_once(
-        [&] () {wf::get_core_impl().erase_view(self());});
+    wf::get_core_impl().erase_view(self());
 }


### PR DESCRIPTION
We no longer need to wait for idle to erase views from the list.
This fixes a crash when a plugin with a color_rect_view_t is unloaded
when calling close() in fini().