### PR TITLE
do not break fullscreen views

### DIFF
--- a/plugins/single_plugins/move-snap-helper.hpp
+++ b/plugins/single_plugins/move-snap-helper.hpp
@@ -129,12 +129,7 @@ class move_snap_helper_t : public wf::custom_data_t
     virtual void snap_off()
     {
         view_in_slot = false;
-        if (view->fullscreen)
-        {
-            view->fullscreen_request(view->get_output(), false);
-        }
-
-        if (view->tiled_edges)
+        if (view->tiled_edges && !view->fullscreen)
         {
             view->tile_request(0);
         }

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -303,8 +303,22 @@ class wayfire_move : public wf::plugin_interface_t
             return;
         }
 
-        /* Snap the view */
-        if (enable_snap && (slot.slot_id != 0))
+        /**
+         * Snap the view
+         * A view that is fullscreened may break if resized i.e
+         * tiled_vertical or tiled_horizontal, games usually have
+         * their own option to be fullscreen.
+         * If the compositor resizes them and thus removes
+         * for xwayland _NET_WM_STATE fullscreen (there
+         * are not much wayland games around to test what wayland games
+         * do when they have fullscreen in their settings and
+         * the compositor puts them in another state) they break.
+         *
+         * This way fullscreened view can be moved from one
+         * output to another and be restored to fullscreen
+         * on a different output (hopefully with the same resolotion)
+         */
+        if (enable_snap && (slot.slot_id != 0) && !this->view->fullscreen)
         {
             snap_signal data;
             data.view = view;
@@ -320,6 +334,15 @@ class wayfire_move : public wf::plugin_interface_t
         workspace_may_changed.to   = output->workspace->get_current_workspace();
         workspace_may_changed.old_viewport_invalid = false;
         output->emit_signal("view-change-viewport", &workspace_may_changed);
+        /**
+         * Restore the fullscreen state so the window is
+         * not in a weird position afterwards, fullscreen
+         * are by spec the geometry of the output (or span outputs)
+         */
+        if (this->view->fullscreen)
+        {
+            view->fullscreen_request(output, true);
+        }
 
         this->view = nullptr;
     }
@@ -618,7 +641,8 @@ class wayfire_move : public wf::plugin_interface_t
         /* View might get destroyed when updating multi-output */
         if (view)
         {
-            if (enable_snap && !MOVE_HELPER->is_view_fixed())
+            if (enable_snap && !MOVE_HELPER->is_view_fixed() &&
+                !this->view->fullscreen)
             {
                 update_slot(calc_slot(input.x, input.y));
             }

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -205,7 +205,7 @@ class wayfire_resize : public wf::plugin_interface_t
     bool initiate(wayfire_view view, uint32_t forced_edges = 0)
     {
         if (!view || (view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT) ||
-            !view->is_mapped())
+            !view->is_mapped() || view->fullscreen)
         {
             return false;
         }
@@ -241,11 +241,6 @@ class wayfire_resize : public wf::plugin_interface_t
         }
 
         view->set_resizing(true, edges);
-
-        if (view->fullscreen)
-        {
-            view->set_fullscreen(false);
-        }
 
         if (view->tiled_edges)
         {

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -410,6 +410,11 @@ struct view_fullscreen_signal : public _view_signal
      * by core and plugins may override it. It may also be undefined (0,0 0x0).
      */
     wf::geometry_t desired_size;
+
+    /**
+     * The workspace the view will be fullscreened on.
+     */
+    wf::point_t workspace;
 };
 
 /**

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -249,7 +249,8 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
      */
     virtual void tile_request(uint32_t tiled_edges);
     /** Request that the view is (un)fullscreened on the given output */
-    virtual void fullscreen_request(wf::output_t *output, bool state);
+    virtual void fullscreen_request(wf::output_t *output, bool state,
+        wf::point_t workspace = {-1, -1});
 
     /** @return true if the view is visible */
     virtual bool is_visible();


### PR DESCRIPTION
Note: games that have the option 'desktop friendly fullscreen minimizes on focus loss'
are still broken when they loose focus, without the minimize PR