### PR TITLE
Add support for sticky views

### DIFF
--- a/metadata/wm-actions.xml
+++ b/metadata/wm-actions.xml
@@ -14,5 +14,10 @@
 			<_long>Toggle the fullsreen state of a view.</_long>
 			<default>disabled</default>
 		</option>
+		<option name="toggle_sticky" type="activator">
+			<_short>Toggle Sticky</_short>
+			<_long>Toggle the sticky state of a view.</_long>
+			<default>disabled</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/tile/tree.cpp
+++ b/plugins/tile/tree.cpp
@@ -347,11 +347,11 @@ wf::geometry_t view_node_t::calculate_target_geometry()
     local_geometry.width -= gaps.left + gaps.right;
     local_geometry.height -= gaps.top + gaps.bottom;
 
+    auto size = output->get_screen_size();
     /* If view is maximized, we want to use the full available geometry */
     if (view->fullscreen)
     {
-        auto vp   = output->workspace->get_current_workspace();
-        auto size = output->get_screen_size();
+        auto vp = output->workspace->get_current_workspace();
 
         int view_vp_x = std::floor(1.0 * geometry.x / size.width);
         int view_vp_y = std::floor(1.0 * geometry.y / size.height);
@@ -362,6 +362,14 @@ wf::geometry_t view_node_t::calculate_target_geometry()
             size.width,
             size.height,
         };
+    }
+
+    if (view->sticky)
+    {
+        local_geometry.x =
+            (local_geometry.x % size.width + size.width) % size.width;
+        local_geometry.y =
+            (local_geometry.y % size.height + size.height) % size.height;
     }
 
     return local_geometry;

--- a/plugins/vswitch/vswitch.cpp
+++ b/plugins/vswitch/vswitch.cpp
@@ -56,6 +56,13 @@ class vswitch : public wf::plugin_interface_t
         bindings = std::make_unique<wf::vswitch::control_bindings_t>(output);
         bindings->setup([this] (wf::point_t delta, wayfire_view view)
         {
+            // Do not switch workspace with sticky view, they are on all
+            // workspaces anyway
+            if (view && view->sticky)
+            {
+                view = nullptr;
+            }
+
             if (this->set_capabilities(wf::CAPABILITY_MANAGE_DESKTOP))
             {
                 return add_direction(delta, view);

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'08;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'11;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -454,6 +454,13 @@ struct view_fullscreen_signal : public _view_signal
 using view_fullscreen_request_signal = view_fullscreen_signal;
 
 /**
+ * name: set-sticky
+ * on: view, output(view-)
+ * when: Whenever the view's sticky state changes.
+ */
+using view_set_sticky_signal = _view_signal;
+
+/**
  * name: title-changed
  * on: view
  * when: After the view's title has changed.

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -215,6 +215,9 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
     /** Whether the view is in minimized state, usually you want to use either
      * set_minizied() or minimize_request() */
     bool minimized = false;
+    /** Whether the view is sticky. If a view is sticky it will not be affected
+     * by changes of the current workspace. */
+    bool sticky = false;
     /** The tiled edges of the view, usually you want to use set_tiled().
      * If the view is tiled to all edges, it is considered maximized. */
     uint32_t tiled_edges = 0;
@@ -227,6 +230,8 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
     virtual void set_fullscreen(bool fullscreen);
     /** Set the view's activated state.  */
     virtual void set_activated(bool active);
+    /** Set the view's sticky state. */
+    virtual void set_sticky(bool sticky);
 
     /** Request that an interactive move starts for this view */
     virtual void move_request();

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -999,7 +999,7 @@ class wf::render_manager::impl
                     continue;
                 }
 
-                if (view->role == VIEW_ROLE_DESKTOP_ENVIRONMENT)
+                if (view->sticky)
                 {
                     view_delta = {repaint.ws_dx, repaint.ws_dy};
                 }

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -493,7 +493,7 @@ class output_viewport_manager_t
     bool view_visible_on(wayfire_view view, wf::point_t vp)
     {
         auto g = output->get_relative_geometry();
-        if (view->role != VIEW_ROLE_DESKTOP_ENVIRONMENT)
+        if (!view->sticky)
         {
             g.x += (vp.x - current_vx) * g.width;
             g.y += (vp.y - current_vy) * g.height;
@@ -518,6 +518,13 @@ class output_viewport_manager_t
             LOGE("Cannot ensure view visibility for a view from a different output!");
 
             return;
+        }
+
+        // Sticky views are visible on all workspaces, so we just have to make
+        // it visible on the current workspace
+        if (view->sticky)
+        {
+            ws = {current_vx, current_vy};
         }
 
         auto box     = view->get_wm_geometry();
@@ -654,7 +661,7 @@ class output_viewport_manager_t
         for (auto& view : output->workspace->get_views_in_layer(MIDDLE_LAYERS))
         {
             auto it = std::find(fixed_views.cbegin(), fixed_views.cend(), view);
-            if (it == fixed_views.end())
+            if ((it == fixed_views.end()) && !view->sticky)
             {
                 for (auto v : view->enumerate_views())
                 {

--- a/src/view/layer-shell.cpp
+++ b/src/view/layer-shell.cpp
@@ -336,6 +336,7 @@ wayfire_layer_shell_view::wayfire_layer_shell_view(wlr_layer_surface_v1 *lsurf) 
 
     role = wf::VIEW_ROLE_DESKTOP_ENVIRONMENT;
     std::memset(&this->prev_state, 0, sizeof(prev_state));
+    sticky = true;
 
     /* If we already have an output set, then assign it before core assigns us
      * an output */

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -392,6 +392,27 @@ void wf::view_interface_t::set_minimized(bool minim)
     desktop_state_updated();
 }
 
+void wf::view_interface_t::set_sticky(bool sticky)
+{
+    if (this->sticky == sticky)
+    {
+        return;
+    }
+
+    damage();
+    this->sticky = sticky;
+    damage();
+
+    wf::view_set_sticky_signal data;
+    data.view = self();
+
+    this->emit_signal("set-sticky", &data);
+    if (this->get_output())
+    {
+        this->get_output()->emit_signal("view-set-sticky", &data);
+    }
+}
+
 void wf::view_interface_t::set_tiled(uint32_t edges)
 {
     // store last unmaximized geometry for restoring
@@ -1186,9 +1207,8 @@ void wf::view_damage_raw(wayfire_view view, const wlr_box& box)
         return;
     }
 
-    /* shell views are visible in all workspaces. That's why we must apply
-     * their damage to all workspaces as well */
-    if (view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT)
+    /* Sticky views are visible on all workspaces. */
+    if (view->sticky)
     {
         auto wsize = output->workspace->get_workspace_grid_size();
         auto cws   = output->workspace->get_current_workspace();

--- a/uncrustify.ini
+++ b/uncrustify.ini
@@ -842,7 +842,7 @@ nl_after_do                     = force   # ignore/add/remove/force
 
 # Whether to put a blank line before 'return' statements, unless after an open
 # brace.
-nl_before_return                = true    # true/false
+nl_before_return                = false    # true/false
 
 # Whether to force a newline before '}' of a 'struct'/'union'/'enum'.
 # (Lower priority than eat_blanks_before_close_brace.)


### PR DESCRIPTION
This PR adds basic support for sticky views. Sticky views are very similar to
how layer-shell surfaces were behaving previously (in fact, layer-shell surfaces
are now sticky). They do not change coordinates when changing their workspace (so their
coordinates are always on the current workspace), and some plugins need to be careful
when dealing with such views.

Since this is a strange category of views, I expect a few issues to pop up. I'd welcome
reports about that.

To use the feature, enable `wm-actions/toggle_sticky` and either click on a view or if
using a keybinding, the currently focused view will be made (un)sticky.

Known issues:
- Sticky views appear only halfway in Expo (won't fix)

Fixes #405 
