### PR TITLE
Signal rename

### DIFF
--- a/plugins/animate/animate.cpp
+++ b/plugins/animate/animate.cpp
@@ -185,8 +185,8 @@ class wayfire_animation : public wf::singleton_plugin_t<animation_global_cleanup
         grab_interface->name = "animate";
         grab_interface->capabilities = 0;
 
-        output->connect_signal("map-view", &on_view_mapped);
-        output->connect_signal("pre-unmap-view", &on_view_unmapped);
+        output->connect_signal("view-mapped", &on_view_mapped);
+        output->connect_signal("view-pre-unmapped", &on_view_unmapped);
         output->connect_signal("start-rendering", &on_render_start);
         output->connect_signal("view-minimize-request", &on_minimize_request);
     }
@@ -279,7 +279,7 @@ class wayfire_animation : public wf::singleton_plugin_t<animation_global_cleanup
 
     wf::signal_callback_t on_minimize_request = [=] (wf::signal_data_t *data)
     {
-        auto ev = static_cast<view_minimize_request_signal*>(data);
+        auto ev = static_cast<wf::view_minimize_request_signal*>(data);
         if (ev->state)
         {
             ev->carried_out = true;
@@ -299,8 +299,8 @@ class wayfire_animation : public wf::singleton_plugin_t<animation_global_cleanup
 
     void fini() override
     {
-        output->disconnect_signal("map-view", &on_view_mapped);
-        output->disconnect_signal("pre-unmap-view", &on_view_unmapped);
+        output->disconnect_signal("view-mapped", &on_view_mapped);
+        output->disconnect_signal("view-pre-unmapped", &on_view_unmapped);
         output->disconnect_signal("start-rendering", &on_render_start);
         output->disconnect_signal("view-minimize-request", &on_minimize_request);
 

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -268,9 +268,9 @@ class wayfire_blur : public wf::plugin_interface_t
             auto view = get_signaled_view(data);
             pop_transformer(view);
         };
-        output->connect_signal("attach-view", &view_attached);
-        output->connect_signal("map-view", &view_attached);
-        output->connect_signal("detach-view", &view_detached);
+        output->connect_signal("view-attached", &view_attached);
+        output->connect_signal("view-mapped", &view_attached);
+        output->connect_signal("view-detached", &view_detached);
 
         /* frame_pre_paint is called before each frame has started.
          * It expands the damage by the blur radius.
@@ -419,9 +419,9 @@ class wayfire_blur : public wf::plugin_interface_t
         remove_transformers();
 
         output->rem_binding(&button_toggle);
-        output->disconnect_signal("attach-view", &view_attached);
-        output->disconnect_signal("map-view", &view_attached);
-        output->disconnect_signal("detach-view", &view_detached);
+        output->disconnect_signal("view-attached", &view_attached);
+        output->disconnect_signal("view-mapped", &view_attached);
+        output->disconnect_signal("view-detached", &view_detached);
         output->render->rem_effect(&frame_pre_paint);
         output->render->disconnect_signal("workspace-stream-pre",
             &workspace_stream_pre);

--- a/plugins/common/wayfire/plugins/common/view-change-viewport-signal.hpp
+++ b/plugins/common/wayfire/plugins/common/view-change-viewport-signal.hpp
@@ -5,7 +5,7 @@
 /**
  * Each plugin which changes the view's workspace should emit this signal.
  */
-struct view_change_viewport_signal : public _view_signal
+struct view_change_viewport_signal : public wf::_view_signal
 {
     wf::point_t from, to;
 

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -176,21 +176,6 @@ class simple_decoration_surface : public wf::surface_interface_t,
         layout.handle_motion(x, y);
     }
 
-    void send_move_request()
-    {
-        wf::view_move_request_signal move_request;
-        move_request.view = view;
-        get_output()->emit_signal("view-move-request", &move_request);
-    }
-
-    void send_resize_request(uint32_t edges)
-    {
-        wf::view_resize_request_signal resize_request;
-        resize_request.view  = view;
-        resize_request.edges = edges;
-        get_output()->emit_signal("view-resize-request", &resize_request);
-    }
-
     virtual void on_pointer_button(uint32_t button, uint32_t state) override
     {
         if (button != BTN_LEFT)
@@ -206,10 +191,10 @@ class simple_decoration_surface : public wf::surface_interface_t,
         switch (action.action)
         {
           case wf::decor::DECORATION_ACTION_MOVE:
-            return send_move_request();
+            return view->move_request();
 
           case wf::decor::DECORATION_ACTION_RESIZE:
-            return send_resize_request(action.edges);
+            return view->resize_request(action.edges);
 
           case wf::decor::DECORATION_ACTION_CLOSE:
             return view->close();

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -178,17 +178,17 @@ class simple_decoration_surface : public wf::surface_interface_t,
 
     void send_move_request()
     {
-        move_request_signal move_request;
+        wf::view_move_request_signal move_request;
         move_request.view = view;
-        get_output()->emit_signal("move-request", &move_request);
+        get_output()->emit_signal("view-move-request", &move_request);
     }
 
     void send_resize_request(uint32_t edges)
     {
-        resize_request_signal resize_request;
+        wf::view_resize_request_signal resize_request;
         resize_request.view  = view;
         resize_request.edges = edges;
-        get_output()->emit_signal("resize-request", &resize_request);
+        get_output()->emit_signal("view-resize-request", &resize_request);
     }
 
     virtual void on_pointer_button(uint32_t button, uint32_t state) override

--- a/plugins/decor/decoration.cpp
+++ b/plugins/decor/decoration.cpp
@@ -37,8 +37,8 @@ class wayfire_decoration :
         grab_interface->name = "simple-decoration";
         grab_interface->capabilities = wf::CAPABILITY_VIEW_DECORATOR;
 
-        output->connect_signal("map-view", &view_updated);
-        output->connect_signal("decoration-state-updated-view", &view_updated);
+        output->connect_signal("view-mapped", &view_updated);
+        output->connect_signal("view-decoration-state-updated", &view_updated);
     }
 
     /**

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -197,7 +197,7 @@ class wayfire_expo : public wf::plugin_interface_t
             finalize_and_exit();
         };
 
-        output->connect_signal("detach-view", &view_removed);
+        output->connect_signal("view-detached", &view_removed);
         output->connect_signal("view-disappeared", &view_removed);
     }
 
@@ -505,7 +505,7 @@ class wayfire_expo : public wf::plugin_interface_t
 
     void fini() override
     {
-        output->disconnect_signal("detach-view", &view_removed);
+        output->disconnect_signal("view-detached", &view_removed);
         output->disconnect_signal("view-disappeared", &view_removed);
 
         if (state.active)

--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -171,7 +171,6 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
         switch_next();
 
         output->connect_signal("view-disappeared", &cleanup_view);
-        output->connect_signal("detach-view", &cleanup_view);
 
         return true;
     };
@@ -190,7 +189,6 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
         active = false;
 
         output->disconnect_signal("view-disappeared", &cleanup_view);
-        output->disconnect_signal("detach-view", &cleanup_view);
     }
 
     void switch_next()

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -70,7 +70,6 @@ class wayfire_grid_view_cdata : public wf::custom_data_t
 
         output->render->set_redraw_always(true);
         output->connect_signal("view-disappeared", &unmapped);
-        output->connect_signal("detach-view", &unmapped);
     }
 
     void destroy()
@@ -158,7 +157,6 @@ class wayfire_grid_view_cdata : public wf::custom_data_t
         output->deactivate_plugin(iface);
         output->render->set_redraw_always(false);
         output->disconnect_signal("view-disappeared", &unmapped);
-        output->disconnect_signal("detach-view", &unmapped);
     }
 };
 
@@ -294,10 +292,10 @@ class wayfire_grid : public wf::plugin_interface_t
 
         output->add_activator(restore_opt, &restore);
 
-        output->connect_signal("reserved-workarea", &on_workarea_changed);
+        output->connect_signal("workarea-changed", &on_workarea_changed);
         output->connect_signal("view-snap", &on_snap_signal);
         output->connect_signal("query-snap-geometry", &on_snap_query);
-        output->connect_signal("view-maximized-request", &on_maximize_signal);
+        output->connect_signal("view-tile-request", &on_maximize_signal);
         output->connect_signal("view-fullscreen-request", &on_fullscreen_signal);
     }
 
@@ -357,7 +355,7 @@ class wayfire_grid : public wf::plugin_interface_t
 
     wf::signal_callback_t on_workarea_changed = [=] (wf::signal_data_t *data)
     {
-        auto ev = static_cast<reserved_workarea_signal*>(data);
+        auto ev = static_cast<wf::workarea_changed_signal*>(data);
         for (auto& view : output->workspace->get_views_in_layer(wf::LAYER_WORKSPACE))
         {
             if (!view->is_mapped())
@@ -408,7 +406,7 @@ class wayfire_grid : public wf::plugin_interface_t
 
     wf::signal_callback_t on_maximize_signal = [=] (wf::signal_data_t *ddata)
     {
-        auto data = static_cast<view_tiled_signal*>(ddata);
+        auto data = static_cast<wf::view_tile_request_signal*>(ddata);
 
         if (data->carried_out || (data->desired_size.width <= 0) ||
             !can_adjust_view(data->view))
@@ -430,7 +428,7 @@ class wayfire_grid : public wf::plugin_interface_t
 
     wf::signal_callback_t on_fullscreen_signal = [=] (wf::signal_data_t *ev)
     {
-        auto data = static_cast<view_fullscreen_signal*>(ev);
+        auto data = static_cast<wf::view_fullscreen_signal*>(ev);
         static const std::string fs_data_name = "grid-saved-fs";
 
         if (data->carried_out || (data->desired_size.width <= 0) ||
@@ -453,10 +451,10 @@ class wayfire_grid : public wf::plugin_interface_t
 
         output->rem_binding(&restore);
 
-        output->disconnect_signal("reserved-workarea", &on_workarea_changed);
+        output->disconnect_signal("workarea-changed", &on_workarea_changed);
         output->disconnect_signal("view-snap", &on_snap_signal);
         output->disconnect_signal("query-snap-geometry", &on_snap_query);
-        output->disconnect_signal("view-maximized-request", &on_maximize_signal);
+        output->disconnect_signal("view-tile-request", &on_maximize_signal);
         output->disconnect_signal("view-fullscreen-request", &on_fullscreen_signal);
     }
 };

--- a/plugins/single_plugins/place.cpp
+++ b/plugins/single_plugins/place.cpp
@@ -21,7 +21,7 @@ class wayfire_place_window : public wf::plugin_interface_t
 
         created_cb = [=] (wf::signal_data_t *data)
         {
-            auto ev   = (map_view_signal*)(data);
+            auto ev   = (wf::view_mapped_signal*)(data);
             auto view = get_signaled_view(data);
 
             if ((view->role != wf::VIEW_ROLE_TOPLEVEL) || view->parent ||
@@ -65,8 +65,8 @@ class wayfire_place_window : public wf::plugin_interface_t
             }
         };
 
-        output->connect_signal("reserved-workarea", &workarea_changed_cb);
-        output->connect_signal("map-view", &created_cb);
+        output->connect_signal("workarea-changed", &workarea_changed_cb);
+        output->connect_signal("view-mapped", &created_cb);
     }
 
     void cascade(wayfire_view & view, wf::geometry_t workarea)
@@ -125,8 +125,8 @@ class wayfire_place_window : public wf::plugin_interface_t
 
     void fini() override
     {
-        output->disconnect_signal("reserved-workarea", &workarea_changed_cb);
-        output->disconnect_signal("map-view", &created_cb);
+        output->disconnect_signal("workarea-changed", &workarea_changed_cb);
+        output->disconnect_signal("view-mapped", &created_cb);
     }
 };
 

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -116,7 +116,7 @@ class wayfire_resize : public wf::plugin_interface_t
         using namespace std::placeholders;
         resize_request = std::bind(std::mem_fn(&wayfire_resize::resize_requested),
             this, _1);
-        output->connect_signal("resize-request", &resize_request);
+        output->connect_signal("view-resize-request", &resize_request);
 
         view_destroyed = [=] (wf::signal_data_t *data)
         {
@@ -127,13 +127,12 @@ class wayfire_resize : public wf::plugin_interface_t
             }
         };
 
-        output->connect_signal("detach-view", &view_destroyed);
         output->connect_signal("view-disappeared", &view_destroyed);
     }
 
     void resize_requested(wf::signal_data_t *data)
     {
-        auto request = static_cast<resize_request_signal*>(data);
+        auto request = static_cast<wf::view_resize_request_signal*>(data);
         auto view    = get_signaled_view(data);
 
         if (!view)
@@ -348,8 +347,7 @@ class wayfire_resize : public wf::plugin_interface_t
         output->rem_binding(&activate_binding);
         output->rem_binding(&touch_activate_binding);
 
-        output->disconnect_signal("resize-request", &resize_request);
-        output->disconnect_signal("detach-view", &view_destroyed);
+        output->disconnect_signal("view-resize-request", &resize_request);
         output->disconnect_signal("view-disappeared", &view_destroyed);
     }
 };

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -119,7 +119,7 @@ class WayfireSwitcher : public wf::plugin_interface_t
         output->add_gesture(
             wf::option_wrapper_t<wf::touchgesture_t>{"switcher/gesture_toggle"},
             &touch_activate);
-        output->connect_signal("detach-view", &view_removed);
+        output->connect_signal("view-detached", &view_removed);
 
         grab_interface->callbacks.keyboard.mod = [=] (uint32_t mod, uint32_t state)
         {
@@ -872,7 +872,7 @@ class WayfireSwitcher : public wf::plugin_interface_t
         output->rem_binding(&next_view_binding);
         output->rem_binding(&prev_view_binding);
         output->rem_binding(&touch_activate);
-        output->disconnect_signal("detach-view", &view_removed);
+        output->disconnect_signal("view-detached", &view_removed);
     }
 };
 

--- a/plugins/single_plugins/vswitch.cpp
+++ b/plugins/single_plugins/vswitch.cpp
@@ -122,7 +122,7 @@ class vswitch : public wf::plugin_interface_t
         output->connect_signal("set-workspace-request", &on_set_workspace_request);
 
         output->connect_signal("view-disappeared", &on_grabbed_view_disappear);
-        output->connect_signal("detach-view", &on_grabbed_view_disappear);
+        output->connect_signal("view-detached", &on_grabbed_view_disappear);
 
         wall = std::make_unique<wf::workspace_wall_t>(output);
         wall->connect_signal("frame", &on_frame);
@@ -195,17 +195,16 @@ class vswitch : public wf::plugin_interface_t
         }
     };
 
-    wf::signal_connection_t on_set_workspace_request = {[=] (wf::signal_data_t *data)
+    wf::signal_connection_t on_set_workspace_request = [=] (wf::signal_data_t *data)
+    {
+        if (is_active())
         {
-            if (is_active())
-            {
-                return;
-            }
-
-            auto ev = static_cast<change_viewport_signal*>(data);
-            ev->carried_out = add_direction(ev->new_viewport.x - ev->old_viewport.x,
-                ev->new_viewport.y - ev->old_viewport.y);
+            return;
         }
+
+        auto ev = static_cast<wf::workspace_change_request_signal*>(data);
+        ev->carried_out = add_direction(ev->new_viewport.x - ev->old_viewport.x,
+            ev->new_viewport.y - ev->old_viewport.y);
     };
 
     bool start_switch()

--- a/plugins/single_plugins/window-rules.cpp
+++ b/plugins/single_plugins/window-rules.cpp
@@ -237,7 +237,7 @@ class wayfire_window_rules : public wf::plugin_interface_t
         {
             exec.action = [action] (wayfire_view view)
             {
-                view_fullscreen_signal data;
+                wf::view_fullscreen_signal data;
                 data.view  = view;
                 data.state = starts_with(action, "set");
                 view->get_output()->emit_signal("view-fullscreen-request", &data);
@@ -312,14 +312,14 @@ class wayfire_window_rules : public wf::plugin_interface_t
                 rule(get_signaled_view(data));
             }
         };
-        output->connect_signal("map-view", &created);
+        output->connect_signal("view-mapped", &created);
 
         maximized = [=] (wf::signal_data_t *data)
         {
-            auto conv = static_cast<view_tiled_signal*>(data);
+            auto conv = static_cast<wf::view_tiled_signal*>(data);
             assert(conv);
 
-            if (conv->edges != wf::TILED_EDGES_ALL)
+            if (conv->new_edges != wf::TILED_EDGES_ALL)
             {
                 return;
             }
@@ -333,7 +333,7 @@ class wayfire_window_rules : public wf::plugin_interface_t
 
         fullscreened = [=] (wf::signal_data_t *data)
         {
-            auto conv = static_cast<view_fullscreen_signal*>(data);
+            auto conv = static_cast<wf::view_fullscreen_signal*>(data);
             assert(conv);
 
             if (!conv->state || conv->carried_out)
@@ -353,7 +353,7 @@ class wayfire_window_rules : public wf::plugin_interface_t
 
     void fini()
     {
-        output->disconnect_signal("map-view", &created);
+        output->disconnect_signal("view-mapped", &created);
         output->disconnect_signal("view-maximized", &maximized);
         output->disconnect_signal("view-fullscreen", &fullscreened);
     }

--- a/plugins/wobbly/wobbly-signal.hpp
+++ b/plugins/wobbly/wobbly-signal.hpp
@@ -19,7 +19,7 @@ enum wobbly_corner
     WOBBLY_CORNER_BR = 3,
 };
 
-struct wobbly_signal : public _view_signal
+struct wobbly_signal : public wf::_view_signal
 {
     wobbly_event events;
     int grab_x, grab_y; // set only with events & WOBBLY_EVENT_GRAB

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -500,13 +500,13 @@ class wf_wobbly : public wf::view_transformer_t
 
     wf::signal_callback_t view_geometry_changed = [=] (wf::signal_data_t *data)
     {
-        auto sig = static_cast<view_geometry_changed_signal*>(data);
+        auto sig = static_cast<wf::view_geometry_changed_signal*>(data);
         state->handle_wm_geometry(sig->old_geometry);
     };
 
     wf::signal_callback_t view_output_changed = [=] (wf::signal_data_t *data)
     {
-        auto sig = static_cast<_output_signal*>(data);
+        auto sig = static_cast<wf::_output_signal*>(data);
 
         if (!view->get_output())
         {
@@ -562,7 +562,7 @@ class wf_wobbly : public wf::view_transformer_t
         pre_hook = [=] () { update_model(); };
         view->get_output()->render->add_effect(&pre_hook, wf::OUTPUT_EFFECT_PRE);
 
-        view->connect_signal("unmap", &view_removed);
+        view->connect_signal("unmapped", &view_removed);
         view->connect_signal("tiled", &view_state_changed);
         view->connect_signal("fullscreen", &view_state_changed);
         view->connect_signal("set-output", &view_output_changed);
@@ -774,7 +774,7 @@ class wf_wobbly : public wf::view_transformer_t
         wobbly_fini(model.get());
         view->get_output()->render->rem_effect(&pre_hook);
 
-        view->disconnect_signal("unmap", &view_removed);
+        view->disconnect_signal("unmapped", &view_removed);
         view->disconnect_signal("tiled", &view_state_changed);
         view->disconnect_signal("fullscreen", &view_state_changed);
         view->disconnect_signal("set-output", &view_output_changed);

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -4,164 +4,148 @@
 #include "wayfire/view.hpp"
 #include "wayfire/output.hpp"
 
-/*
- * signal definitions
- * convenience functions are provided to get some basic info from the signal
- */
-struct _view_signal : public wf::signal_data_t
-{
-    wayfire_view view;
-};
-wayfire_view get_signaled_view(wf::signal_data_t *data);
-
 /**
- * attach-view is a signal emitted by an output. It is emitted whenever a view's
- * output is set to the given output.
+ * Documentation of signals emitted from core components.
+ * Each signal documentation follows the following scheme:
  *
- * layer-attach-view is a signal emitted by an output. It is emitted whenever a
- * view is added to a layer on the output, where it was not in any layer on the
- * output previously.
+ * name: The base name of the signal
+ * on: Which components the plugin is emitted on. Prefixes are specified
+ *     in (), i.e test(view-) means that the signal is emitted on component
+ *     test with prefix 'view-'.
+ * when: Description of when the signal is emitted.
+ * argument: What the signal data represents when there is no dedicated
+ *   signal data struct.
  */
-using attach_view_signal = _view_signal;
+
+namespace wf
+{
+/* ----------------------------------------------------------------------------/
+ * Core signals
+ * -------------------------------------------------------------------------- */
 
 /**
- * detach-view is a signal emitted by an output. It is emitted whenever a view's
- * output is no longer the given output, or the view is about to be destroyed.
- *
- * layer-detach-view is a signal emitted by an output. It is emitted whenever a
- * view is no longer in a layer of the given output.
+ * name: shutdown
+ * on: core
+ * when: Right before the shutdown sequence starts.
+ * argument: unused
  */
-using detach_view_signal    = _view_signal;
-using unmap_view_signal     = _view_signal;
-using pre_unmap_view_signal = _view_signal;
 
-struct map_view_signal : public _view_signal
+class input_device_t;
+/**
+ * name: input-device-added, input-device-removed
+ * on: core
+ * when: Whenever a new input device is added or removed.
+ */
+struct input_device_signal : public wf::signal_data_t
 {
-    /* Indicates whether the position already has its initial posittion */
-    bool is_positioned = false;
-};
-
-/* Indicates the view is no longer available, for ex. it has been minimized
- * or unmapped */
-using view_disappeared_signal = _view_signal;
-
-using focus_view_signal = _view_signal;
-using view_set_parent_signal = _view_signal;
-using move_request_signal    = _view_signal;
-using title_changed_signal   = _view_signal;
-using app_id_changed_signal  = _view_signal;
-
-struct resize_request_signal : public _view_signal
-{
-    uint32_t edges;
-};
-
-/* sent when the view geometry changes */
-struct view_geometry_changed_signal : public _view_signal
-{
-    wf::geometry_t old_geometry;
-};
-
-struct view_tiled_signal : public _view_signal
-{
-    uint32_t edges;
-    bool carried_out = false;
-    wf::geometry_t desired_size;
+    nonstd::observer_ptr<input_device_t> device;
 };
 
 /**
- * view-self-request-focus signal is emitted on the view's output whenever the client
- * indicates the
- * view should become active.
+ * name: tablet-mode, lid-state
+ * on: core
+ * when: When the corresponding switch device state changes.
  */
-struct view_self_request_focus_signal : public _view_signal
-{};
-
-/**
- * view-system-bell signal is emitted whenever the client indicates
- * the view wants to invoke the system bell if such is available.
- *
- * Note: system-bell may be invoked with a nullptr view.
- */
-struct view_system_bell_signal : public _view_signal
-{};
-
-/**
- * The view-fullscreen-request and view-fullscreen signals are emitted on the view's
- * output when the view's fullscreen state changes.
- * view-fullscreen-request is emitted when the view needs to be fullscreened, but has
- * not been fullscreened yet.
- * view-fullscreen is emitted whenever the view's fullscreen state actually changes.
- * state is true if the view is fullscreen and false otherwise.
- * carried_out should be set by the listener if it handles the signal,
- * by setting the view fullscreen.
- * desired_size is the intended size for the fullscreen view
- * but may be undefined (0,0 0x0).
- */
-struct view_fullscreen_signal : public _view_signal
+struct switch_signal : public wf::signal_data_t
 {
-    bool state;
-    bool carried_out = false;
-    wf::geometry_t desired_size;
-};
-
-struct view_minimize_request_signal : public _view_signal
-{
-    bool state;
-    /* If some plugin wants to delay the (un)minimize of the view, it needs to
-    * listen for the view-minimize-request and set carried_out to true.
-    * It is a hint to core that the action will be (or already was) performed
-    * by a plugin, and minimized state shouldn't be further changed by core */
-    bool carried_out = false;
-};
-
-/* view-minimized: sent on view minimize state change
- * In contrast to view_minimize_request_signal, this signal is sent after
- * the minimized state has been finalized. */
-struct view_minimized_signal : public _view_signal
-{
+    /** The switch device */
+    nonstd::observer_ptr<input_device_t> device;
+    /** On or off */
     bool state;
 };
 
-/* same as both change_viewport_request and change_viewport_notify */
-struct change_viewport_signal : public wf::signal_data_t
+/**
+ * name:
+ *   pointer_motion, pointer_motion_abs, pointer_button, pointer_axis,
+ *   pointer_swipe_begin, pointer_swipe_update, pointer_swipe_end,
+ *   pointer_pinch_begin, pointer_pinch_update, pointer_pinch_end,
+ *   keyboard_key,
+ *   touch_down, touch_up, touch_motion,
+ *   tablet_proximity, tablet_axis, tablet_button, tablet_tip
+ *
+ * on: core
+ * when: The input event signals are sent from core whenever a new input from an
+ *   input device arrives. The events are sent before any processing is done,
+ *   and they are independent of plugin input grabs and other wayfire input
+ *   mechanisms.
+ *
+ *   The event data can be modified by plugins, and then the modified event
+ *   will be used instead. However plugins which modify the event must ensure
+ *   that subsequent events are adjusted accordingly as well.
+ *
+ * example: The pointer_motion event is emitted with data of type
+ *   input_event_signal<wlr_event_pointer_motion>
+ */
+template<class wlr_event_t>
+struct input_event_signal : public wf::signal_data_t
 {
-    bool carried_out;
-    wf::point_t old_viewport, new_viewport;
-    wf::output_t *output;
+    /* The event as it has arrived from wlroots */
+    wlr_event_t *event;
 };
-using change_viewport_notify = change_viewport_signal;
 
-/* sent when the workspace implementation actually reserves the workarea */
-struct reserved_workarea_signal : public wf::signal_data_t
+/**
+ * name: drag-started, drag-stopped
+ * on: core
+ * when: When a DnD action is started/stopped
+ */
+struct dnd_signal : public wf::signal_data_t
 {
-    wf::geometry_t old_workarea;
-    wf::geometry_t new_workarea;
+    /** The DnD icon */
+    wf::surface_interface_t *icon;
 };
 
-// TODO: this is a private signal, maybe we should hide it? */
-struct _surface_map_state_changed_signal : public wf::signal_data_t
+/**
+ * name: surface-mapped, surface-unmapped
+ * on: core
+ * when: Whenever a surface map state changes. This must be emitted for all
+ *   surfaces regardless of their type (view, subsurface, etc).
+ */
+struct surface_map_state_changed_signal : public wf::signal_data_t
 {
     wf::surface_interface_t *surface;
 };
 
-/* Part 2: Signals from wf::output_layout_t */
+/**
+ * name: reload-config
+ * on: core
+ * when: When the config file is reloaded
+ * argument: unused
+ */
+
+/* ----------------------------------------------------------------------------/
+ * Output signals
+ * -------------------------------------------------------------------------- */
+
+/** Base class for all output signals. */
 struct _output_signal : public wf::signal_data_t
 {
     wf::output_t *output;
 };
 
-wf::output_t *get_signaled_output(wf::signal_data_t *data);
+/** @return The output in the signal. Must be an _output_signal. */
+output_t *get_signaled_output(signal_data_t *data);
 
-using output_added_signal   = _output_signal;
+/**
+ * name: output-added
+ * on: output-layout
+ * when: Each time a new output is added.
+ */
+using output_added_signal = _output_signal;
+
+/**
+ * name: pre-remove
+ * on: output, output-layout(output-)
+ * when: Emitted just before starting the destruction procedure for an output.
+ */
+using output_pre_remove_signal = _output_signal;
+
+/**
+ * name: output-removed
+ * on: output-layout
+ * when: Each time a new output is added.
+ */
 using output_removed_signal = _output_signal;
 
-namespace wf
-{
-/**
- * output-configuration-changed is a signal emitted on an output whenever the
- * output's source, mode, scale or transform changes.
- */
 enum output_config_field_t
 {
     /** Output source changed */
@@ -177,6 +161,13 @@ enum output_config_field_t
 };
 
 struct output_state_t;
+
+/**
+ * name: configuration-changed
+ * on: output, output-layout(output-)
+ * when: Each time the output's source, mode, scale, transform and/or position
+ *   changes.
+ */
 struct output_configuration_changed_signal : public _output_signal
 {
     output_configuration_changed_signal(const wf::output_state_t& st) :
@@ -194,80 +185,405 @@ struct output_configuration_changed_signal : public _output_signal
     const wf::output_state_t& state;
 };
 
-class input_device_t;
-/* Used in the tablet-mode and lid-state signals from core */
-struct switch_signal : public wf::signal_data_t
+/**
+ * name: gain-focus
+ * on: output, core(output-)
+ * when: Immediately after the output becomes focused.
+ */
+using output_gain_focus_signal = _output_signal;
+
+/* ----------------------------------------------------------------------------/
+ * Output rendering signals (see also wayfire/workspace-stream.hpp)
+ * -------------------------------------------------------------------------- */
+/**
+ * name: start-rendering
+ * on: output
+ * when: Whenever the output is ready to start rendering. This can happen
+ *   either on output creation or whenever all inhibits in wayfire-shell have
+ *   been removed.
+ */
+using output_start_rendering_signal = _output_signal;
+
+/* ----------------------------------------------------------------------------/
+ * Output workspace signals
+ * -------------------------------------------------------------------------- */
+
+/**
+ * name: workspace-changed
+ * on: output
+ * when: Whenever the current workspace on the output has changed.
+ */
+struct workspace_changed_signal : public wf::signal_data_t
 {
-    nonstd::observer_ptr<input_device_t> device;
+    /** For workspace-change-request, whether the request has already been
+     * handled. */
+    bool carried_out;
+
+    /** Previously focused workspace */
+    wf::point_t old_viewport;
+
+    /** Workspace that is to be focused or became focused */
+    wf::point_t new_viewport;
+
+    /** The output this is happening on */
+    wf::output_t *output;
+};
+
+/**
+ * name: workspace-change-request
+ * on: output
+ * when: Whenever a workspace change is requested by core or by a plugin.
+ *   This can be used by plugins who wish to handle workspace changing
+ *   themselves, for ex. if animating the transition.
+ */
+using workspace_change_request_signal = workspace_changed_signal;
+
+/**
+ * name: workarea-changed
+ * on: output
+ * when: Whenever the available workarea changes.
+ */
+struct workarea_changed_signal : public wf::signal_data_t
+{
+    wf::geometry_t old_workarea;
+    wf::geometry_t new_workarea;
+};
+
+/**
+ * name: fullscreen-layer-focused
+ * on: output
+ * when: Whenever a fullscreen view is promoted on top of the other layers.
+ * argument: The event data pointer is null if there are no promoted views,
+ *   and not-null otherwise.
+ */
+
+/* ----------------------------------------------------------------------------/
+ * View signals
+ * -------------------------------------------------------------------------- */
+
+/** Base class for all view signals. */
+struct _view_signal : public wf::signal_data_t
+{
+    wayfire_view view;
+};
+
+/**
+ * @return The view contained in the signal data, it must be
+ * a _view_signal.
+ */
+wayfire_view get_signaled_view(wf::signal_data_t *data);
+
+/**
+ * name: mapped
+ * on: view, output(view-)
+ * when: After the view becomes mapped. This signal must also be emitted from
+ *   all compositor views.
+ */
+struct view_mapped_signal : public _view_signal
+{
+    /* Indicates whether the position already has its initial position */
+    bool is_positioned = false;
+};
+
+/**
+ * name: pre-unmapped
+ * on: view, output(view-)
+ * when: Immediately before unmapping a mapped view. The signal may not be
+ *   emitted from all views, but it is necessary for unmap animations to work.
+ */
+using view_pre_unmap_signal = _view_signal;
+
+/**
+ * name: unmapped
+ * on: view, output(view-)
+ * when: After a previously mapped view becomes unmapped. This must be emitted
+ *   for all views.
+ */
+using view_unmapped_signal = _view_signal;
+
+/**
+ * name: set-output
+ * on: view
+ * when: Immediately after the view's output changes. Note that child views may
+ *   still be on the old output.
+ * argument: The old output of the view.
+ */
+using view_set_output_signal = _output_signal;
+
+/* ----------------------------------------------------------------------------/
+ * View state signals
+ * -------------------------------------------------------------------------- */
+
+/**
+ * name: minimized
+ * on: view, output(view-)
+ * when: After the view's minimized state changes.
+ */
+struct view_minimized_signal : public _view_signal
+{
+    /** true is minimized, false is restored */
     bool state;
 };
 
-/* in input-device-added and input-device-removed signals from core */
-struct input_device_signal : public signal_data_t
+/**
+ * name: view-minimize-request
+ * on: output
+ * when: Emitted whenever some entity requests that the view's minimized state
+ *   changes. If no plugin is available to service the request, it is carried
+ *   out by core. See view_interface_t::minimize_request()
+ */
+struct view_minimize_request_signal : public _view_signal
 {
-    nonstd::observer_ptr<input_device_t> device;
+    /** true is minimized, false is restored */
+    bool state;
+
+    /**
+     * Whether some plugin will service the minimization request, in which
+     * case other plugins and core should ignore the request.
+     */
+    bool carried_out = false;
 };
 
 /**
- * Used for the following events:
- *
- * pointer_motion, pointer_motion_abs, pointer_button, pointer_axis,
- * pointer_swipe_begin, pointer_swipe_update, pointer_swipe_end,
- * pointer_pinch_begin, pointer_pinch_update, pointer_pinch_end,
- *
- * keyboard_key,
- *
- * touch_down, touch_up, touch_motion,
- *
- * tablet_proximity, tablet_axis, tablet_button, tablet_tip
- *
- * The template parameter is the corresponding type of wlr events.
- *
- * The input event signals are sent from core whenever a new input from an
- * input device arrives. The events are sent before any processing is done,
- * and they are independent of plugin input grabs and other wayfire input
- * mechanisms.
- *
- * The event data can be modified by plugins, and then the modified event
- * will be used instead. However plugins which modify the event must ensure
- * that subsequent events are adjusted accordingly as well.
+ * name: tiled
+ * on: view, output(view-)
+ * when: After the view's tiled edges change.
  */
-template<class wlr_event_t>
-struct input_event_signal : public wf::signal_data_t
+struct view_tiled_signal : public _view_signal
 {
-    /* The event as it has arrived from wlroots */
-    wlr_event_t *event;
+    /** Previously tiled edges */
+    uint32_t old_edges;
+    /** Currently tiled edges */
+    uint32_t new_edges;
 };
 
 /**
- * decoration-state-updated signal is emitted when the value of
- * view::should_be_decorated() changes.
- *
- * decoration-state-updated-view is emitted on the output of the view.
+ * name: view-tile-request
+ * on: output
+ * when: Emitted whenever some entity requests that the view's tiled edges
+ *   change. If no plugin is available to service the request, it is carried
+ *   out by core. See view_interface_t::tile_request()
  */
-using decoration_state_updated_signal = _view_signal;
+struct view_tile_request_signal : public _view_signal
+{
+    /** The desired edges */
+    uint32_t edges;
+
+    /**
+     * The geometry the view should have. This is for example the last geometry
+     * a view had before being tiled.  The given geometry is only a hint by core
+     * and plugins may override it. It may also be undefined (0,0 0x0).
+     */
+    wf::geometry_t desired_size;
+
+    /**
+     * Whether some plugin will service the tile request, in which case other
+     * plugins and core should ignore the request.
+     */
+    bool carried_out = false;
+};
+
 
 /**
- * view-move-to-output signal is emitted by core just before a view is moved
- * from one output to another.
+ * name: fullscreen
+ * on: view, output(view-)
+ * when: After the view's fullscreen state changes.
  */
-struct view_move_to_output_signal : public signal_data_t
+struct view_fullscreen_signal : public _view_signal
+{
+    /** The desired fullscreen state */
+    bool state;
+
+    /**
+     * For view-fullscreen-request:
+     *
+     * Whether some plugin will service the fullscreen request, in which case
+     * other plugins and core should ignore the request.
+     */
+    bool carried_out = false;
+
+    /**
+     * For view-fullscreen-request:
+     *
+     * The geometry the view should have. This is for example the last geometry
+     * a view had before being fullscreened. The given geometry is only a hint
+     * by core and plugins may override it. It may also be undefined (0,0 0x0).
+     */
+    wf::geometry_t desired_size;
+};
+
+/**
+ * name: view-fullscreen-request
+ * on: output
+ * when: Emitted whenever some entity requests that the view's fullscreen state
+ *   change. If no plugin is available to service the request, it is carried
+ *   out by core. See view_interface_t::fullscreen_request()
+ */
+using view_fullscreen_request_signal = view_fullscreen_signal;
+
+/**
+ * name: title-changed
+ * on: view
+ * when: After the view's title has changed.
+ */
+using title_changed_signal = _view_signal;
+
+/**
+ * name: app-id-changed
+ * on: view
+ * when: After the view's app-id has changed.
+ */
+using app_id_changed_signal = _view_signal;
+
+/**
+ * name: geometry-changed
+ * on: view
+ * when: Whenever the view's wm geometry changes.
+ */
+struct view_geometry_changed_signal : public _view_signal
+{
+    /** The old wm geometry */
+    wf::geometry_t old_geometry;
+};
+
+/**
+ * name: region-damaged
+ * on: view
+ * when: Whenever a region of the view becomes damaged, for ex. when the client
+ *   updates its contents.
+ * argument: Unused.
+ */
+
+/**
+ * name: decoration-state-updated
+ * on: view, output(view-)
+ * when: Whenever the value of view::should_be_decorated() changes.
+ */
+using view_decoration_state_updated_signal = _view_signal;
+
+/**
+ * name: decoration-changed
+ * on: view
+ * when: Whenever the view's decoration changes.
+ * argument: unused.
+ */
+
+/* ----------------------------------------------------------------------------/
+ * View <-> output signals
+ * -------------------------------------------------------------------------- */
+
+/**
+ * name: view-attached
+ * on: output
+ * when: As soon as the view's output is set to the given output. This is the
+ *   first point where the view is considered to be part of that output.
+ */
+using view_attached_signal = _view_signal;
+
+/**
+ * name: view-layer-attached
+ * on: output
+ * when: Emitted when the view is added to a layer in the output's workspace
+ *   manager and it was in no layer previously.
+ */
+using view_layer_attached_signal = _view_signal;
+
+/**
+ * name: view-detached
+ * on: output
+ * when: Emitted when the view's output is about to be changed to another one.
+ *   This is the last point where the view is considered to be part of the given
+ *   output.
+ */
+using view_detached_signal = _view_signal;
+
+/**
+ * name: view-layer-detached
+ * on: output
+ * when: Emitted when the view is removed from a layer but is not added to
+ *   another.
+ */
+using view_layer_detached_signal = _view_signal;
+
+/**
+ * name: view-pre-moved-to-output
+ * on: core
+ * when: Immediately before the view is moved to another output. The usual
+ *   sequence when moving views to another output is:
+ *
+ *   pre-moved-to-output -> layer-detach -> detach ->
+ *      attach -> layer-attach -> moved-to-output
+ */
+struct view_pre_moved_to_output_signal : public signal_data_t
 {
     /* The view being moved */
     wayfire_view view;
-    /* The output the view was on */
+    /* The output the view was on, may be NULL. */
     wf::output_t *old_output;
     /* The output the view is being moved to. */
     wf::output_t *new_output;
 };
 
 /**
- * stack-order-changed is emitted whenever the stacking order changes in the
- * workspace-manager of an output.
+ * name: view-moved-to-output
+ * on: core
+ * when: After the view has been moved to a new output.
  */
-struct stack_order_changed_signal : public signal_data_t
+using view_moved_to_output_signal = view_pre_moved_to_output_signal;
+
+/**
+ * name: view-disappeared
+ * on: output
+ * when: This is a signal which combines view-unmapped, view-detached and
+ *   view-minimized, and is emitted together with each of these three. Semantic
+ *   meaning is that the view is no longer available for focus, interaction with
+ *   the user, etc.
+ */
+using view_disappeared_signal = _view_signal;
+
+/**
+ * name: view-focused
+ * on: output
+ * when: As soon as the output focus changes.
+ * argument: The newly focused view.
+ */
+using focus_view_signal = _view_signal;
+
+/**
+ * name: view-move-request
+ * on: output
+ * when: Whenever an interactive move is requested on the view. See also
+ *   view_interface_t::move_request()
+ */
+using view_move_request_signal = _view_signal;
+
+/**
+ * name: view-resize-request
+ * on: output
+ * when: Whenever an interactive resize is requested on the view. See also
+ *   view_interface_t::resize_request()
+ */
+struct view_resize_request_signal : public _view_signal
 {
-    /* Empty */ };
+    /** The requested resize edges */
+    uint32_t edges;
+};
+
+/**
+ * name: view-self-request-focus
+ * on: output
+ * when: Whenever the client requests that a view be focused.
+ */
+using view_self_request_focus_signal = _view_signal;
+
+/**
+ * name: view-system-bell
+ * on: core
+ * when: Whenever a client wants to invoke the system bell if such is available.
+ *   Note the system bell may or may not be tied to a particular view, so the
+ *   signal may be emitted with a nullptr view.
+ */
+using view_system_bell_signal = _view_signal;
 }
 
 #endif

--- a/src/api/wayfire/workspace-stream.hpp
+++ b/src/api/wayfire/workspace-stream.hpp
@@ -28,7 +28,11 @@ struct workspace_stream_t
     wf::color_t background = {0.0f, 0.0f, 0.0f, -1.0f};
 };
 
-/** Emitted whenever a workspace stream is being started or stopped */
+/**
+ * name: workspace-stream-pre, workspace-stream-post
+ * on: render-manager
+ * when: Immediately before(after) repainting a workspace stream.
+ */
 struct stream_signal_t : public wf::signal_data_t
 {
     stream_signal_t(wf::point_t _ws, wf::region_t& damage,

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -466,7 +466,11 @@ void wf::compositor_core_impl_t::focus_output(wf::output_t *wo)
     }
 
     wlr_output_schedule_frame(active_output->handle);
-    active_output->emit_signal("output-gain-focus", nullptr);
+
+    wf::output_gain_focus_signal data;
+    data.output = active_output;
+    active_output->emit_signal("gain-focus", &data);
+    this->emit_signal("output-gain-focus", &data);
 }
 
 wf::output_t*wf::compositor_core_impl_t::get_active_output()
@@ -716,11 +720,11 @@ void wf::compositor_core_impl_t::move_view_to_output(wayfire_view v,
     wf::output_t *new_output, bool reconfigure)
 {
     auto old_output = v->get_output();
-    wf::view_move_to_output_signal data;
+    wf::view_pre_moved_to_output_signal data;
     data.view = v;
     data.old_output = old_output;
     data.new_output = new_output;
-    this->emit_signal("view-move-to-output", &data);
+    this->emit_signal("view-pre-moved-to-output", &data);
 
     uint32_t edges;
     bool fullscreen;
@@ -763,6 +767,8 @@ void wf::compositor_core_impl_t::move_view_to_output(wayfire_view v,
             v->set_geometry(new_g);
         }
     }
+
+    this->emit_signal("view-moved-to-output", &data);
 }
 
 wf::compositor_core_t::compositor_core_t()

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -571,7 +571,7 @@ struct output_layout_output_t
         LOGE("disabling output: ", output->handle->name);
 
         auto wo = output.get();
-        output_removed_signal data;
+        output_pre_remove_signal data;
         data.output = wo;
 
         wo->emit_signal("pre-remove", &data);

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -62,9 +62,11 @@ void wf::plugin_interface_t::fini()
 wf::plugin_interface_t::~plugin_interface_t()
 {}
 
+namespace wf
+{
 wayfire_view get_signaled_view(wf::signal_data_t *data)
 {
-    auto conv = static_cast<_view_signal*>(data);
+    auto conv = static_cast<wf::_view_signal*>(data);
     if (!conv)
     {
         LOGE("Got a bad _view_signal");
@@ -77,7 +79,8 @@ wayfire_view get_signaled_view(wf::signal_data_t *data)
 
 wf::output_t *get_signaled_output(wf::signal_data_t *data)
 {
-    auto result = static_cast<_output_signal*>(data);
+    auto result = static_cast<wf::_output_signal*>(data);
 
     return result ? result->output : nullptr;
+}
 }

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -182,7 +182,7 @@ input_manager::input_manager()
     create_seat();
     surface_map_state_changed = [=] (wf::signal_data_t *data)
     {
-        auto ev = static_cast<_surface_map_state_changed_signal*>(data);
+        auto ev = static_cast<wf::surface_map_state_changed_signal*>(data);
         if (our_touch)
         {
             if (ev && (our_touch->grabbed_surface == ev->surface) &&
@@ -199,8 +199,8 @@ input_manager::input_manager()
             }
         }
     };
-    wf::get_core().connect_signal("_surface_mapped", &surface_map_state_changed);
-    wf::get_core().connect_signal("_surface_unmapped", &surface_map_state_changed);
+    wf::get_core().connect_signal("surface-mapped", &surface_map_state_changed);
+    wf::get_core().connect_signal("surface-unmapped", &surface_map_state_changed);
 
     config_updated = [=] (wf::signal_data_t*)
     {
@@ -233,9 +233,9 @@ input_manager::input_manager()
 input_manager::~input_manager()
 {
     wf::get_core().disconnect_signal("reload-config", &config_updated);
-    wf::get_core().disconnect_signal("_surface_mapped",
+    wf::get_core().disconnect_signal("surface-mapped",
         &surface_map_state_changed);
-    wf::get_core().disconnect_signal("_surface_unmapped",
+    wf::get_core().disconnect_signal("surface-unmapped",
         &surface_map_state_changed);
     wf::get_core().output_layout->disconnect_signal(
         "output-added", &output_added);
@@ -527,22 +527,22 @@ wf::SurfaceMapStateListener::SurfaceMapStateListener()
     {
         if (this->callback)
         {
-            auto ev = static_cast<_surface_map_state_changed_signal*>(data);
+            auto ev = static_cast<surface_map_state_changed_signal*>(data);
             this->callback(ev ? ev->surface : nullptr);
         }
     };
 
-    wf::get_core().connect_signal("_surface_mapped",
+    wf::get_core().connect_signal("surface-mapped",
         &on_surface_map_state_change);
-    wf::get_core().connect_signal("_surface_unmapped",
+    wf::get_core().connect_signal("surface-unmapped",
         &on_surface_map_state_change);
 }
 
 wf::SurfaceMapStateListener::~SurfaceMapStateListener()
 {
-    wf::get_core().disconnect_signal("_surface_mapped",
+    wf::get_core().disconnect_signal("surface-mapped",
         &on_surface_map_state_change);
-    wf::get_core().disconnect_signal("_surface_unmapped",
+    wf::get_core().disconnect_signal("surface-unmapped",
         &on_surface_map_state_change);
 }
 

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -21,8 +21,10 @@ wf_drag_icon::wf_drag_icon(wlr_drag_icon *ic) :
     {
         /* we don't dec_keep_count() because the surface memory is
          * managed by the unique_ptr */
+        wf::dnd_signal data;
+        data.icon = wf::get_core_impl().input->drag_icon.get();
+        wf::get_core().emit_signal("drag-stopped", &data);
         wf::get_core_impl().input->drag_icon = nullptr;
-        wf::get_core().emit_signal("drag-stopped", nullptr);
     });
 
     on_map.connect(&icon->events.map);
@@ -139,7 +141,10 @@ void input_manager::create_seat()
         auto d = static_cast<wlr_drag*>(data);
         wf::get_core_impl().input->drag_icon =
             std::make_unique<wf_drag_icon>(d->icon);
-        wf::get_core().emit_signal("drag-started", nullptr);
+
+        wf::dnd_signal evdata;
+        evdata.icon = wf::get_core_impl().input->drag_icon.get();
+        wf::get_core().emit_signal("drag-started", &evdata);
     });
     start_drag.connect(&seat->events.start_drag);
 

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -37,7 +37,7 @@ wf::tablet_tool_t::tablet_tool_t(wlr_tablet_tool *tool,
      * surface. */
     on_surface_map_state_changed = [=] (signal_data_t *data)
     {
-        auto ev = static_cast<_surface_map_state_changed_signal*>(data);
+        auto ev = static_cast<surface_map_state_changed_signal*>(data);
         if (!ev->surface->is_mapped() && (ev->surface == this->grabbed_surface))
         {
             this->grabbed_surface = nullptr;
@@ -46,9 +46,9 @@ wf::tablet_tool_t::tablet_tool_t(wlr_tablet_tool *tool,
         update_tool_position();
     };
 
-    wf::get_core().connect_signal("_surface_mapped",
+    wf::get_core().connect_signal("surface-mapped",
         &on_surface_map_state_changed);
-    wf::get_core().connect_signal("_surface_unmapped",
+    wf::get_core().connect_signal("surface-unmapped",
         &on_surface_map_state_changed);
 
     /* Just pass cursor set requests to core, but translate them to
@@ -89,9 +89,9 @@ wf::tablet_tool_t::tablet_tool_t(wlr_tablet_tool *tool,
 
 wf::tablet_tool_t::~tablet_tool_t()
 {
-    wf::get_core().disconnect_signal("_surface_mapped",
+    wf::get_core().disconnect_signal("surface-mapped",
         &on_surface_map_state_changed);
-    wf::get_core().disconnect_signal("_surface_unmapped",
+    wf::get_core().disconnect_signal("surface-unmapped",
         &on_surface_map_state_changed);
 
     tool->data = NULL;

--- a/src/output/gtk-shell.cpp
+++ b/src/output/gtk-shell.cpp
@@ -81,7 +81,7 @@ static void handle_gtk_surface_present(wl_client *client, wl_resource *resource,
     wayfire_view view = wf::wl_surface_to_wayfire_view(surface);
     if (view)
     {
-        view_self_request_focus_signal data;
+        wf::view_self_request_focus_signal data;
         data.view = view;
         view->get_output()->emit_signal("view-self-request-focus", &data);
     }
@@ -101,7 +101,7 @@ static void handle_gtk_surface_request_focus(struct wl_client *client,
     wayfire_view view = wf::wl_surface_to_wayfire_view(surface);
     if (view)
     {
-        view_self_request_focus_signal data;
+        wf::view_self_request_focus_signal data;
         data.view = view;
         view->get_output()->emit_signal("view-self-request-focus", &data);
     }
@@ -168,7 +168,7 @@ static void handle_gtk_shell_set_startup_id(wl_client *client, wl_resource *reso
 static void handle_gtk_shell_system_bell(wl_client *client, wl_resource *resource,
     wl_resource *surface)
 {
-    view_system_bell_signal data;
+    wf::view_system_bell_signal data;
     if (surface)
     {
         auto wl_surface =

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -36,7 +36,6 @@ wf::output_impl_t::output_impl_t(wlr_output *handle,
     };
 
     connect_signal("view-disappeared", &view_disappeared_cb);
-    connect_signal("detach-view", &view_disappeared_cb);
 }
 
 void wf::output_impl_t::start_plugins()
@@ -292,7 +291,7 @@ void wf::output_impl_t::focus_view(wayfire_view v, uint32_t flags)
 
         focus_view_signal data;
         data.view = v;
-        emit_signal("focus-view", &data);
+        emit_signal("view-focused", &data);
     }
 }
 

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -476,7 +476,10 @@ class wf::render_manager::impl
         if (output_inhibit_counter == 0)
         {
             output_damage->damage_whole_idle();
-            output->emit_signal("start-rendering", nullptr);
+
+            wf::output_start_rendering_signal data;
+            data.output = output;
+            output->emit_signal("start-rendering", &data);
         }
     }
 

--- a/src/output/wayfire-shell.cpp
+++ b/src/output/wayfire-shell.cpp
@@ -130,7 +130,7 @@ class wfs_hotspot : public noncopyable_t
         // setup output destroy listener
         on_output_removed = [this, output] (wf::signal_data_t *data)
         {
-            auto ev = static_cast<output_removed_signal*>(data);
+            auto ev = static_cast<wf::output_removed_signal*>(data);
             if (ev->output == output)
             {
                 /* Make hotspot inactive by setting the region to empty */
@@ -200,7 +200,7 @@ class wfs_output : public noncopyable_t
 
     wf::signal_callback_t on_output_removed = [=] (wf::signal_data_t *data)
     {
-        auto ev = static_cast<output_removed_signal*>(data);
+        auto ev = static_cast<wf::output_removed_signal*>(data);
         if (ev->output == this->output)
         {
             disconnect_from_output();
@@ -346,14 +346,14 @@ class wfs_surface : public noncopyable_t
         wl_resource_set_implementation(resource, &zwf_surface_impl,
             this, handle_surface_destroy);
 
-        view->connect_signal("unmap", &on_unmap);
+        view->connect_signal("unmapped", &on_unmap);
     }
 
     ~wfs_surface()
     {
         if (this->view)
         {
-            view->disconnect_signal("unmap", &on_unmap);
+            view->disconnect_signal("unmapped", &on_unmap);
         }
     }
 

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -619,7 +619,7 @@ class output_viewport_manager_t
             return;
         }
 
-        change_viewport_signal data;
+        wf::workspace_changed_signal data;
         data.old_viewport = {current_vx, current_vy};
         data.new_viewport = {nws.x, nws.y};
 
@@ -767,13 +767,13 @@ class output_workarea_manager_t
             }
         }
 
-        reserved_workarea_signal data;
+        wf::workarea_changed_signal data;
         data.old_workarea = old_workarea;
         data.new_workarea = current_workarea;
 
         if (data.old_workarea != data.new_workarea)
         {
-            output->emit_signal("reserved-workarea", &data);
+            output->emit_signal("workarea-changed", &data);
         }
     }
 };
@@ -842,7 +842,7 @@ class workspace_manager::impl
         o->connect_signal("view-change-viewport", &view_changed_viewport);
         o->connect_signal("output-configuration-changed", &output_geometry_changed);
         o->connect_signal("view-fullscreen", &on_view_state_updated);
-        o->connect_signal("unmap-view", &on_view_state_updated);
+        o->connect_signal("view-unmapped", &on_view_state_updated);
     }
 
     workspace_implementation_t *get_implementation()
@@ -898,7 +898,7 @@ class workspace_manager::impl
             return;
         }
 
-        change_viewport_signal data;
+        wf::workspace_change_request_signal data;
         data.carried_out  = false;
         data.old_viewport = viewport_manager.get_current_workspace();
         data.new_viewport = ws;
@@ -941,9 +941,9 @@ class workspace_manager::impl
 
     void handle_view_first_add(wayfire_view view)
     {
-        attach_view_signal data;
+        view_layer_attached_signal data;
         data.view = view;
-        output->emit_signal("layer-attach-view", &data);
+        output->emit_signal("view-layer-attached", &data);
     }
 
     void add_view_to_layer(wayfire_view view, layer_t layer)
@@ -1036,9 +1036,9 @@ class workspace_manager::impl
         uint32_t view_layer = layer_manager.get_view_layer(view);
         layer_manager.remove_view(view);
 
-        detach_view_signal data;
+        view_layer_detached_signal data;
         data.view = view;
-        output->emit_signal("layer-detach-view", &data);
+        output->emit_signal("view-layer-detached", &data);
 
         /* Check if the next focused view is fullscreen. If so, then we need
          * to make sure it is in the fullscreen layer */

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -26,14 +26,14 @@ wf::mirror_view_t::mirror_view_t(wayfire_view base_view) :
         close();
     };
 
-    base_view->connect_signal("unmap", &base_view_unmapped);
+    base_view->connect_signal("unmapped", &base_view_unmapped);
 
     base_view_damaged = [=] (wf::signal_data_t*)
     {
         damage();
     };
 
-    base_view->connect_signal("damaged-region", &base_view_damaged);
+    base_view->connect_signal("region-damaged", &base_view_damaged);
 }
 
 wf::mirror_view_t::~mirror_view_t()
@@ -48,8 +48,8 @@ void wf::mirror_view_t::close()
 
     emit_view_pre_unmap();
 
-    base_view->disconnect_signal("unmap", &base_view_unmapped);
-    base_view->disconnect_signal("damaged-region", &base_view_damaged);
+    base_view->disconnect_signal("unmapped", &base_view_unmapped);
+    base_view->disconnect_signal("region-damaged", &base_view_damaged);
     base_view = nullptr;
 
     emit_map_state_change(this);

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -281,9 +281,9 @@ wf::dimensions_t wf::wlr_surface_base_t::_get_size() const
 void wf::emit_map_state_change(wf::surface_interface_t *surface)
 {
     std::string state =
-        surface->is_mapped() ? "_surface_mapped" : "_surface_unmapped";
+        surface->is_mapped() ? "surface-mapped" : "surface-unmapped";
 
-    _surface_map_state_changed_signal data;
+    surface_map_state_changed_signal data;
     data.surface = surface;
     wf::get_core().emit_signal(state, &data);
 }

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -259,13 +259,13 @@ void wf::wlr_view_t::set_decoration_mode(bool use_csd)
     this->has_client_decoration = use_csd;
     if ((was_decorated != should_be_decorated()) && is_mapped())
     {
-        wf::decoration_state_updated_signal data;
+        wf::view_decoration_state_updated_signal data;
         data.view = self();
 
         this->emit_signal("decoration-state-updated", &data);
         if (get_output())
         {
-            get_output()->emit_signal("decoration-state-updated-view", &data);
+            get_output()->emit_signal("view-decoration-state-updated", &data);
         }
     }
 }
@@ -348,11 +348,11 @@ void wf::wlr_view_t::unmap()
 
 void wf::emit_view_map_signal(wayfire_view view, bool has_position)
 {
-    map_view_signal data;
+    wf::view_mapped_signal data;
     data.view = view;
     data.is_positioned = has_position;
-    view->get_output()->emit_signal("map-view", &data);
-    view->emit_signal("map", &data);
+    view->get_output()->emit_signal("view-mapped", &data);
+    view->emit_signal("mapped", &data);
 }
 
 void wf::view_interface_t::emit_view_map()
@@ -362,30 +362,29 @@ void wf::view_interface_t::emit_view_map()
 
 void wf::view_interface_t::emit_view_unmap()
 {
-    unmap_view_signal data;
+    view_unmapped_signal data;
     data.view = self();
 
     if (get_output())
     {
-        get_output()->emit_signal("unmap-view", &data);
+        get_output()->emit_signal("view-unmapped", &data);
         get_output()->emit_signal("view-disappeared", &data);
     }
 
-    emit_signal("unmap", &data);
-    emit_signal("disappeared", &data);
+    emit_signal("unmapped", &data);
 }
 
 void wf::view_interface_t::emit_view_pre_unmap()
 {
-    pre_unmap_view_signal data;
+    view_pre_unmap_signal data;
     data.view = self();
 
     if (get_output())
     {
-        get_output()->emit_signal("pre-unmap-view", &data);
+        get_output()->emit_signal("view-pre-unmapped", &data);
     }
 
-    emit_signal("pre-unmap", &data);
+    emit_signal("pre-unmapped", &data);
 }
 
 void wf::wlr_view_t::destroy()


### PR DESCRIPTION
Fixes #108 

I am sorry for all of you who have custom plugins (@damianatorrpm  @myfreeweb  @soreau), this will very likely break compilation. At least with this PR all signal names should be consistent, all signal structs also follow the same naming convention and are all in the `wf::` namespace. Also, I have added documentation for all signals emitted from core.

Here is an incomplete porting guide:

1. Most events are the same, the type has changed `view_geometry_changed_signal` -> `wf::view_geometry_changed_signal`
2. `unmap-view`, `pre-unmap-view`, `map-view` are renamed to `view-unmapped`, `view-pre-unmapped` and `view-mapped`
3. `attach-view`, `detach-view`, `layer-attach-view`, `layer-detach-view` are now `view-(layer-)attached` and `view-(layer-)detached`.
4. `view-disappeared` now is emitted together with all the `view-detached`, `view-unmapped` and `view-minimized` signals.
5. `focus-view` -> `view-focused`
6. `view-maximize-request` -> `view-tile-request`
