### PR TITLE
core: Add get_view_at function to API

### DIFF
--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -155,10 +155,17 @@ class compositor_core_t : public wf::object_base_t
      */
     virtual wf::surface_interface_t *get_touch_focus() = 0;
 
+    /**
+     * @return The surface at point, or null if none.
+     */
+    virtual wf::surface_interface_t *get_surface_at(wf::pointf_t point) = 0;
+
     /** @return The view whose surface is cursor focus */
     wayfire_view get_cursor_focus_view();
     /** @return The view whose surface is touch focus */
     wayfire_view get_touch_focus_view();
+    /** @return The view whose surface is at point */
+    wayfire_view get_view_at(wf::pointf_t point);
 
     /**
      * @return A list of all currently attached input devices.

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -164,7 +164,8 @@ class compositor_core_t : public wf::object_base_t
     wayfire_view get_cursor_focus_view();
     /** @return The view whose surface is touch focus */
     wayfire_view get_touch_focus_view();
-    /** @return The view whose surface is under the give global coordinates,
+    /**
+     * @return The view whose surface is under the given global coordinates,
      *  or null if none */
     wayfire_view get_view_at(wf::pointf_t point);
 

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -156,7 +156,7 @@ class compositor_core_t : public wf::object_base_t
     virtual wf::surface_interface_t *get_touch_focus() = 0;
 
     /**
-     * @return The surface at point, or null if none.
+     * @return The surface under the given global coordinates, or null if none.
      */
     virtual wf::surface_interface_t *get_surface_at(wf::pointf_t point) = 0;
 
@@ -164,7 +164,8 @@ class compositor_core_t : public wf::object_base_t
     wayfire_view get_cursor_focus_view();
     /** @return The view whose surface is touch focus */
     wayfire_view get_touch_focus_view();
-    /** @return The view whose surface is at point */
+    /** @return The view whose surface is under the give global coordinates,
+     *  or null if none */
     wayfire_view get_view_at(wf::pointf_t point);
 
     /**

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -61,6 +61,7 @@ class compositor_core_impl_t : public compositor_core_t
 
     wf::surface_interface_t *get_cursor_focus() override;
     wf::surface_interface_t *get_touch_focus() override;
+    wf::surface_interface_t *get_surface_at(wf::pointf_t point) override;
 
     std::vector<nonstd::observer_ptr<wf::input_device_t>> get_input_devices() override;
     virtual wlr_cursor* get_wlr_cursor() override;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -336,7 +336,7 @@ wf::surface_interface_t *wf::compositor_core_impl_t::get_surface_at(wf::pointf_t
 wayfire_view wf::compositor_core_t::get_view_at(wf::pointf_t point)
 {
     auto surface = get_surface_at(point);
-    auto view = dynamic_cast<wf::view_interface_t*> (surface);
+    auto view = dynamic_cast<wf::view_interface_t*> (surface->get_main_surface());
 
     return view ? view->self() : nullptr;
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -327,6 +327,20 @@ wayfire_view wf::compositor_core_t::get_cursor_focus_view()
     return view ? view->self() : nullptr;
 }
 
+wf::surface_interface_t *wf::compositor_core_impl_t::get_surface_at(wf::pointf_t point)
+{
+    wf::pointf_t local = {0.0, 0.0};
+    return input->input_surface_at(point, local);
+}
+
+wayfire_view wf::compositor_core_t::get_view_at(wf::pointf_t point)
+{
+    auto surface = get_surface_at(point);
+    auto view = dynamic_cast<wf::view_interface_t*> (surface);
+
+    return view ? view->self() : nullptr;
+}
+
 wf::surface_interface_t *wf::compositor_core_impl_t::get_touch_focus()
 {
     return input->touch_focus;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -342,7 +342,6 @@ wayfire_view wf::compositor_core_t::get_view_at(wf::pointf_t point)
     }
 
     auto view = dynamic_cast<wf::view_interface_t*> (surface->get_main_surface());
-
     return view ? view->self() : nullptr;
 }
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -336,7 +336,6 @@ wf::surface_interface_t *wf::compositor_core_impl_t::get_surface_at(wf::pointf_t
 wayfire_view wf::compositor_core_t::get_view_at(wf::pointf_t point)
 {
     auto surface = get_surface_at(point);
-
     if (!surface)
     {
         return nullptr;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -336,6 +336,12 @@ wf::surface_interface_t *wf::compositor_core_impl_t::get_surface_at(wf::pointf_t
 wayfire_view wf::compositor_core_t::get_view_at(wf::pointf_t point)
 {
     auto surface = get_surface_at(point);
+
+    if (!surface)
+    {
+        return nullptr;
+    }
+
     auto view = dynamic_cast<wf::view_interface_t*> (surface->get_main_surface());
 
     return view ? view->self() : nullptr;


### PR DESCRIPTION
Create and expose a new core function get_view_at, which takes a point and
returns a view, or null if none is found. This is useful for plugins like
scale where it makes sense to be able to pick views while holding a grab.