### PR TITLE
blur: Optimize gaussian and box shaders

### DIFF
--- a/metadata/blur.xml
+++ b/metadata/blur.xml
@@ -50,7 +50,7 @@
 		<option name="box_offset" type="double">
 			<_short>Box offset</_short>
 			<_long>Sets the offset value for the box method.</_long>
-			<default>2</default>
+			<default>1</default>
 			<min>0</min>
 			<max>25</max>
 		</option>
@@ -72,7 +72,7 @@
 		<option name="gaussian_offset" type="double">
 			<_short>Gaussian offset</_short>
 			<_long>Sets the offset value for the gaussian method.</_long>
-			<default>2</default>
+			<default>1</default>
 			<min>0</min>
 			<max>25</max>
 		</option>

--- a/plugins/blur/blur-base.cpp
+++ b/plugins/blur/blur-base.cpp
@@ -38,11 +38,10 @@ void main()
     gl_FragColor = wp + (1.0 - wp.a) * c;
 })";
 
-wf_blur_base::wf_blur_base(wf::output_t *output,
-    const wf_blur_default_option_values& defaults)
+wf_blur_base::wf_blur_base(wf::output_t *output, std::string name)
 {
     this->output = output;
-    this->algorithm_name = defaults.algorithm_name;
+    this->algorithm_name = name;
 
     this->offset_opt.load_option("blur/" + algorithm_name + "_offset");
     this->degrade_opt.load_option("blur/" + algorithm_name + "_degrade");

--- a/plugins/blur/blur.hpp
+++ b/plugins/blur/blur.hpp
@@ -84,11 +84,6 @@
  * |                                                               |
  * `````````````````````````````````````````````````````````````````
  */
-struct wf_blur_default_option_values
-{
-    std::string algorithm_name;
-    std::string offset, degrade, iterations;
-};
 
 class wf_blur_base
 {
@@ -129,8 +124,7 @@ class wf_blur_base
     virtual int blur_fb0(const wf::region_t& blur_region, int width, int height) = 0;
 
   public:
-    wf_blur_base(wf::output_t *output,
-        const wf_blur_default_option_values& values);
+    wf_blur_base(wf::output_t *output, std::string name);
     virtual ~wf_blur_base();
 
     virtual int calculate_blur_radius();

--- a/plugins/blur/bokeh.cpp
+++ b/plugins/blur/bokeh.cpp
@@ -54,17 +54,10 @@ void main()
 }
 )";
 
-static const wf_blur_default_option_values bokeh_defaults = {
-    .algorithm_name = "bokeh",
-    .offset     = "5",
-    .degrade    = "1",
-    .iterations = "15"
-};
-
 class wf_bokeh_blur : public wf_blur_base
 {
   public:
-    wf_bokeh_blur(wf::output_t *output) : wf_blur_base(output, bokeh_defaults)
+    wf_bokeh_blur(wf::output_t *output) : wf_blur_base(output, "bokeh")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(bokeh_vertex_shader,

--- a/plugins/blur/box.cpp
+++ b/plugins/blur/box.cpp
@@ -68,20 +68,13 @@ void main()
 }
 )";
 
-static const wf_blur_default_option_values box_defaults = {
-    .algorithm_name = "box",
-    .offset     = "1",
-    .degrade    = "1",
-    .iterations = "2"
-};
-
 class wf_box_blur : public wf_blur_base
 {
   public:
     void get_id_locations(int i)
     {}
 
-    wf_box_blur(wf::output_t *output) : wf_blur_base(output, box_defaults)
+    wf_box_blur(wf::output_t *output) : wf_blur_base(output, "box")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(

--- a/plugins/blur/box.cpp
+++ b/plugins/blur/box.cpp
@@ -8,7 +8,7 @@ attribute mediump vec2 position;
 uniform vec2 size;
 uniform float offset;
 
-varying highp vec2 blurcoord[9];
+varying highp vec2 blurcoord[5];
 
 void main() {
     gl_Position = vec4(position.xy, 0.0, 1.0);
@@ -16,14 +16,10 @@ void main() {
     vec2 texcoord = (position.xy + vec2(1.0, 1.0)) / 2.0;
 
     blurcoord[0] = texcoord;
-    blurcoord[1] = texcoord + vec2(1.0 * offset) / size;
-    blurcoord[2] = texcoord - vec2(1.0 * offset) / size;
-    blurcoord[3] = texcoord + vec2(2.0 * offset) / size;
-    blurcoord[4] = texcoord - vec2(2.0 * offset) / size;
-    blurcoord[5] = texcoord + vec2(3.0 * offset) / size;
-    blurcoord[6] = texcoord - vec2(3.0 * offset) / size;
-    blurcoord[7] = texcoord + vec2(4.0 * offset) / size;
-    blurcoord[8] = texcoord - vec2(4.0 * offset) / size;
+    blurcoord[1] = texcoord + vec2(1.5 * offset) / size;
+    blurcoord[2] = texcoord - vec2(1.5 * offset) / size;
+    blurcoord[3] = texcoord + vec2(3.5 * offset) / size;
+    blurcoord[4] = texcoord - vec2(3.5 * offset) / size;
 }
 )";
 
@@ -35,18 +31,18 @@ precision mediump float;
 uniform sampler2D bg_texture;
 uniform int mode;
 
-varying highp vec2 blurcoord[9];
+varying highp vec2 blurcoord[5];
 
 void main()
 {
     vec2 uv = blurcoord[0];
     vec4 bp = vec4(0.0);
-    for(int i = 0; i < 9; i++) {
+    for(int i = 0; i < 5; i++) {
         vec2 uv = vec2(blurcoord[i].x, uv.y);
         bp += texture2D(bg_texture, uv);
     }
 
-    gl_FragColor = bp / 9.0;
+    gl_FragColor = bp / 5.0;
 }
 )";
 
@@ -58,23 +54,23 @@ precision mediump float;
 uniform sampler2D bg_texture;
 uniform int mode;
 
-varying highp vec2 blurcoord[9];
+varying highp vec2 blurcoord[5];
 
 void main()
 {
     vec2 uv = blurcoord[0];
     vec4 bp = vec4(0.0);
-    for(int i = 0; i < 9; i++) {
+    for(int i = 0; i < 5; i++) {
         vec2 uv = vec2(uv.x, blurcoord[i].y);
         bp += texture2D(bg_texture, uv);
     }
-    gl_FragColor = bp / 9.0;
+    gl_FragColor = bp / 5.0;
 }
 )";
 
 static const wf_blur_default_option_values box_defaults = {
     .algorithm_name = "box",
-    .offset     = "2",
+    .offset     = "1",
     .degrade    = "1",
     .iterations = "2"
 };

--- a/plugins/blur/gaussian.cpp
+++ b/plugins/blur/gaussian.cpp
@@ -67,17 +67,10 @@ void main()
     gl_FragColor = bp;
 })";
 
-static const wf_blur_default_option_values gaussian_defaults = {
-    .algorithm_name = "gaussian",
-    .offset     = "1",
-    .degrade    = "1",
-    .iterations = "2"
-};
-
 class wf_gaussian_blur : public wf_blur_base
 {
   public:
-    wf_gaussian_blur(wf::output_t *output) : wf_blur_base(output, gaussian_defaults)
+    wf_gaussian_blur(wf::output_t *output) : wf_blur_base(output, "gaussian")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(

--- a/plugins/blur/gaussian.cpp
+++ b/plugins/blur/gaussian.cpp
@@ -8,7 +8,7 @@ attribute mediump vec2 position;
 uniform vec2 size;
 uniform float offset;
 
-varying highp vec2 blurcoord[9];
+varying highp vec2 blurcoord[5];
 
 void main() {
     gl_Position = vec4(position.xy, 0.0, 1.0);
@@ -16,14 +16,10 @@ void main() {
     vec2 texcoord = (position.xy + vec2(1.0, 1.0)) / 2.0;
 
     blurcoord[0] = texcoord;
-    blurcoord[1] = texcoord + vec2(1.0 * offset) / size;
-    blurcoord[2] = texcoord - vec2(1.0 * offset) / size;
-    blurcoord[3] = texcoord + vec2(2.0 * offset) / size;
-    blurcoord[4] = texcoord - vec2(2.0 * offset) / size;
-    blurcoord[5] = texcoord + vec2(3.0 * offset) / size;
-    blurcoord[6] = texcoord - vec2(3.0 * offset) / size;
-    blurcoord[7] = texcoord + vec2(4.0 * offset) / size;
-    blurcoord[8] = texcoord - vec2(4.0 * offset) / size;
+    blurcoord[1] = texcoord + vec2(1.5 * offset) / size;
+    blurcoord[2] = texcoord - vec2(1.5 * offset) / size;
+    blurcoord[3] = texcoord + vec2(3.5 * offset) / size;
+    blurcoord[4] = texcoord - vec2(3.5 * offset) / size;
 }
 )";
 
@@ -35,21 +31,17 @@ precision mediump float;
 uniform sampler2D bg_texture;
 uniform int mode;
 
-varying highp vec2 blurcoord[9];
+varying highp vec2 blurcoord[5];
 
 void main()
 {
     vec2 uv = blurcoord[0];
     vec4 bp = vec4(0.0);
-    bp += texture2D(bg_texture, vec2(blurcoord[0].x, uv.y)) * 0.2270270270;
-    bp += texture2D(bg_texture, vec2(blurcoord[1].x, uv.y)) * 0.1945945946;
-    bp += texture2D(bg_texture, vec2(blurcoord[2].x, uv.y)) * 0.1945945946;
-    bp += texture2D(bg_texture, vec2(blurcoord[3].x, uv.y)) * 0.1216216216;
-    bp += texture2D(bg_texture, vec2(blurcoord[4].x, uv.y)) * 0.1216216216;
-    bp += texture2D(bg_texture, vec2(blurcoord[5].x, uv.y)) * 0.0540540541;
-    bp += texture2D(bg_texture, vec2(blurcoord[6].x, uv.y)) * 0.0540540541;
-    bp += texture2D(bg_texture, vec2(blurcoord[7].x, uv.y)) * 0.0162162162;
-    bp += texture2D(bg_texture, vec2(blurcoord[8].x, uv.y)) * 0.0162162162;
+    bp += texture2D(bg_texture, vec2(blurcoord[0].x, uv.y)) * 0.204164;
+    bp += texture2D(bg_texture, vec2(blurcoord[1].x, uv.y)) * 0.304005;
+    bp += texture2D(bg_texture, vec2(blurcoord[2].x, uv.y)) * 0.304005;
+    bp += texture2D(bg_texture, vec2(blurcoord[3].x, uv.y)) * 0.093913;
+    bp += texture2D(bg_texture, vec2(blurcoord[4].x, uv.y)) * 0.093913;
     gl_FragColor = bp;
 })";
 
@@ -61,27 +53,23 @@ precision mediump float;
 uniform sampler2D bg_texture;
 uniform int mode;
 
-varying highp vec2 blurcoord[9];
+varying highp vec2 blurcoord[5];
 
 void main()
 {
     vec2 uv = blurcoord[0];
     vec4 bp = vec4(0.0);
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[0].y)) * 0.2270270270;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[1].y)) * 0.1945945946;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[2].y)) * 0.1945945946;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[3].y)) * 0.1216216216;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[4].y)) * 0.1216216216;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[5].y)) * 0.0540540541;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[6].y)) * 0.0540540541;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[7].y)) * 0.0162162162;
-    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[8].y)) * 0.0162162162;
+    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[0].y)) * 0.204164;
+    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[1].y)) * 0.304005;
+    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[2].y)) * 0.304005;
+    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[3].y)) * 0.093913;
+    bp += texture2D(bg_texture, vec2(uv.x, blurcoord[4].y)) * 0.093913;
     gl_FragColor = bp;
 })";
 
 static const wf_blur_default_option_values gaussian_defaults = {
     .algorithm_name = "gaussian",
-    .offset     = "2",
+    .offset     = "1",
     .degrade    = "1",
     .iterations = "2"
 };

--- a/plugins/blur/kawase.cpp
+++ b/plugins/blur/kawase.cpp
@@ -57,18 +57,11 @@ void main()
     gl_FragColor = sum / 12.0;
 })";
 
-static const wf_blur_default_option_values kawase_defaults = {
-    .algorithm_name = "kawase",
-    .offset     = "5",
-    .degrade    = "1",
-    .iterations = "2"
-};
-
 class wf_kawase_blur : public wf_blur_base
 {
   public:
     wf_kawase_blur(wf::output_t *output) :
-        wf_blur_base(output, kawase_defaults)
+        wf_blur_base(output, "kawase")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(kawase_vertex_shader,


### PR DESCRIPTION
This reduces the number of texture reads from 18 to 10 per pass,
while making the effects slightly stronger. This improves performance
because it uses hardware interpolation to read a weighted average of
more than one pixel at a time.