### PR TITLE
fix switching to the workspace of the selected view in interactive mode

### DIFF
--- a/plugins/single_plugins/scale.cpp
+++ b/plugins/single_plugins/scale.cpp
@@ -246,6 +246,7 @@ class wayfire_scale : public wf::plugin_interface_t
                 all_workspaces_option_changed();
             } else
             {
+                select_view(last_focused_view);
                 deactivate();
             }
         } else


### PR DESCRIPTION
This currently does not work. Steps to reproduce:

1. Open views on multiple workspaces
2. Start scale for all workspaces, in interactive mode
3. Select one of the view from a different workspace (with the mouse)
4. Exit scale (with the toggle keybinding)

Expected behavior: switch to the workspace of the selected view

Actual behavior: stays on the original workspace
