### PR TITLE
meson: detect address sanitizer via CXXFLAGS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,7 +13,6 @@ project(
 	],
 )
 
-so_version = ['0', '4', '0']
 wayfire_api_inc  = include_directories('src/api')
 
 wayland_server = dependency('wayland-server')

--- a/src/meson.build
+++ b/src/meson.build
@@ -55,7 +55,10 @@ else
   debug_arguments += ['-DHAS_ADDR2LINE=0']
 endif
 
-if get_option('b_sanitize').contains('address')
+
+cxx_flags_asan = run_command('/bin/sh', '-c', 'echo $CXXFLAGS $CPPFLAGS | grep fsanitize')
+if get_option('b_sanitize').contains('address') or cxx_flags_asan.returncode() == 0
+  message('Address sanitizer enabled, disabling internal backtrace')
   debug_arguments += ['-DASAN_ENABLED']
 endif
 


### PR DESCRIPTION
We need to disable our internal backtrace in this case.