### PR TITLE
input-method-relay: hopefully appease ASan

### DIFF
--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -44,6 +44,7 @@ class input_method_relay
     input_method_relay();
     void send_im_state(wlr_text_input_v3*);
     void disable_text_input(wlr_text_input_v3*);
+    void remove_text_input(wlr_text_input_v3*);
     ~input_method_relay();
 };
 


### PR DESCRIPTION
ASan detected a heap-use-after-free with both the use and the free
pointing at the `remove_if` thing (specifically the use was pointing at `input`,
aka `this->input`, so I guess `this` was freed).

Let's move the `remove_if` thing into a method on `relay`.