### PR TITLE
cube: cubemap: Reset state on error

### DIFF
--- a/plugins/cube/cubemap.cpp
+++ b/plugins/cube/cubemap.cpp
@@ -80,6 +80,7 @@ void wf_cube_background_cubemap::render_frame(const wf::framebuffer_t& fb,
     {
         GL_CALL(glClearColor(TEX_ERROR_FLAG_COLOR));
         GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
+        OpenGL::render_end();
         return;
     }
     program.use(wf::TEXTURE_TYPE_RGBA);


### PR DESCRIPTION
Call OpenGL::render_end() where needed and unbind cubemap texture.
Without this, rotate cube crashes when no cubemap image is set.
Fixes #530.