### PR TITLE
seat: force map drag icons when starting drag

### DIFF
--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -150,6 +150,13 @@ void input_manager::create_seat()
         {
             wf::get_core_impl().input->drag_icon =
                 std::make_unique<wf_drag_icon>(d->icon);
+
+            // Sometimes, the drag surface is reused between two or more drags.
+            // In this case, when the drag starts, the icon is already mapped.
+            if (d->icon->surface && wlr_surface_has_buffer(d->icon->surface))
+            {
+                wf::get_core_impl().input->drag_icon->force_map();
+            }
         }
 
         wf::dnd_signal evdata;

--- a/src/core/seat/seat.hpp
+++ b/src/core/seat/seat.hpp
@@ -25,6 +25,12 @@ struct wf_drag_icon : public wf::wlr_child_surface_base_t
     void damage();
     void damage_surface_box(const wlr_box& rect) override;
 
+    /* Force map without receiving a wlroots event */
+    void force_map()
+    {
+        this->map(icon->surface);
+    }
+
   private:
     /** Last icon box. */
     wf::geometry_t last_box = {0, 0, 0, 0};


### PR DESCRIPTION
This can cause crashes in some clients, if the drag icon is already
mapped when the drag starts.
