### PR TITLE
core: Use GL_DEPTH_COMPONENT with GL_UNSIGNED_INT when setting up dep…

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -443,8 +443,8 @@ class depth_buffer_manager_t : public noncopyable_t
 
         GL_CALL(glGenTextures(1, &buffer.tex));
         GL_CALL(glBindTexture(GL_TEXTURE_2D, buffer.tex));
-        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT32F,
-            width, height, 0, GL_DEPTH_COMPONENT, GL_FLOAT, NULL));
+        GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT,
+            width, height, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, NULL));
         buffer.width  = width;
         buffer.height = height;
 


### PR DESCRIPTION
…th buffer

Some drivers like VC4 on RPI3 were failing on headless backend with
GL errors because we were using GL_DEPTH_COMPONENT32F with GL_FLOAT,
when setting up the depth buffer. This doesn't currently affect the
drm backend because this code is simply not used in that case. Here
we use a combination that is supported by more drivers.