### PR TITLE
Move 'Toggle fullscreen' from simple-tile to wm-actions plugin

### DIFF
--- a/metadata/simple-tile.xml
+++ b/metadata/simple-tile.xml
@@ -30,11 +30,6 @@
 			<_long>Toggles tiling mode with the specified key.</_long>
 			<default>&lt;super&gt; KEY_T</default>
 		</option>
-		<option name="key_toggle_fullscreen" type="key">
-			<_short>Key toggle fullscreen</_short>
-			<_long>Makes focused view fullscreen with the specified key.</_long>
-			<default>&lt;super&gt; KEY_M</default>
-		</option>
 		<option name="key_focus_left" type="key">
 			<_short>Key focus left</_short>
 			<_long>Moves focus to the window left with the specified key.</_long>

--- a/metadata/wm-actions.xml
+++ b/metadata/wm-actions.xml
@@ -9,5 +9,10 @@
 			<_long>Toggle the always-on-top state of a view.</_long>
 			<default>&lt;super&gt; KEY_T</default>
 		</option>
+		<option name="toggle_fullscreen" type="activator">
+			<_short>Toggle Fulsreen</_short>
+			<_long>Toggle the fullsreen state of a view.</_long>
+			<default>&lt;super&gt; KEY_M</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/single_plugins/wm-actions.cpp
+++ b/plugins/single_plugins/wm-actions.cpp
@@ -40,7 +40,23 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
         return true;
     };
 
+    wf::activator_callback on_toggle_fullscreen =
+        [=](wf::activator_source_t source, uint32_t) -> bool
+    {
+        if (!output->can_activate_plugin(this->grab_interface))
+            return false;
+
+        auto view = choose_view(source);
+        if (!view || view->role != wf::VIEW_ROLE_TOPLEVEL)
+            return false;
+
+        view->fullscreen_request(view->get_output(), !view->fullscreen);
+
+        return true;
+    };
+
     wf::option_wrapper_t<wf::activatorbinding_t> toggle_above{"wm-actions/toggle_always_on_top"};
+    wf::option_wrapper_t<wf::activatorbinding_t> toggle_fullscreen{"wm-actions/toggle_fullscreen"};
 
   public:
     void init() override
@@ -48,12 +64,14 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
         always_above = output->workspace->create_sublayer(
             wf::LAYER_WORKSPACE, wf::SUBLAYER_DOCKED_ABOVE);
         output->add_activator(toggle_above, &on_toggle_above);
+        output->add_activator(toggle_fullscreen, &on_toggle_fullscreen);
     }
 
     void fini() override
     {
         output->workspace->destroy_sublayer(always_above);
         output->rem_binding(&on_toggle_above);
+        output->rem_binding(&on_toggle_fullscreen);
     }
 };
 

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -41,7 +41,7 @@ class tile_plugin_t : public wf::plugin_interface_t
     wf::view_matcher_t tile_by_default{"simple-tile/tile_by_default"};
     wf::option_wrapper_t<bool> keep_fullscreen_on_adjacent{"simple-tile/keep_fullscreen_on_adjacent"};
     wf::option_wrapper_t<wf::buttonbinding_t> button_move{"simple-tile/button_move"}, button_resize{"simple-tile/button_resize"};
-    wf::option_wrapper_t<wf::keybinding_t> key_toggle_tile{"simple-tile/key_toggle"}, key_toggle_fullscreen{"simple-tile/key_toggle_fullscreen"};
+    wf::option_wrapper_t<wf::keybinding_t> key_toggle_tile{"simple-tile/key_toggle"};
 
     wf::option_wrapper_t<wf::keybinding_t> key_focus_left{"simple-tile/key_focus_left"}, key_focus_right{"simple-tile/key_focus_right"};
     wf::option_wrapper_t<wf::keybinding_t> key_focus_above{"simple-tile/key_focus_above"}, key_focus_below{"simple-tile/key_focus_below"};
@@ -359,15 +359,6 @@ class tile_plugin_t : public wf::plugin_interface_t
         return false;
     }
 
-    wf::key_callback on_toggle_fullscreen = [=] (uint32_t key)
-    {
-        return conditioned_view_execute(true, [=] (wayfire_view view)
-        {
-            stop_controller(true);
-            set_view_fullscreen(view, !view->fullscreen);
-        });
-    };
-
     wf::key_callback on_toggle_tiled_state = [=] (uint32_t key)
     {
         return conditioned_view_execute(false, [=] (wayfire_view view)
@@ -430,7 +421,6 @@ class tile_plugin_t : public wf::plugin_interface_t
         output->add_button(button_move, &on_move_view);
         output->add_button(button_resize, &on_resize_view);
         output->add_key(key_toggle_tile, &on_toggle_tiled_state);
-        output->add_key(key_toggle_fullscreen, &on_toggle_fullscreen);
 
         output->add_key(key_focus_left,  &on_focus_adjacent);
         output->add_key(key_focus_right, &on_focus_adjacent);
@@ -489,7 +479,6 @@ class tile_plugin_t : public wf::plugin_interface_t
 
         output->rem_binding(&on_move_view);
         output->rem_binding(&on_resize_view);
-        output->rem_binding(&on_toggle_fullscreen);
         output->rem_binding(&on_toggle_tiled_state);
         output->rem_binding(&on_focus_adjacent);
 


### PR DESCRIPTION
To resolve: https://github.com/WayfireWM/wayfire/issues/535

I have also noticed that when running alacritty and having `preferred_decoration_mode = server` the client decorations show up when I fullscreen the window for the second time. I think this is a bug unrelated to this PR but I cannot figure it out.