### PR TITLE
build: Add xwayland option

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -8,6 +8,7 @@
 #define SYSCONFDIR "@SYSCONFDIR@"
 #mesondefine BUILD_WITH_IMAGEIO
 #mesondefine USE_GLES32
+#mesondefine WF_HAS_XWAYLAND
 
 
 #endif /* end of include guard: CONFIG_H */

--- a/meson.build
+++ b/meson.build
@@ -97,30 +97,42 @@ else
   conf_data.set('BUILD_WITH_IMAGEIO', false)
 endif
 
-configure_file(input: 'config.h.in',
-               output: 'config.h',
-               configuration: conf_data)
-
 wayfire_conf_inc = include_directories(['.'])
 
 add_project_arguments(['-Wno-unused-parameter'], language: 'cpp')
 
-wlroots_has_xwayland = false
-wlroots_has_x11_backend = false
+have_xwayland = false
+have_x11_backend = false
 if use_system_wlroots
   cpp = meson.get_compiler('cpp')
-  wlroots_has_xwayland = cpp.get_define('WLR_HAS_XWAYLAND', prefix: '#include <wlr/config.h>', dependencies: wlroots) == '1'
-  wlroots_has_x11_backend = cpp.get_define('WLR_HAS_X11_BACKEND', prefix: '#include <wlr/config.h>', dependencies: wlroots) == '1'
+  have_xwayland = cpp.get_define('WLR_HAS_XWAYLAND', prefix: '#include <wlr/config.h>', dependencies: wlroots) == '1'
+  have_x11_backend = cpp.get_define('WLR_HAS_X11_BACKEND', prefix: '#include <wlr/config.h>', dependencies: wlroots) == '1'
 else
-  wlroots_has_xwayland = subproject('wlroots').get_variable('conf_data').get('WLR_HAS_XWAYLAND', false) == 1
-  wlroots_has_x11_backend = subproject('wlroots').get_variable('conf_data').get('WLR_HAS_X11_BACKEND', false) == 1
+  have_xwayland = subproject('wlroots').get_variable('conf_data').get('WLR_HAS_XWAYLAND', false) == 1
+  have_x11_backend = subproject('wlroots').get_variable('conf_data').get('WLR_HAS_X11_BACKEND', false) == 1
 endif
 
-if wlroots_has_xwayland
+if get_option('xwayland').enabled() and not have_xwayland
+  error('Cannot enable Xwayland in wayfire: wlroots has been built without Xwayland support')
+endif
+
+if get_option('xwayland').enabled()
+  have_xwayland = true
+elif get_option('xwayland').disabled()
+  have_xwayland = false
+endif
+
+if have_xwayland
   xcb = dependency('xcb')
+  conf_data.set('WF_HAS_XWAYLAND', 1)
 else
   xcb = declare_dependency() # dummy dep
+  conf_data.set('WF_HAS_XWAYLAND', 0)
 endif
+
+configure_file(input: 'config.h.in',
+               output: 'config.h',
+               configuration: conf_data)
 
 subdir('proto')
 subdir('src')
@@ -134,8 +146,8 @@ summary = [
 	'',
     'system wfconfig: @0@'.format(use_system_wfconfig),
     ' system wlroots: @0@'.format(use_system_wlroots),
-    '       xwayland: @0@'.format(wlroots_has_xwayland),
-    '    x11-backend: @0@'.format(wlroots_has_x11_backend),
+    '       xwayland: @0@'.format(have_xwayland),
+    '    x11-backend: @0@'.format(have_x11_backend),
     '        imageio: @0@'.format(conf_data.get('BUILD_WITH_IMAGEIO')),
     '         gles32: @0@'.format(conf_data.get('USE_GLES32')),
     '----------------',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('enable_gles32', type: 'boolean', value: true, description: 'Enable usage of GLES 3.2')
 option('use_system_wfconfig', type: 'feature', value: 'auto', description: 'Use the system-wide installation of wf-config')
 option('use_system_wlroots', type: 'feature', value: 'auto', description: 'Use the system-wide installation of wlroots')
+option('xwayland', type: 'feature', value: 'auto', description: 'Build with xwayland support. Requires wlroots also built with xwayland support')

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -602,7 +602,7 @@ pid_t wf::compositor_core_impl_t::run(std::string command)
 
             setenv("_JAVA_AWT_WM_NONREPARENTING", "1", 1);
             setenv("WAYLAND_DISPLAY", wayland_display.c_str(), 1);
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
             if (!xwayland_get_display().empty()) {
                 setenv("DISPLAY", xwayland_get_display().c_str(), 1);
             }

--- a/src/core/view-access-interface.cpp
+++ b/src/core/view-access-interface.cpp
@@ -9,7 +9,7 @@
 #include <wlr/config.h>
 #include <wlr/util/edges.h>
 
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
 extern "C"
 {
 #define static
@@ -110,7 +110,7 @@ variant_t view_access_interface_t::get(const std::string &identifier, bool &erro
             if (_view->role == VIEW_ROLE_UNMANAGED)
             {
                 auto surf = _view->get_wlr_surface();
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
                 if (surf && wlr_surface_is_xwayland_surface(surf)) {
                     out = std::string("x-or");
                     break;

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -506,7 +506,7 @@ extern "C"
 #undef namespace
 #include <wlr/types/wlr_xdg_shell.h>
 
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
 #define class class_t
 #define static
 #include <wlr/xwayland.h>
@@ -552,7 +552,7 @@ wayfire_view wf::wl_surface_to_wayfire_view(wl_resource *resource)
     if (wlr_surface_is_layer_surface(surface))
         handle = wlr_layer_surface_v1_from_wlr_surface(surface)->data;
 
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
     if (wlr_surface_is_xwayland_surface(surface))
         handle = wlr_xwayland_surface_from_wlr_surface(surface)->data;
 #endif

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -12,7 +12,7 @@ extern "C"
 {
 #include <wlr/config.h>
 
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
 #define class class_t
 #define static
 #include <wlr/xwayland.h>
@@ -22,7 +22,7 @@ extern "C"
 #endif
 }
 
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
 
 class wayfire_xwayland_view_base : public wf::wlr_view_t
 {
@@ -615,7 +615,7 @@ static wlr_xwayland *xwayland_handle = nullptr;
 
 void wf::init_xwayland()
 {
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
     static wf::wl_listener_wrapper on_created;
     static wf::wl_listener_wrapper on_ready;
 
@@ -659,7 +659,7 @@ void wf::init_xwayland()
 
 void wf::xwayland_set_seat(wlr_seat *seat)
 {
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
     if (xwayland_handle)
     {
         wlr_xwayland_set_seat(xwayland_handle,
@@ -670,7 +670,7 @@ void wf::xwayland_set_seat(wlr_seat *seat)
 
 void wf::xwayland_set_cursor(wlr_xcursor_image *image)
 {
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
     if (!xwayland_handle)
         return;
     wlr_xwayland_set_cursor(xwayland_handle, image->buffer,
@@ -681,7 +681,7 @@ void wf::xwayland_set_cursor(wlr_xcursor_image *image)
 
 std::string wf::xwayland_get_display()
 {
-#if WLR_HAS_XWAYLAND
+#if WF_HAS_XWAYLAND
     return xwayland_handle ? nonull(xwayland_handle->display_name) : "";
 #else
     return "";


### PR DESCRIPTION
This makes it so xwayland can be disabled at runtime when building against
wlroots that is built with xwayland. If the option is enabled and wlroots
was built without wlroots, the build will fail. Helpful for package maintainers
to avoid inconsistencies.