### PR TITLE
Prepare for wlroots #2240

### DIFF
--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -645,8 +645,7 @@ class WayfireSwitcher : public wf::plugin_interface_t
             (float)sv.attribs.rotation, {0.0, 1.0, 0.0});
 
         transform->color[3] = sv.attribs.alpha;
-        sv.view->render_transformed(output->render->get_target_framebuffer(),
-            output->render->get_target_framebuffer().geometry);
+        sv.view->render_transformed(buffer, buffer.geometry);
     }
 
     wf::render_hook_t switcher_renderer = [=] (const wf::framebuffer_t& fb)

--- a/src/api/wayfire/opengl.hpp
+++ b/src/api/wayfire/opengl.hpp
@@ -171,7 +171,7 @@ namespace OpenGL
  * and render_end() */
 void render_begin(); // use if you just want to bind GL context but won't draw
 void render_begin(const wf::framebuffer_base_t& fb);
-void render_begin(int32_t viewport_width, int32_t viewport_height, uint32_t fb = 0);
+void render_begin(int32_t viewport_width, int32_t viewport_height, uint32_t fb);
 
 /* Call this to indicate an end of the rendering.
  * Resets bound framebuffer and scissor box.

--- a/src/core/opengl-priv.hpp
+++ b/src/core/opengl-priv.hpp
@@ -11,7 +11,7 @@ void init();
 /** Destroy the default GL program and resources */
 void fini();
 /** Indicate we have started repainting the given output */
-void bind_output(wf::output_t *output);
+void bind_output(wf::output_t *output, uint32_t fb);
 /** Indicate the output frame has been finished */
 void unbind_output(wf::output_t *output);
 }

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -279,6 +279,28 @@ void render_end()
 }
 }
 
+static std::string framebuffer_status_to_str(
+    GLuint status)
+{
+    switch (status)
+    {
+      case GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT:
+        return "incomplete attachment";
+
+      case GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT:
+        return "missing attachment";
+
+      case GL_FRAMEBUFFER_INCOMPLETE_DIMENSIONS:
+        return "incomplete dimensions";
+
+      case GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE:
+        return "incomplete multisample";
+
+      default:
+        return "unknown";
+    }
+}
+
 bool wf::framebuffer_base_t::allocate(int width, int height)
 {
     bool first_allocate = false;
@@ -320,14 +342,12 @@ bool wf::framebuffer_base_t::allocate(int width, int height)
         GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
         GL_CALL(glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
             GL_TEXTURE_2D, tex, 0));
-    }
 
-    if (is_resize || first_allocate)
-    {
         auto status = GL_CALL(glCheckFramebufferStatus(GL_FRAMEBUFFER));
         if (status != GL_FRAMEBUFFER_COMPLETE)
         {
-            LOGE("Failed to initialize framebuffer");
+            LOGE("Failed to initialize framebuffer: ",
+                framebuffer_status_to_str(status));
 
             return false;
         }

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -124,16 +124,19 @@ void fini()
 namespace
 {
 wf::output_t *current_output = NULL;
+uint32_t current_output_fb   = 0;
 }
 
-void bind_output(wf::output_t *output)
+void bind_output(wf::output_t *output, uint32_t fb)
 {
-    current_output = output;
+    current_output    = output;
+    current_output_fb = fb;
 }
 
 void unbind_output(wf::output_t *output)
 {
-    current_output = NULL;
+    current_output    = NULL;
+    current_output_fb = 0;
 }
 
 void render_transformed_texture(wf::texture_t tex,
@@ -270,7 +273,7 @@ void clear(wf::color_t col, uint32_t mask)
 
 void render_end()
 {
-    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, current_output_fb));
     wlr_renderer_scissor(wf::get_core().renderer, NULL);
     wlr_renderer_end(wf::get_core().renderer);
 }
@@ -299,7 +302,7 @@ bool wf::framebuffer_base_t::allocate(int width, int height)
     bool is_resize = false;
     /* Special case: fb = 0. This occurs in the default workspace streams, we don't
      * resize anything */
-    if (fb != 0)
+    if (fb != OpenGL::current_output_fb)
     {
         if (first_allocate || (width != viewport_width) ||
             (height != viewport_height))
@@ -334,7 +337,7 @@ bool wf::framebuffer_base_t::allocate(int width, int height)
     viewport_height = height;
 
     GL_CALL(glBindTexture(GL_TEXTURE_2D, 0));
-    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, 0));
+    GL_CALL(glBindFramebuffer(GL_FRAMEBUFFER, OpenGL::current_output_fb));
 
     return is_resize || first_allocate;
 }

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -389,7 +389,7 @@ class wf::render_manager::impl
     wf::wl_listener_wrapper on_frame;
     wf::wl_listener_wrapper on_present;
     wf::wl_timer repaint_timer;
-    int64_t refresh_nsec;
+    int64_t refresh_nsec = 0;
 
     output_t *output;
     wf::region_t swap_damage;


### PR DESCRIPTION
wlroots #2240 is a breaking change which would silently break Wayfire (because it changes some assumptions we make about how GL works). This PR attempts to fix that. There should be no code breakage for plugins, although some adjustments may be necessary.

~~On the way I managed to reproduce #636 and I think it should be fixed with this PR.
@damianatorrpm Can you confirm?~~

Fixes #98
Fixes #636
Fixes #703 

Also, this PR is wlroots-backwards-compatible, i.e it should work with current wlroots master too.