### PR TITLE
Use transformed geometry when computing visibility if view is transformed

### DIFF
--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -60,7 +60,7 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
     {
         current_view_index = 0;
         views = output->workspace->get_views_on_workspace(
-            output->workspace->get_current_workspace(), wf::WM_LAYERS, true);
+            output->workspace->get_current_workspace(), wf::WM_LAYERS);
     }
 
     void view_chosen(int i, bool reorder_only)

--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -210,6 +210,7 @@ class wayfire_idle_singleton : public wf::singleton_plugin_t<wayfire_idle>
 
         auto fs_views = output->workspace->get_promoted_views(
             output->workspace->get_current_workspace());
+
         if (fs_views.size())
         {
             get_instance().idle_inhibit();

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -588,11 +588,6 @@ class WayfireSwitcher : public wf::plugin_interface_t
         transform->color[3] = sv.attribs.alpha;
         sv.view->render_transformed(output->render->get_target_framebuffer(),
             output->render->get_target_framebuffer().geometry);
-
-        transform->translation = glm::mat4();
-        transform->scaling = glm::mat4();
-        transform->rotation = glm::mat4();
-        transform->color[3] = 1.0;
     }
 
     wf::render_hook_t switcher_renderer = [=] (const wf::framebuffer_t& fb)

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -421,7 +421,7 @@ class WayfireSwitcher : public wf::plugin_interface_t
     {
         auto all_views = output->workspace->get_views_on_workspace(
             output->workspace->get_current_workspace(),
-            wf::WM_LAYERS | wf::LAYER_MINIMIZED, true);
+            wf::WM_LAYERS | wf::LAYER_MINIMIZED);
 
         decltype(all_views) mapped_views;
         for (auto view : all_views)
@@ -519,13 +519,13 @@ class WayfireSwitcher : public wf::plugin_interface_t
     std::vector<wayfire_view> get_background_views() const
     {
         return output->workspace->get_views_on_workspace(
-            output->workspace->get_current_workspace(), wf::BELOW_LAYERS, false);
+            output->workspace->get_current_workspace(), wf::BELOW_LAYERS);
     }
 
     std::vector<wayfire_view> get_overlay_views() const
     {
         return output->workspace->get_views_on_workspace(
-            output->workspace->get_current_workspace(), wf::ABOVE_LAYERS, false);
+            output->workspace->get_current_workspace(), wf::ABOVE_LAYERS);
     }
 
     void dim_background(float dim)

--- a/plugins/single_plugins/vswitch.cpp
+++ b/plugins/single_plugins/vswitch.cpp
@@ -40,8 +40,7 @@ class vswitch : public wf::plugin_interface_t
     wayfire_view get_top_view()
     {
         auto ws = output->workspace->get_current_workspace();
-        auto views = output->workspace->get_views_on_workspace(ws,
-            wf::LAYER_WORKSPACE, true);
+        auto views = output->workspace->get_views_on_workspace(ws, wf::LAYER_WORKSPACE);
 
         return views.empty() ? nullptr : views[0];
     }

--- a/src/api/wayfire/workspace-manager.hpp
+++ b/src/api/wayfire/workspace-manager.hpp
@@ -131,22 +131,18 @@ class workspace_manager
      * order. The stacking order is the same as in get_views_in_layer().
      *
      * @param layer_mask - The layers whose views should be included
-     * @param wm_only - If set to true, then only the view's wm geometry
-     *        will be taken into account when computing visibility.
      */
     std::vector<wayfire_view> get_views_on_workspace(wf::point_t ws,
-        uint32_t layer_mask, bool wm_only);
+        uint32_t layer_mask);
 
     /**
      * Get a list of all views visible on the given workspace and in the given
      * sublayer.
      *
      * @param sublayer - The sublayer whose views are queried.
-     * @param wm_only - If set to true, then only the view's wm geometry
-     *        will be taken into account when computing visibility.
      */
     std::vector<wayfire_view> get_views_on_workspace_sublayer(wf::point_t ws,
-        nonstd::observer_ptr<sublayer_t> sublayer, bool wm_only);
+        nonstd::observer_ptr<sublayer_t> sublayer);
 
     /**
      * Ensure that the view's wm_geometry is visible on the workspace ws. This

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -50,7 +50,7 @@ std::string wf::output_t::to_string() const
 void wf::output_impl_t::refocus(wayfire_view skip_view, uint32_t layers)
 {
     wayfire_view next_focus = nullptr;
-    auto views = workspace->get_views_on_workspace(workspace->get_current_workspace(), layers, true);
+    auto views = workspace->get_views_on_workspace(workspace->get_current_workspace(), layers);
 
     for (auto v : views)
     {
@@ -71,7 +71,7 @@ void wf::output_t::refocus(wayfire_view skip_view)
     uint32_t layers = focused_layer <= LAYER_WORKSPACE ?  WM_LAYERS : focused_layer;
 
     auto views = workspace->get_views_on_workspace(
-        workspace->get_current_workspace(), layers, true);
+        workspace->get_current_workspace(), layers);
 
     if (views.empty())
     {
@@ -277,7 +277,7 @@ void wf::output_impl_t::focus_view(wayfire_view v, bool raise)
 wayfire_view wf::output_t::get_top_view() const
 {
     auto views = workspace->get_views_on_workspace(workspace->get_current_workspace(),
-        LAYER_WORKSPACE, false);
+        LAYER_WORKSPACE);
 
     return views.empty() ? nullptr : views[0];
 }

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -630,7 +630,7 @@ class wf::render_manager::impl
         {
             visible_views = output->workspace->get_views_on_workspace(
                 output->workspace->get_current_workspace(),
-                wf::MIDDLE_LAYERS, false);
+                wf::MIDDLE_LAYERS);
 
             // send to all panels/backgrounds/etc
             auto additional_views = output->workspace->get_views_in_layer(
@@ -795,7 +795,7 @@ class wf::render_manager::impl
         workspace_stream_t& stream)
     {
         auto views = output->workspace->get_views_on_workspace(stream.ws,
-            wf::VISIBLE_LAYERS, false);
+            wf::VISIBLE_LAYERS);
 
         schedule_drag_icon(repaint);
         for (auto& v : views)

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -441,7 +441,7 @@ class output_viewport_manager_t
      *
      * @return true if the view is visible on the workspace vp
      */
-    bool view_visible_on(wayfire_view view, wf::point_t vp, bool use_bbox)
+    bool view_visible_on(wayfire_view view, wf::point_t vp)
     {
         auto g = output->get_relative_geometry();
         if (view->role != VIEW_ROLE_DESKTOP_ENVIRONMENT)
@@ -450,7 +450,7 @@ class output_viewport_manager_t
             g.y += (vp.y - current_vy) * g.height;
         }
 
-        if (view->has_transformer() && use_bbox) {
+        if (view->has_transformer()) {
             return view->intersects_region(g);
         } else {
             return g & view->get_wm_geometry();
@@ -493,7 +493,7 @@ class output_viewport_manager_t
     }
 
     std::vector<wayfire_view> get_views_on_workspace(wf::point_t vp,
-        uint32_t layers_mask, bool wm_only)
+        uint32_t layers_mask)
     {
         /* get all views in the given layers */
         std::vector<wayfire_view> views =
@@ -501,7 +501,7 @@ class output_viewport_manager_t
 
         /* remove those which aren't visible on the workspace */
         auto it = std::remove_if(views.begin(), views.end(), [&] (wayfire_view view) {
-            return !view_visible_on(view, vp, !wm_only);
+            return !view_visible_on(view, vp);
         });
 
         views.erase(it, views.end());
@@ -515,7 +515,7 @@ class output_viewport_manager_t
 
         /* remove those which aren't visible on the workspace */
         auto it = std::remove_if(views.begin(), views.end(), [&] (wayfire_view view) {
-            return !view_visible_on(view, workspace, true);
+            return !view_visible_on(view, workspace);
         });
 
         views.erase(it, views.end());
@@ -523,13 +523,13 @@ class output_viewport_manager_t
     }
 
     std::vector<wayfire_view> get_views_on_workspace_sublayer(wf::point_t vp,
-        nonstd::observer_ptr<sublayer_t> sublayer, bool wm_only)
+        nonstd::observer_ptr<sublayer_t> sublayer)
     {
         std::vector<wayfire_view> views =
             output->workspace->get_views_in_sublayer(sublayer);
 
         auto it = std::remove_if(views.begin(), views.end(), [&] (wayfire_view view) {
-            return !view_visible_on(view, vp, !wm_only);
+            return !view_visible_on(view, vp);
         });
 
         views.erase(it, views.end());
@@ -592,7 +592,7 @@ class output_viewport_manager_t
         /* we iterate through views on current viewport from bottom to top
          * that way we ensure that they will be focused before all others */
         auto views = get_views_on_workspace(get_current_workspace(),
-            MIDDLE_LAYERS, true);
+            MIDDLE_LAYERS);
 
         for (auto& view : wf::reverse(views))
             output->workspace->bring_to_front(view);
@@ -834,7 +834,7 @@ class workspace_manager::impl
             view->get_data_safe<layer_view_data_t>()->is_promoted = false;
 
         auto views = viewport_manager.get_views_on_workspace(
-            vp, LAYER_WORKSPACE, true);
+            vp, LAYER_WORKSPACE);
 
         /* Do not consider unmapped views or views which are not visible */
         auto it = std::remove_if(views.begin(), views.end(),
@@ -954,11 +954,11 @@ workspace_manager::~workspace_manager() = default;
 /* Just pass to the appropriate function from above */
 std::vector<wf::point_t> workspace_manager::get_view_workspaces(wayfire_view view, double threshold)
 { return pimpl->viewport_manager.get_view_workspaces(view, threshold); }
-bool workspace_manager::view_visible_on(wayfire_view view, wf::point_t ws) { return pimpl->viewport_manager.view_visible_on(view, ws, true); }
-std::vector<wayfire_view> workspace_manager::get_views_on_workspace(wf::point_t ws, uint32_t layer_mask, bool wm_only)
-{ return pimpl->viewport_manager.get_views_on_workspace(ws, layer_mask, wm_only); }
-std::vector<wayfire_view> workspace_manager::get_views_on_workspace_sublayer(wf::point_t ws, nonstd::observer_ptr<sublayer_t> sublayer, bool wm_only)
-{ return pimpl->viewport_manager.get_views_on_workspace_sublayer(ws, sublayer, wm_only); }
+bool workspace_manager::view_visible_on(wayfire_view view, wf::point_t ws) { return pimpl->viewport_manager.view_visible_on(view, ws); }
+std::vector<wayfire_view> workspace_manager::get_views_on_workspace(wf::point_t ws, uint32_t layer_mask)
+{ return pimpl->viewport_manager.get_views_on_workspace(ws, layer_mask); }
+std::vector<wayfire_view> workspace_manager::get_views_on_workspace_sublayer(wf::point_t ws, nonstd::observer_ptr<sublayer_t> sublayer)
+{ return pimpl->viewport_manager.get_views_on_workspace_sublayer(ws, sublayer); }
 
 nonstd::observer_ptr<sublayer_t> workspace_manager::create_sublayer(layer_t layer, sublayer_mode_t mode)
 { return pimpl->layer_manager.create_sublayer(layer, mode); }

--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -197,8 +197,18 @@ wf::pointf_t wf::view_3D::transform_point(
     glm::vec4 v(1.0f * p.x, 1.0f * p.y, 0, 1);
     v = calculate_total_transform() * v;
 
-    v.x /= v.w;
-    v.y /= v.w;
+    if (std::abs(v.w) < 1e-6)
+    {
+        /* This should never happen as long as we use well-behaving matrices.
+         * However if we set transform to the zero matrix we might get
+         * this case where v.w is zero. In this case we assume the view is
+         * just a single point at 0,0 */
+        v.x = v.y = 0;
+    } else
+    {
+        v.x /= v.w;
+        v.y /= v.w;
+    }
 
     return get_absolute_coords_from_relative(geometry, {v.x, v.y});
 }


### PR DESCRIPTION
This removes the wm_only flag from get_views_on_workspace which was an artifact
of when wayfire used libweston and a shadow discrepancy called for this hack.