### PR TITLE
Support plugin installation outside of Wayfire’s prefix

### DIFF
--- a/plugins/single_plugins/autostart.cpp
+++ b/plugins/single_plugins/autostart.cpp
@@ -29,9 +29,9 @@ class wayfire_autostart
         }
 
         if (autostart_wf_shell && !panel_manually_started)
-            wf::get_core().run(INSTALL_PREFIX "/bin/wf-panel");
+            wf::get_core().run("wf-panel");
         if (autostart_wf_shell && !background_manually_started)
-            wf::get_core().run(INSTALL_PREFIX "/bin/wf-background");
+            wf::get_core().run("wf-background");
     }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -309,9 +309,19 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
+    std::vector<std::string> xmldirs;
+    if (char *plugin_xml_path = getenv("WAYFIRE_PLUGIN_XML_PATH"))
+    {
+        std::stringstream ss (plugin_xml_path);
+        std::string entry;
+        while (std::getline(ss, entry, ':'))
+            xmldirs.push_back(entry);
+    }
+    xmldirs.push_back(PLUGIN_XML_DIR);
+
     LOGI("using config file: ", config_file.c_str());
     core.config = wf::config::build_configuration(
-        PLUGIN_XML_DIR, SYSCONFDIR "/wayfire/defaults.ini", config_file);
+        xmldirs, SYSCONFDIR "/wayfire/defaults.ini", config_file);
 
     int inotify_fd = inotify_init1(IN_CLOEXEC);
     reload_config(inotify_fd);


### PR DESCRIPTION
Part 2 of #493. Implemented as proposed there. Also changes autostart to start wf-panel and wf-background from PATH rather than Wayfire’s prefix.