### PR TITLE
meson.build: drop GLES3/gl32.h check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
 	'cpp',
 	version: '0.4.0',
 	license: 'MIT',
-	meson_version: '>=0.47.0',
+	meson_version: '>=0.50.0',
 	default_options: [
 		'cpp_std=c++17',
 		'c_std=c11',
@@ -66,8 +66,8 @@ conf_data.set('SYSCONFDIR', sysconfdir)
 add_project_arguments(['-DWLR_USE_UNSTABLE'], language: ['cpp', 'c'])
 add_project_link_arguments(['-rdynamic', '-Wl,-E'], language: 'cpp')
 
-if get_option('enable_gles32') and meson.get_compiler('cpp').has_header(
-    'GLES3/gl32.h', args: '-I' + glesv2.get_pkgconfig_variable('includedir'))
+if get_option('enable_gles32')
+  meson.get_compiler('cpp').check_header('GLES3/gl32.h', dependencies: glesv2, required: true)
   conf_data.set('USE_GLES32', true)
 else
   conf_data.set('USE_GLES32', false)


### PR DESCRIPTION
My glesv2.pc looks like this:

    Name: glesv2
    Description: GLESv2 library
    Version: 20.0.2
    Libs: -L/nix/store/cx6mp08wgy516yp5078i30ydj4g9hmah-libglvnd-1.2.0/lib -lGLESv2
    Cflags: -I/nix/store/h1fhjwi5m2q09xi42f4rnaldm4q916xi-mesa-20.0.2-dev/include -I/nix/store/nvyl0ml7i69vqywdlmhjkdslc2l1yydh-libglvnd-1.2.0-dev/include

There's no includedir variable, so the header check always fails.

It would be possible to fix the check as follows:

    meson.get_compiler('cpp')
      .has_header('GLES3/gl32.h', dependencies: glesv2)

But I don't think it should actually be checked in this conditional at
all.  Having the header check means that even if I am building with
-Denable_gles32=true, Wayfire might decide to build with gles32
disabled.  It would be much better to error if enable_gles32 is true,
but the appropriate headers cannot be found.

So in addition to fixing gles32 with a pkg-config file with no
includedir variable, this patch makes glesv2 and GLES3/gl32.h required
dependencies if enable_gles32 is set to true.

An alternative, if it would be better for gles32 support to
automatically be disabled if the library and header are not present,
would be to change enable_gles32 to a feature, and have the 'auto'
behaviour do this.