### PR TITLE
ci: Don't ignore any files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,16 +1,5 @@
 name: CI
 
-# "run when at least one file does not match paths-ignore"
-on:
-  push:
-    paths-ignore:
-    - 'metadata/**'
-    - 'proto/**'
-  pull_request:
-    paths-ignore:
-    - 'metadata/**'
-    - 'proto/**'
-
 jobs:
   test_musl_gcc:
     name: "Test with GCC/musl/libstdc++/BFD on Alpine Linux"


### PR DESCRIPTION
This makes it so ci will run even if the only files modified are in
metadata/ or proto/.