### PR TITLE
Add missing damage to bring_to_front, fixes #700

### DIFF
--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -240,6 +240,8 @@ class output_layer_manager_t
     /** Precondition: view is in some sublayer */
     void bring_to_front(wayfire_view view)
     {
+        view->damage();
+
         auto sublayer = get_view_sublayer(view);
         assert(sublayer);
         if (sublayer->mode == SUBLAYER_FLOATING)


### PR DESCRIPTION
Yeeeah.. so the dock's damage was the only thing revealing the brought-up-to-front surface, hence the not-redrawn-by-gtk-yet window showing up *inside* the region where the dock's transparent surface is.