### PR TITLE
keyboard: Populate lock key states after creating context

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -21,6 +21,16 @@
 			<_long>Sets the frequency of key repeats once the `input.kb_repeat_delay` has passed.</_long>
 			<default>40</default>
 		</option>
+		<option name="kb_numlock_default_state" type="bool">
+			<_short>Numlock default state</_short>
+			<_long>Default numlock state when wayfire starts.</_long>
+			<default>false</default>
+		</option>
+		<option name="kb_capslock_default_state" type="bool">
+			<_short>Capslock default state</_short>
+			<_long>Default capslock state when wayfire starts.</_long>
+			<default>false</default>
+		</option>
 		<!-- XKB configuration -->
 		<option name="xkb_layout" type="string">
 			<_short>XKB layout</_short>

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -167,9 +167,28 @@ void input_manager::handle_input_destroyed(wlr_input_device *dev)
     update_capabilities();
 }
 
+void load_locked_mods_from_config(xkb_mod_mask_t& locked_mods)
+{
+    wf::option_wrapper_t<bool> numlock_state, capslock_state;
+    numlock_state.load_option("input/kb_numlock_default_state");
+    capslock_state.load_option("input/kb_capslock_default_state");
+
+    if (numlock_state)
+    {
+        locked_mods |= WF_KB_NUM;
+    }
+
+    if (capslock_state)
+    {
+        locked_mods |= WF_KB_CAPS;
+    }
+}
+
 input_manager::input_manager()
 {
     wf::pointing_device_t::config.load();
+
+    load_locked_mods_from_config(locked_mods);
 
     input_device_created.set_callback([&] (void *data)
     {

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -28,6 +28,12 @@ struct wlr_seat;
 struct wf_touch;
 struct wf_keyboard;
 
+enum wf_locked_mods
+{
+    WF_KB_NUM  = 1 << 0,
+    WF_KB_CAPS = 1 << 1,
+};
+
 enum wf_binding_type
 {
     WF_BINDING_KEY,
@@ -142,6 +148,7 @@ class input_manager
         wf::pointf_t& local);
 
     uint32_t get_modifiers();
+    uint32_t locked_mods = 0;
 
     void free_output_bindings(wf::output_t *output);
 


### PR DESCRIPTION
Fixes #589 