### PR TITLE
Change Arch Linux installation procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Installing [wf-shell](https://github.com/WayfireWM/wf-shell) is recommended for 
 [wayfire] and [wayfire-git] are available in the [AUR].
 
 ``` sh
-pacman -S wayfire
+yay -S wayfire
 ```
 
 [AUR]: https://aur.archlinux.org


### PR DESCRIPTION
The package is in the AUR and `pacman` can not install packages from there. A popular suggestion for installing from the AUR is `yay`.