### PR TITLE
Bump wlroots version.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ libinput       = dependency('libinput', version: '>=1.7.0')
 pixman         = dependency('pixman-1')
 threads        = dependency('threads')
 xkbcommon      = dependency('xkbcommon')
-wlroots        = dependency('wlroots', version: ['>=0.9.0', '<0.11.0'], required: get_option('use_system_wlroots'))
+wlroots        = dependency('wlroots', version: ['>=0.11.0', '<0.12.0'], required: get_option('use_system_wlroots'))
 wfconfig       = dependency('wf-config', version: ['>=0.4.0', '<0.5.0'], required: get_option('use_system_wfconfig'))
 
 use_system_wlroots = not get_option('use_system_wlroots').disabled() and wlroots.found()


### PR DESCRIPTION
There are compilation errors with 0.10.0, so the minimum has been bumped
to the latest wlroots release.