### PR TITLE
Fix almost all game related issues

### DIFF
--- a/plugins/single_plugins/move-snap-helper.hpp
+++ b/plugins/single_plugins/move-snap-helper.hpp
@@ -106,18 +106,15 @@ class move_snap_helper_t : public wf::custom_data_t
   protected:
     virtual bool should_enable_snap_off() const
     {
-        return enable_snap_off &&
-            (view->tiled_edges || view->fullscreen);
+        return enable_snap_off && (view->tiled_edges || view->fullscreen);
     }
 
     /** Move the view out of its slot */
     virtual void snap_off()
     {
         view_in_slot = false;
-        if (view->fullscreen)
-            view->fullscreen_request(view->get_output(), false);
 
-        if (view->tiled_edges)
+        if (view->tiled_edges && !view->fullscreen)
             view->tile_request(0);
     }
 

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -182,7 +182,7 @@ class wayfire_resize : public wf::plugin_interface_t
     bool initiate(wayfire_view view, uint32_t forced_edges = 0)
     {
         if (!view || view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT ||
-            !view->is_mapped())
+            !view->is_mapped() || view->fullscreen)
         {
             return false;
         }
@@ -210,8 +210,6 @@ class wayfire_resize : public wf::plugin_interface_t
 
         view->set_resizing(true, edges);
 
-        if (view->fullscreen)
-            view->set_fullscreen(false);
         if (view->tiled_edges)
             view->set_tiled(0);
 

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -76,6 +76,23 @@ struct view_self_request_focus_signal : public _view_signal
 };
 
 /**
+ * view-hints-changed signal is emitted on the view's output whenever the client indicates the
+ * views hints have changed (example urgency hint).
+ */
+struct view_hints_changed_signal : public _view_signal
+{
+    bool demands_attention = false;
+};
+
+/**
+ * view-system-bell signal is emitted on the view's output whenever the client indicates the
+ * view wants to invoke the system bell if such is available.
+ */
+struct view_system_bell_signal : public _view_signal
+{
+};
+
+/**
  * The view-fullscreen-request and view-fullscreen signals are emitted on the view's output when the view's fullscreen state changes.
  * view-fullscreen-request is emitted when the view needs to be fullscreened, but has not been fullscreened yet.
  * view-fullscreen is emitted whenever the view's fullscreen state actually changes.

--- a/src/output/gtk-shell.cpp
+++ b/src/output/gtk-shell.cpp
@@ -86,7 +86,7 @@ static void handle_gtk_surface_present(wl_client *client, wl_resource *resource,
  * gnome-control-center, gnome-clocks, dconf-editor are single instance and if
  * they are already running and launched again, this will request that they get focused.
  */
-static void handle_gtk_surface_request_focus(struct wl_client *client, struct wl_resource *resource, const char* startup_id)
+static void handle_gtk_surface_request_focus(wl_client *client, wl_resource *resource, const char* startup_id)
 {
     auto surface = static_cast<wl_resource*> (wl_resource_get_user_data(resource));
     wayfire_view view = wf::wl_surface_to_wayfire_view(surface);
@@ -147,7 +147,18 @@ static void handle_gtk_shell_set_startup_id(wl_client *client, wl_resource *reso
  *  A view could use this to invoke the system bell, be it aural, visual or none at all.
  *  Not implemented.
  */
-static void handle_gtk_shell_system_bell(wl_client *client, wl_resource *resource, wl_resource *surface) {}
+static void handle_gtk_shell_system_bell(wl_client *client, wl_resource *resource, wl_resource *surface)
+{
+    auto wl_surface = static_cast<wl_resource*> (wl_resource_get_user_data(surface));
+    wayfire_view view = wf::wl_surface_to_wayfire_view(wl_surface);
+
+    if (view)
+    {
+        view_system_bell_signal data;
+        data.view = view;
+        view->get_output()->emit_signal("view-system-bell", &data);
+    }
+}
 
 
 /**

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -319,10 +319,8 @@ class wayfire_xwayland_view : public wayfire_xwayland_view_base
             minimize_request(xw->minimized);
         });
         on_request_maximize.set_callback([&] (void*) {
-            if (xw->maximized_horz && xw->maximized_vert)
-                tile_request(wf::TILED_EDGES_ALL);
-            else
-                tile_request(0);
+            tile_request((xw->maximized_horz && xw->maximized_vert) ?
+                wf::TILED_EDGES_ALL : 0);
 
         });
         on_request_fullscreen.set_callback([&] (void*) {

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -316,6 +316,7 @@ class wayfire_xwayland_view : public wayfire_xwayland_view_base
             }
         });
         on_request_minimize.set_callback([&] (void*) {
+            LOG(wf::log::LOG_LEVEL_ERROR, "on_request_minimize");
             minimize_request(xw->minimized);
         });
         on_request_maximize.set_callback([&] (void*) {


### PR DESCRIPTION
Requires https://github.com/swaywm/wlroots/pull/2264

* Adds minimizing support for chrome / steam csd
  and games that want to minimize on focus loss
* Adds view-self-focus-request for xwayland like gtk-shell has
* Adds view-hints-changed-signal (for urgency hint, possibly others)
* Adds view-system-bell signal (currently used in gtk-shell only)
* Fixes fullscreen games, the move behavior of fullscreen views,
   is to snap back to fullscreen after move. I would demo how 
  smooth and nice this works with multiple outputs but wf-recorder
  can only record one.
* Disallow resizing & snap off for fullscreen as this breaks 95 % of steam games,
   since they expect the size to be the resolution it is set to.

I have to say that in some occasions the switcher plugin crashes wayfire,
but I am unable to find the cause. The crash never happens if you 
reload the wobbly plugin at the beginning of your session,
maybe the load order is important here...

The fast switcher work perfectly fine.
It seems to be a 'floating point exception in switcher' and I found switcher
to also have other kind of strange behavior as setting views alpha to 0.0
when minimized and sometimes after restore it is not restored to 1.0,
also the other issue I demoed with the switcher (can't switch).

I have disabled this plugin and hope for a soon present plugin :100: 
