### PR TITLE
Add view-minimized signal

### DIFF
--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -102,6 +102,14 @@ struct view_minimize_request_signal : public _view_signal
     bool carried_out = false;
 };
 
+/* view-minimized: sent on view minimize state change
+ * In contrast to view_minimize_request_signal, this signal is sent after
+ * the minimized state has been finalized. */
+struct view_minimized_signal : public _view_signal
+{
+    bool state;
+};
+
 /* same as both change_viewport_request and change_viewport_notify */
 struct change_viewport_signal : public wf::signal_data_t
 {

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -354,6 +354,11 @@ void wf::view_interface_t::set_minimized(bool minim)
         get_output()->focus_view(self(), true);
     }
 
+    view_minimized_signal data;
+    data.view = self();
+    data.state = minimized;
+    get_output()->emit_signal("view-minimized", &data);
+
     desktop_state_updated();
 }
 


### PR DESCRIPTION
If a plugin listens to view_minimize_request_signal, the layer isn't set and the state isn't
guaranteed to eventually become the state in the signal. Here we add view-minimized signal,
which is emitted after the state has been decided and the layer has been set.