### PR TITLE
[vswitch] fix for requesting the same workspace multiple times

### DIFF
--- a/plugins/single_plugins/vswitch.cpp
+++ b/plugins/single_plugins/vswitch.cpp
@@ -135,11 +135,6 @@ class vswitch : public wf::plugin_interface_t
 
     bool add_direction(int x, int y, wayfire_view view = nullptr)
     {
-        if (!x && !y)
-        {
-            return false;
-        }
-
         if (!is_active() && !start_switch())
         {
             return false;
@@ -198,16 +193,24 @@ class vswitch : public wf::plugin_interface_t
     wf::signal_connection_t on_set_workspace_request = [=] (wf::signal_data_t *data)
     {
         auto ev = static_cast<wf::workspace_change_request_signal*>(data);
+        int x, y;
         if (is_active())
         {
             auto cws = output->workspace->get_current_workspace();
-            ev->carried_out =
-                add_direction(ev->new_viewport.x - (cws.x + animation.dx.end),
-                    ev->new_viewport.y - (cws.y + animation.dy.end));
+            x = ev->new_viewport.x - (cws.x + animation.dx.end);
+            y = ev->new_viewport.y - (cws.y + animation.dy.end);
         } else
         {
-            ev->carried_out = add_direction(ev->new_viewport.x - ev->old_viewport.x,
-                ev->new_viewport.y - ev->old_viewport.y);
+            x = ev->new_viewport.x - ev->old_viewport.x;
+            y = ev->new_viewport.y - ev->old_viewport.y;
+        }
+
+        if (!x && !y)
+        {
+            ev->carried_out = true;
+        } else
+        {
+            ev->carried_out = add_direction(x, y);
         }
     };
 


### PR DESCRIPTION
Special case of issue #676 

My comment from there:

I've just found that this issue can persist in the edge case when the same workspace is requested twice in quick succession. I've been able to see it with the scale plugin with this patch by @soreau

I've added a simple print statement and I think what is happening is that for the second request, vswitch::add_direction() is called with x == y == 0, and thus returns false (line 140). This sets carried_out to false in on_set_workspace_request() (line 204).

In workspace-impl.cpp, line 910, then it will test this and call set_workspace() that instantly sets the new workspace. But the vswitch animation is still running, so it ends up on the wrong workspace in the end.

Maybe, add_direction() could return true if x == y == 0, and thus the operation is a no-op? This fixes in the cases I could test.