### PR TITLE
use request_workspace() to change workspaces

### DIFF
--- a/plugins/single_plugins/scale.cpp
+++ b/plugins/single_plugins/scale.cpp
@@ -73,7 +73,7 @@ class wayfire_scale : public wf::plugin_interface_t
     void init() override
     {
         grab_interface->name = "scale";
-        grab_interface->capabilities = wf::CAPABILITY_MANAGE_COMPOSITOR;
+        grab_interface->capabilities = wf::CAPABILITY_GRAB_INPUT;
 
         active = hook_set = button_connected = false;
 
@@ -219,8 +219,7 @@ class wayfire_scale : public wf::plugin_interface_t
 
         if (!interact)
         {
-            /* TODO: animate transition, possibly using another plugin */
-            output->workspace->set_workspace(get_view_main_workspace(view));
+            output->workspace->request_workspace(get_view_main_workspace(view));
         }
 
         if (scale_data[view].transformer)
@@ -301,8 +300,7 @@ class wayfire_scale : public wf::plugin_interface_t
                 break;
             case KEY_ENTER:
                 toggle_cb(wf::activator_source_t{}, 0);
-                /* TODO: animate transition */
-                output->workspace->set_workspace(get_view_main_workspace(last_focused_view));
+                output->workspace->request_workspace(get_view_main_workspace(last_focused_view));
                 return;
             case KEY_ESC:
                 toggle_cb(wf::activator_source_t{}, 0);


### PR DESCRIPTION
this will use vswitch plugin if enabled

note: this requires to change grab_interface->capabilities to only include wf::CAPABILITY_GRAB_INPUT, otherwise they would clash with vswitch; as far as I understand this is OK since only this is actually used

There is some strangeness in during the workspace switch animation: the windows seem to "jump" a bit and the inactive ones stay transparent and revert later (instead of fading); I'll try to look into this more

the other crash I mentioned yesterday is fixed since then (it was caused by remove_transformers() and scale_data.clear() being reversed when deactivating the plugin

     
