### PR TITLE
core: Disable max_render_time by default

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -51,7 +51,7 @@
 		<option name="max_render_time" type="int">
 			<_short>Maximum render time</_short>
 			<_long>Sets the compositor render delay in milliseconds, which allows applications to render with low latency.</_long>
-			<default>7</default>
+			<default>-1</default>
 		</option>
 	</plugin>
 </wayfire>


### PR DESCRIPTION
Many users complaining about wayfire performance were able to fix the
problem by setting max_render_time to -1, which disables it. This option
is also supposed to be a per-output setting so it could cause problems
where there is more than one monitor with different refresh rates.