### PR TITLE
API: move all wlroots includes into their own header

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -140,6 +140,7 @@ else
   conf_data.set('WF_HAS_XWAYLAND', 0)
 endif
 
+add_project_arguments(['-DWF_USE_CONFIG_H'], language: ['cpp', 'c'])
 configure_file(input: 'config.h.in',
                output: 'config.h',
                install: true,

--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -24,7 +24,7 @@
 #define ZOOM_MIN 0.1f
 
 #ifdef USE_GLES32
- #include <GLES3/gl32.h>
+    #include <GLES3/gl32.h>
 #endif
 
 #include "shaders.tpp"

--- a/plugins/decor/deco-layout.cpp
+++ b/plugins/decor/deco-layout.cpp
@@ -2,11 +2,7 @@
 #include "deco-theme.hpp"
 #include <wayfire/core.hpp>
 #include <wayfire/nonstd/reverse.hpp>
-
-extern "C"
-{
-#include <wlr/types/wlr_xcursor_manager.h>
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #define BUTTON_ASPECT_RATIO (25.0 / 16.0)
 #define BUTTON_HEIGHT_PC 0.8

--- a/plugins/decor/deco-layout.hpp
+++ b/plugins/decor/deco-layout.hpp
@@ -3,10 +3,6 @@
 #include <vector>
 #include <wayfire/util.hpp>
 #include "deco-button.hpp"
-extern "C"
-{
-#include <wlr/util/edges.h>
-}
 
 namespace wf
 {

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -3,6 +3,7 @@
 
 #include <linux/input-event-codes.h>
 
+#include <wayfire/nonstd/wlroots.hpp>
 #include <wayfire/compositor-surface.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/opengl.hpp>
@@ -17,15 +18,6 @@
 #include <wayfire/plugins/common/cairo-util.hpp>
 
 #include <cairo.h>
-
-extern "C"
-{
-#define static
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/types/wlr_matrix.h>
-#include <wlr/types/wlr_xcursor_manager.h>
-#undef static
-}
 
 class simple_decoration_surface : public wf::surface_interface_t,
     public wf::compositor_surface_t, public wf::decorator_frame_t_t

--- a/plugins/decor/deco-theme.cpp
+++ b/plugins/decor/deco-theme.cpp
@@ -4,14 +4,6 @@
 #include <config.h>
 #include <map>
 
-extern "C"
-{
-#define static
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/types/wlr_matrix.h>
-#undef static
-}
-
 namespace wf
 {
 namespace decor

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -13,11 +13,6 @@
 #include "snap_signal.hpp"
 #include <wayfire/plugins/wobbly/wobbly-signal.hpp>
 
-extern "C"
-{
-#include <wlr/util/edges.h>
-}
-
 const std::string grid_view_id = "grid-view";
 
 class wayfire_grid_view_cdata : public wf::custom_data_t

--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -1,8 +1,3 @@
-extern "C"
-{
-#include <wlr/types/wlr_idle.h>
-}
-
 #include "wayfire/singleton-plugin.hpp"
 #include "wayfire/render-manager.hpp"
 #include "wayfire/output.hpp"
@@ -15,6 +10,7 @@ extern "C"
 #include <cmath>
 #include <wayfire/util/duration.hpp>
 #include <wayfire/util/log.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #define CUBE_ZOOM_BASE 1.0
 
@@ -182,7 +178,6 @@ class wayfire_idle_singleton : public wf::singleton_plugin_t<wayfire_idle>
     uint32_t last_time;
     wlr_idle_timeout *timeout_screensaver = NULL;
     wf::wl_listener_wrapper on_idle_screensaver, on_resume_screensaver;
-    wf::pointf_t saved_cursor_position;
 
     wf::activator_callback toggle = [=] (wf::activator_source_t, uint32_t)
     {

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -7,13 +7,8 @@
 #include <linux/input.h>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/plugins/common/view-change-viewport-signal.hpp>
-
-extern "C"
-{
-#include <wlr/types/wlr_xcursor_manager.h>
-}
-
 #include <wayfire/plugins/wobbly/wobbly-signal.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 class wayfire_resize : public wf::plugin_interface_t
 {

--- a/src/api/wayfire/bindings.hpp
+++ b/src/api/wayfire/bindings.hpp
@@ -2,10 +2,8 @@
 #define WF_BINDINGS_HPP
 
 #include <functional>
-extern "C"
-{
-    struct wlr_event_pointer_axis;
-}
+#include <cstdint>
+#include <wayfire/nonstd/wlroots.hpp>
 
 namespace wf
 {

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -10,38 +10,8 @@
 #include <wayfire/nonstd/observer_ptr.h>
 #include <wayfire/config/config-manager.hpp>
 
-extern "C"
-{
-    struct wlr_backend;
-    struct wlr_renderer;
-    struct wlr_seat;
-    struct wlr_cursor;
-    struct wlr_data_device_manager;
-    struct wlr_data_control_manager_v1;
-    struct wlr_gamma_control_manager_v1;
-    struct wlr_xdg_output_manager_v1;
-    struct wlr_export_dmabuf_manager_v1;
-    struct wlr_server_decoration_manager;
-    struct wlr_xdg_decoration_manager_v1;
-    struct wlr_input_inhibit_manager;
-    struct wlr_virtual_keyboard_manager_v1;
-    struct wlr_virtual_pointer_manager_v1;
-    struct wlr_idle;
-    struct wlr_idle_inhibit_manager_v1;
-    struct wlr_screencopy_manager_v1;
-    struct wlr_foreign_toplevel_manager_v1;
-    struct wlr_pointer_gestures_v1;
-    struct wlr_relative_pointer_manager_v1;
-    struct wlr_pointer_constraints_v1;
-    struct wlr_tablet_manager_v2;
-    struct wlr_input_method_manager_v2;
-    struct wlr_text_input_manager_v3;
-    struct wlr_presentation;
-    struct wlr_gtk_primary_selection_device_manager;
-    struct wlr_primary_selection_v1_device_manager;
-
 #include <wayland-server.h>
-}
+#include <wayfire/nonstd/wlroots.hpp>
 
 namespace wf
 {

--- a/src/api/wayfire/debug.hpp
+++ b/src/api/wayfire/debug.hpp
@@ -2,7 +2,7 @@
 #define DEBUG_HPP
 
 #ifndef WAYFIRE_PLUGIN
- #include "config.h"
+    #include "config.h"
 #endif
 
 #define nonull(x) ((x) ? (x) : ("nil"))

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -2,10 +2,7 @@
 #define WF_GEOMETRY_HPP
 
 #include <sstream>
-extern "C"
-{
-#include <wlr/types/wlr_box.h>
-}
+#include <wayfire/nonstd/wlroots.hpp>
 
 namespace wf
 {

--- a/src/api/wayfire/input-device.hpp
+++ b/src/api/wayfire/input-device.hpp
@@ -1,10 +1,7 @@
 #ifndef WF_INPUT_DEVICE_HPP
 #define WF_INPUT_DEVICE_HPP
 
-extern "C"
-{
-#include <wlr/types/wlr_input_device.h>
-}
+#include <wayfire/nonstd/wlroots.hpp>
 
 namespace wf
 {

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -1,0 +1,125 @@
+#pragma once
+
+/**
+ * This file is used to put all wlroots headers needed in the Wayfire
+ * (not only API) in an extern "C" block because wlroots headers are not
+ * always compatible with C++.
+ *
+ * Note that some wlroots headers require generated protocol header files.
+ * There are disabled unless the protocol header file is present.
+ */
+#include <wayfire/nonstd/wlroots.hpp>
+
+// WF_USE_CONFIG_H is set only when building Wayfire itself, external plugins
+// need to use <wayfire/config.h>
+#ifdef WF_USE_CONFIG_H
+    #include <config.h>
+#else
+    #include <wayfire/config.h>
+#endif
+
+extern "C"
+{
+// Rendering
+#define static
+#include <wlr/types/wlr_compositor.h>
+#include <wlr/render/wlr_renderer.h>
+#include <wlr/render/gles2.h>
+#include <wlr/render/egl.h>
+#include <wlr/types/wlr_matrix.h>
+#undef static
+#include <wlr/types/wlr_buffer.h>
+
+#include <wlr/types/wlr_output_damage.h>
+#include <wlr/types/wlr_presentation_time.h>
+#include <wlr/util/region.h>
+#include <wlr/types/wlr_screencopy_v1.h>
+#include <wlr/types/wlr_export_dmabuf_v1.h>
+
+// Shells
+#if  __has_include(<xdg-shell-protocol.h>)
+    #include <wlr/types/wlr_xdg_shell.h>
+    #include <wlr/types/wlr_xdg_decoration_v1.h>
+#endif
+#include <wlr/types/wlr_surface.h>
+
+#include <wlr/types/wlr_foreign_toplevel_management_v1.h>
+#include <wlr/types/wlr_server_decoration.h>
+
+// layer-shell needs the protocol file, so we cannot expose it here
+#if  __has_include(<wlr-layer-shell-unstable-v1-protocol.h>)
+    #define namespace namespace_t
+    #include <wlr/types/wlr_layer_shell_v1.h>
+    #undef namespace
+#endif
+
+#if WF_HAS_XWAYLAND
+    // We need to rename class to class_t for the xwayland definitions.
+    // However, it indirectly includes pthread.h which uses 'class' in the
+    // C++ meaning, so we should include pthread before overriding 'class'.
+    #if __has_include(<pthread.h>)
+        #include <pthread.h>
+    #endif
+
+    #define class class_t
+    #define static
+    #include <wlr/xwayland.h>
+    #undef static
+    #undef class
+#endif
+
+// Backends
+#include <wlr/config.h>
+#define static
+#include <wlr/backend.h>
+#include <wlr/backend/drm.h>
+#if WLR_HAS_X11_BACKEND
+    #include <wlr/backend/x11.h>
+#endif
+#include <wlr/backend/noop.h>
+#include <wlr/backend/wayland.h>
+#undef static
+#include <wlr/backend/libinput.h>
+#include <wlr/backend/session.h>
+#include <wlr/util/log.h>
+
+// Output management
+#include <wlr/types/wlr_output_layout.h>
+#include <wlr/types/wlr_output_management_v1.h>
+
+#if __has_include(<wlr-output-power-management-unstable-v1-protocol.h>)
+    #include <wlr/types/wlr_output_power_management_v1.h>
+#endif
+#include <wlr/types/wlr_gamma_control_v1.h>
+#include <wlr/types/wlr_xdg_output_v1.h>
+
+// Input
+#include <wlr/types/wlr_seat.h>
+#if __has_include(<pointer-constraints-unstable-v1-protocol.h>)
+    #include <wlr/types/wlr_pointer_constraints_v1.h>
+#endif
+#include <wlr/types/wlr_cursor.h>
+#if __has_include(<tablet-unstable-v2-protocol.h>)
+    #include <wlr/types/wlr_tablet_v2.h>
+#endif
+#include <wlr/types/wlr_data_device.h>
+#include <wlr/types/wlr_primary_selection.h>
+#include <wlr/types/wlr_switch.h>
+#include <wlr/types/wlr_xcursor_manager.h>
+#include <wlr/types/wlr_pointer_gestures_v1.h>
+#include <wlr/types/wlr_idle.h>
+#include <wlr/interfaces/wlr_keyboard.h>
+#include <wlr/xcursor.h>
+#include <wlr/types/wlr_data_control_v1.h>
+#include <wlr/types/wlr_virtual_keyboard_v1.h>
+#include <wlr/types/wlr_virtual_pointer_v1.h>
+#include <wlr/types/wlr_idle_inhibit_v1.h>
+#include <wlr/types/wlr_input_inhibitor.h>
+#define delete delete_
+#include <wlr/types/wlr_input_method_v2.h>
+#undef delete
+#include <wlr/types/wlr_relative_pointer_v1.h>
+#include <wlr/types/wlr_text_input_v3.h>
+#include <wlr/types/wlr_gtk_primary_selection.h>
+#include <wlr/types/wlr_primary_selection_v1.h>
+}

--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+/**
+ * This file is used to put all wlroots headers needed in the Wayfire API
+ * in an extern "C" block because wlroots headers are not always compatible
+ * with C++.
+ */
+extern "C"
+{
+    struct wlr_backend;
+    struct wlr_renderer;
+    struct wlr_seat;
+    struct wlr_cursor;
+    struct wlr_data_device_manager;
+    struct wlr_data_control_manager_v1;
+    struct wlr_gamma_control_manager_v1;
+    struct wlr_xdg_output_manager_v1;
+    struct wlr_export_dmabuf_manager_v1;
+    struct wlr_server_decoration_manager;
+    struct wlr_xdg_decoration_manager_v1;
+    struct wlr_input_inhibit_manager;
+    struct wlr_virtual_keyboard_manager_v1;
+    struct wlr_virtual_pointer_manager_v1;
+    struct wlr_idle;
+    struct wlr_idle_inhibit_manager_v1;
+    struct wlr_screencopy_manager_v1;
+    struct wlr_foreign_toplevel_manager_v1;
+    struct wlr_pointer_gestures_v1;
+    struct wlr_relative_pointer_manager_v1;
+    struct wlr_pointer_constraints_v1;
+    struct wlr_tablet_manager_v2;
+    struct wlr_input_method_manager_v2;
+    struct wlr_text_input_manager_v3;
+    struct wlr_presentation;
+    struct wlr_gtk_primary_selection_device_manager;
+    struct wlr_primary_selection_v1_device_manager;
+
+    struct wlr_event_pointer_axis;
+    struct wlr_event_pointer_motion;
+    struct wlr_output_layout;
+    struct wlr_surface;
+    struct wlr_texture;
+
+#include <wlr/types/wlr_input_device.h>
+#include <wlr/types/wlr_output.h>
+#include <wlr/types/wlr_box.h>
+#include <wlr/util/edges.h>
+}

--- a/src/api/wayfire/opengl.hpp
+++ b/src/api/wayfire/opengl.hpp
@@ -6,6 +6,7 @@
 #include <wayfire/config/types.hpp>
 #include <wayfire/util.hpp>
 #include <wayfire/nonstd/noncopyable.hpp>
+#include <wayfire/nonstd/wlroots.hpp>
 
 #include <wayfire/geometry.hpp>
 
@@ -16,7 +17,7 @@
 void gl_call(const char*, uint32_t, const char*);
 
 #ifndef __STRING
- #  define __STRING(x) #x
+    #  define __STRING(x) #x
 #endif
 
 /*
@@ -29,10 +30,6 @@ struct gl_geometry
 {
     float x1, y1, x2, y2;
 };
-
-extern "C" {
-    struct wlr_texture;
-}
 
 namespace wf
 {

--- a/src/api/wayfire/output-layout.hpp
+++ b/src/api/wayfire/output-layout.hpp
@@ -1,18 +1,12 @@
 #ifndef OUTPUT_LAYOUT_HPP
 #define OUTPUT_LAYOUT_HPP
 
-extern "C"
-{
-    struct wlr_backend;
-    struct wlr_output_layout;
-#include <wlr/types/wlr_output.h>
-}
-
 #include <map>
 #include <vector>
 #include <memory>
 #include <functional>
 
+#include <wayfire/nonstd/wlroots.hpp>
 #include "wayfire/object.hpp"
 #include "wayfire/util.hpp"
 

--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -5,13 +5,9 @@
 #include "wayfire/object.hpp"
 #include "wayfire/bindings.hpp"
 
+#include <wayfire/nonstd/wlroots.hpp>
 #include <wayfire/option-wrapper.hpp>
 #include <wayfire/config/types.hpp>
-
-extern "C"
-{
-    struct wlr_output;
-}
 
 namespace wf
 {

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -6,10 +6,7 @@
 #include "wayfire/util.hpp"
 #include "wayfire/bindings.hpp"
 
-extern "C"
-{
-#include <wlr/types/wlr_input_device.h>
-}
+#include <wayfire/nonstd/wlroots.hpp>
 
 class wayfire_config;
 namespace wf

--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -6,12 +6,9 @@
 #include <vector>
 #include <memory>
 
+#include <wayfire/nonstd/wlroots.hpp>
 #include <wayfire/nonstd/observer_ptr.h>
 #include <wayfire/geometry.hpp>
-
-extern "C" {
-    struct wlr_surface;
-}
 
 namespace wf
 {

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -7,12 +7,7 @@
 #include "wayfire/object.hpp"
 #include "wayfire/surface.hpp"
 #include "wayfire/geometry.hpp"
-
-extern "C"
-{
-    struct wlr_surface;
-#include <wlr/util/edges.h>
-}
+#include <wayfire/nonstd/wlroots.hpp>
 
 namespace wf
 {

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -3,16 +3,10 @@
 
 #include "wayfire/core.hpp"
 #include "wayfire/util.hpp"
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #include <set>
 #include <unordered_map>
-
-extern "C"
-{
-    struct wlr_egl;
-    struct wlr_compositor;
-    struct wlr_surface;
-}
 
 class input_manager;
 class input_method_relay;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -1,42 +1,6 @@
-extern "C"
-{
-#include <wlr/config.h>
-#include <wlr/types/wlr_data_control_v1.h>
-#include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_virtual_keyboard_v1.h>
-#include <wlr/types/wlr_virtual_pointer_v1.h>
-#include <wlr/types/wlr_foreign_toplevel_management_v1.h>
-#include <wlr/types/wlr_idle.h>
-#include <wlr/types/wlr_idle_inhibit_v1.h>
-#include <wlr/types/wlr_input_inhibitor.h>
-#include <wlr/types/wlr_export_dmabuf_v1.h>
-#include <wlr/types/wlr_server_decoration.h>
-#include <wlr/types/wlr_xdg_decoration_v1.h>
-#include <wlr/types/wlr_gamma_control_v1.h>
-#include <wlr/types/wlr_xdg_output_v1.h>
-#include <wlr/types/wlr_screencopy_v1.h>
-#include <wlr/types/wlr_pointer_gestures_v1.h>
-#include <wlr/types/wlr_relative_pointer_v1.h>
-#include <wlr/types/wlr_pointer_constraints_v1.h>
-#include <wlr/types/wlr_tablet_v2.h>
-#include <wlr/types/wlr_text_input_v3.h>
-#include <wlr/types/wlr_presentation_time.h>
-#include <wlr/types/wlr_gtk_primary_selection.h>
-#include <wlr/types/wlr_primary_selection_v1.h>
-
-#define delete delete_
-#include <wlr/types/wlr_input_method_v2.h>
-#undef delete
-
-#define static
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/types/wlr_compositor.h>
-#undef static
-}
-
 /* Needed for pipe2 */
 #ifndef _GNU_SOURCE
- #define _GNU_SOURCE
+    #define _GNU_SOURCE
 #endif
 
 #include <sys/wait.h>
@@ -49,6 +13,7 @@ extern "C"
 #include <wayfire/output-layout.hpp>
 #include <wayfire/workspace-manager.hpp>
 #include <wayfire/signal-definitions.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #include "opengl-priv.hpp"
 #include "seat/input-manager.hpp"

--- a/src/core/img.cpp
+++ b/src/core/img.cpp
@@ -5,9 +5,9 @@
 #include <config.h>
 
 #ifdef BUILD_WITH_IMAGEIO
- #include <png.h>
- #include <jpeglib.h>
- #include <jerror.h>
+    #include <png.h>
+    #include <jpeglib.h>
+    #include <jerror.h>
 #endif
 
 #include <stdint.h>

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -4,16 +4,7 @@
 #include "wayfire/output.hpp"
 #include "core-impl.hpp"
 #include "config.h"
-
-extern "C"
-{
-#define static
-#include <wlr/render/egl.h>
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/render/gles2.h>
-#undef static
-#include <wlr/types/wlr_output.h>
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #include <glm/gtc/matrix_transform.hpp>
 

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -16,26 +16,7 @@
 #include <unordered_set>
 
 #include <wayfire/util/log.hpp>
-
-extern "C"
-{
-#include <wlr/config.h>
-#define static
-#include <wlr/backend.h>
-#include <wlr/backend/drm.h>
-#if WLR_HAS_X11_BACKEND
- #include <wlr/backend/x11.h>
-#endif
-#include <wlr/backend/noop.h>
-#include <wlr/backend/wayland.h>
-#include <wlr/types/wlr_output.h>
-#include <wlr/types/wlr_matrix.h>
-#include <wlr/types/wlr_output_layout.h>
-#include <wlr/types/wlr_output_management_v1.h>
-#include <wlr/types/wlr_output_power_management_v1.h>
-#include <wlr/render/wlr_renderer.h>
-#undef static
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 static wl_output_transform get_transform_from_string(std::string transform)
 {

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -8,14 +8,7 @@
 #include "wayfire/output-layout.hpp"
 #include "tablet.hpp"
 #include "wayfire/signal-definitions.hpp"
-
 #include "wayfire/util/log.hpp"
-
-extern "C" {
-#include <wlr/util/region.h>
-#include <wlr/types/wlr_relative_pointer_v1.h>
-#include <wlr/types/wlr_pointer_constraints_v1.h>
-}
 
 wf_cursor::wf_cursor()
 {

--- a/src/core/seat/cursor.hpp
+++ b/src/core/seat/cursor.hpp
@@ -4,13 +4,6 @@
 #include "seat.hpp"
 #include "wayfire/plugin.hpp"
 
-extern "C"
-{
-#include <wlr/types/wlr_xcursor_manager.h>
-#include <wlr/types/wlr_pointer_gestures_v1.h>
-}
-
-
 struct wf_cursor
 {
     wf_cursor();

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -1,12 +1,6 @@
 #include <cassert>
 #include <algorithm>
 #include "surface-map-state.hpp"
-
-extern "C"
-{
-#include <wlr/types/wlr_seat.h>
-}
-
 #include "wayfire/signal-definitions.hpp"
 #include "../core-impl.hpp"
 #include "../../output/output-impl.hpp"

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -14,14 +14,6 @@
 #include "wayfire/signal-definitions.hpp"
 #include <wayfire/option-wrapper.hpp>
 
-extern "C"
-{
-#include <wlr/types/wlr_idle.h>
-#include <wlr/types/wlr_seat.h>
-    struct wlr_drag_icon;
-    struct wlr_pointer_constraint_v1;
-}
-
 namespace wf
 {
 class touch_interface_t;
@@ -30,8 +22,6 @@ namespace touch
 class gesture_action_t;
 }
 }
-
-struct wlr_seat;
 
 struct wf_keyboard;
 

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -2,15 +2,7 @@
 #include "seat.hpp"
 #include "wayfire/util.hpp"
 #include "wayfire/signal-definitions.hpp"
-
-extern "C" {
-#include <wlr/types/wlr_text_input_v3.h>
-#include <wlr/types/wlr_surface.h>
-
-#define delete delete_
-#include <wlr/types/wlr_input_method_v2.h>
-#undef delete
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #include <vector>
 #include <memory>

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -1,12 +1,6 @@
 #include <cstring>
 #include <linux/input-event-codes.h>
-
-extern "C"
-{
 #include <xkbcommon/xkbcommon.h>
-#include <wlr/backend/session.h>
-#include <wlr/interfaces/wlr_keyboard.h>
-}
 
 #include <wayfire/util/log.hpp>
 #include "keyboard.hpp"

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -8,13 +8,6 @@
 #include <wayfire/output-layout.hpp>
 #include <wayfire/compositor-surface.hpp>
 
-extern "C"
-{
-#include <wlr/types/wlr_seat.h>
-#include <wlr/types/wlr_pointer_constraints_v1.h>
-#include <wlr/types/wlr_relative_pointer_v1.h>
-}
-
 wf::LogicalPointer::LogicalPointer(nonstd::observer_ptr<input_manager> input)
 {
     this->input = input;

--- a/src/core/seat/pointer.hpp
+++ b/src/core/seat/pointer.hpp
@@ -7,12 +7,7 @@
 #include <wayfire/util.hpp>
 #include <wayfire/option-wrapper.hpp>
 #include "surface-map-state.hpp"
-
-extern "C"
-{
-    struct wlr_pointer_constraint_v1;
-#include <wlr/types/wlr_seat.h>
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 class input_manager;
 namespace wf

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -8,11 +8,6 @@
 #include <wayfire/util/log.hpp>
 #include "wayfire/signal-definitions.hpp"
 
-extern "C"
-{
-#include <wlr/backend/libinput.h>
-}
-
 wf_drag_icon::wf_drag_icon(wlr_drag_icon *ic) :
     wf::wlr_child_surface_base_t(this), icon(ic)
 {

--- a/src/core/seat/seat.hpp
+++ b/src/core/seat/seat.hpp
@@ -1,13 +1,7 @@
 #ifndef SEAT_HPP
 #define SEAT_HPP
 
-extern "C"
-{
-#include <wlr/types/wlr_data_device.h>
-#include <wlr/types/wlr_primary_selection.h>
-#include <wlr/backend/libinput.h>
-#include <wlr/types/wlr_switch.h>
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #include "../../view/surface-impl.hpp"
 #include "wayfire/output.hpp"

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -5,11 +5,6 @@
 #include <wayfire/signal-definitions.hpp>
 #include <linux/input-event-codes.h>
 
-extern "C"
-{
-#include <wlr/types/wlr_tablet_v2.h>
-}
-
 /* --------------------- Tablet tool implementation ------------------------- */
 wf::tablet_tool_t::tablet_tool_t(wlr_tablet_tool *tool,
     wlr_tablet_v2_tablet *tablet)

--- a/src/core/seat/tablet.hpp
+++ b/src/core/seat/tablet.hpp
@@ -1,10 +1,6 @@
 #ifndef WF_SEAT_TABLET_HPP
 #define WF_SEAT_TABLET_HPP
 
-extern "C" {
-    struct wlr_cursor;
-#include <wlr/types/wlr_tablet_v2.h>
-}
 #include <wayfire/util.hpp>
 #include "seat.hpp"
 

--- a/src/core/seat/touch.hpp
+++ b/src/core/seat/touch.hpp
@@ -8,12 +8,6 @@
 
 #include "surface-map-state.hpp"
 
-extern "C"
-{
-#include <wlr/types/wlr_cursor.h>
-#include <wlr/types/wlr_seat.h>
-}
-
 // TODO: tests
 namespace wf
 {

--- a/src/core/view-access-interface.cpp
+++ b/src/core/view-access-interface.cpp
@@ -6,21 +6,6 @@
 #include <algorithm>
 #include <iostream>
 #include <string>
-#include <wlr/util/edges.h>
-#include "config.h"
-
-#if WF_HAS_XWAYLAND
-extern "C"
-{
- #define static
- #define class class_t
- #define namespace namespace_t
- #include <wlr/xwayland.h>
- #undef static
- #undef class
- #undef namespace
-}
-#endif
 
 namespace wf
 {

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -6,19 +6,10 @@
 #include "wayfire/output-layout.hpp"
 
 #include <wayfire/util/log.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #include "../output/output-impl.hpp"
 #include "wayfire/signal-definitions.hpp"
-
-extern "C"
-{
-#include <wlr/config.h>
-#if WLR_HAS_X11_BACKEND
- #include <wlr/backend/x11.h>
-#endif
-#include <wlr/backend/wayland.h>
-#include <wlr/backend/noop.h>
-}
 
 static void idle_shutdown(void *data)
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,16 +13,6 @@
 #include "wayfire/nonstd/safe-list.hpp"
 #include <wayfire/config/file.hpp>
 
-extern "C"
-{
-#define static
-#include <wlr/render/gles2.h>
-#undef static
-#include <wlr/backend/multi.h>
-#include <wlr/backend/wayland.h>
-#include <wlr/util/log.h>
-}
-
 #include <wayland-server.h>
 
 #include "core/core-impl.hpp"

--- a/src/meson.build
+++ b/src/meson.build
@@ -70,40 +70,8 @@ executable('wayfire', wayfire_sources,
         link_args: '-ldl',
         install: true)
 
-install_headers(['api/wayfire/nonstd/safe-list.hpp',
-                 'api/wayfire/nonstd/noncopyable.hpp',
-                 'api/wayfire/nonstd/observer_ptr.h',
-                 'api/wayfire/nonstd/reverse.hpp'],
-                subdir: 'wayfire/nonstd')
-
-install_headers(['api/wayfire/compositor-surface.hpp',
-                 'api/wayfire/compositor-view.hpp',
-                 'api/wayfire/bindings.hpp',
-                 'api/wayfire/core.hpp',
-                 'api/wayfire/debug.hpp',
-                 'api/wayfire/decorator.hpp',
-                 'api/wayfire/img.hpp',
-                 'api/wayfire/geometry.hpp',
-                 'api/wayfire/object.hpp',
-                 'api/wayfire/opengl.hpp',
-                 'api/wayfire/option-wrapper.hpp',
-                 'api/wayfire/output.hpp',
-                 'api/wayfire/plugin.hpp',
-                 'api/wayfire/singleton-plugin.hpp',
-                 'api/wayfire/render-manager.hpp',
-                 'api/wayfire/signal-definitions.hpp',
-                 'api/wayfire/util.hpp',
-                 'api/wayfire/surface.hpp',
-                 'api/wayfire/view-transform.hpp',
-                 'api/wayfire/view.hpp',
-                 'api/wayfire/view-access-interface.hpp',
-                 'api/wayfire/workspace-manager.hpp',
-                 'api/wayfire/workspace-stream.hpp',
-                 'api/wayfire/input-device.hpp',
-                 'api/wayfire/output-layout.hpp',
-                 'api/wayfire/matcher.hpp',
-                 'api/wayfire/gtk-shell.hpp'],
-                subdir: 'wayfire')
+install_subdir('api/wayfire',
+    install_dir: get_option('includedir'))
 
 pkgconfig = import('pkgconfig')
 pkgconfig.generate(

--- a/src/output/gtk-shell.cpp
+++ b/src/output/gtk-shell.cpp
@@ -1,7 +1,3 @@
-extern "C"
-{
-#include <wlr/types/wlr_surface.h>
-}
 #include "gtk-shell.hpp"
 #include "gtk-shell-protocol.h"
 #include <wayfire/util/log.hpp>
@@ -11,6 +7,7 @@ extern "C"
 #include <map>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/gtk-shell.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 #define GTK_SHELL_VERSION 3
 
 struct wf_gtk_shell

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -10,12 +10,7 @@
 #include "../core/seat/input-manager.hpp"
 #include "../view/xdg-shell.hpp"
 #include <wayfire/util/log.hpp>
-
-#include <linux/input.h>
-extern "C"
-{
-#include <wlr/types/wlr_output.h>
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 #include <algorithm>
 #include <assert.h>

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -11,17 +11,7 @@
 #include <wayfire/nonstd/reverse.hpp>
 #include <wayfire/nonstd/safe-list.hpp>
 #include <wayfire/util/log.hpp>
-
-extern "C"
-{
-    /* wlr uses some c99 extensions, we "disable" the static keyword to workaround */
-#define static
-#include <wlr/render/wlr_renderer.h>
-#undef static
-#include <wlr/types/wlr_output_damage.h>
-#include <wlr/types/wlr_presentation_time.h>
-#include <wlr/util/region.h>
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 namespace wf
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -5,11 +5,7 @@
 #include <iomanip>
 #include <ctime>
 #include <cmath>
-
-extern "C"
-{
-#include <wlr/util/region.h>
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 /* Geometry helpers */
 std::ostream& operator <<(std::ostream& stream, const wf::geometry_t& geometry)

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -7,14 +7,6 @@
 
 #include <glm/gtc/matrix_transform.hpp>
 
-extern "C"
-{
-#define static
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/types/wlr_matrix.h>
-#undef static
-}
-
 /* Implementation of mirror_view_t */
 wf::mirror_view_t::mirror_view_t(wayfire_view base_view) :
     wf::view_interface_t()

--- a/src/view/layer-shell.cpp
+++ b/src/view/layer-shell.cpp
@@ -5,17 +5,11 @@
 #include "wayfire/core.hpp"
 #include "wayfire/debug.hpp"
 #include <wayfire/util/log.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 #include "wayfire/output.hpp"
 #include "wayfire/workspace-manager.hpp"
 #include "wayfire/output-layout.hpp"
 #include "view-impl.hpp"
-
-extern "C"
-{
-#define namespace namespace_t
-#include <wlr/types/wlr_layer_shell_v1.h>
-#undef namespace
-}
 
 static const uint32_t both_vert =
     ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP | ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM;

--- a/src/view/subsurface.hpp
+++ b/src/view/subsurface.hpp
@@ -2,6 +2,7 @@
 #define WF_SUBSURFACE_HPP
 
 #include "surface-impl.hpp"
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 namespace wf
 {

--- a/src/view/surface-impl.hpp
+++ b/src/view/surface-impl.hpp
@@ -5,11 +5,6 @@
 #include <wayfire/surface.hpp>
 #include <wayfire/util.hpp>
 
-extern "C"
-{
-#include <wlr/types/wlr_surface.h>
-}
-
 namespace wf
 {
 class surface_interface_t::impl

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -1,19 +1,6 @@
 #include <algorithm>
 #include <map>
 #include <wayfire/util/log.hpp>
-extern "C"
-{
-#include <wlr/types/wlr_surface.h>
-#define static
-#include <wlr/types/wlr_compositor.h>
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/render/gles2.h>
-#include <wlr/types/wlr_matrix.h>
-#include <wlr/types/wlr_buffer.h>
-#include <wlr/util/region.h>
-#undef static
-}
-
 #include "surface-impl.hpp"
 #include "subsurface.hpp"
 #include "wayfire/opengl.hpp"

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -9,11 +9,6 @@
 
 #include "xdg-shell.hpp"
 
-extern "C"
-{
-#include <wlr/util/edges.h>
-}
-
 wf::wlr_view_t::wlr_view_t() :
     wf::wlr_surface_base_t(this), wf::view_interface_t()
 {}
@@ -553,24 +548,6 @@ void wf::init_desktop_apis()
     {
         init_xwayland();
     }
-}
-
-extern "C"
-{
-#include <wlr/config.h>
-
-#define namespace namespace_t
-#include <wlr/types/wlr_layer_shell_v1.h>
-#undef namespace
-#include <wlr/types/wlr_xdg_shell.h>
-
-#if WF_HAS_XWAYLAND
- #define class class_t
- #define static
- #include <wlr/xwayland.h>
- #undef static
- #undef class
-#endif
 }
 
 wf::surface_interface_t*wf::wf_surface_from_void(void *handle)

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -6,12 +6,7 @@
 #include <wayfire/opengl.hpp>
 
 #include "surface-impl.hpp"
-
-extern "C"
-{
-#include <wlr/types/wlr_foreign_toplevel_management_v1.h>
-    struct wlr_xcursor_image;
-}
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 // for emit_map_*()
 #include <wayfire/compositor-view.hpp>

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -15,17 +15,6 @@
 #include <glm/glm.hpp>
 #include "wayfire/signal-definitions.hpp"
 
-extern "C"
-{
-#define static
-#include <wlr/config.h>
-#include <wlr/render/wlr_renderer.h>
-#include <wlr/types/wlr_matrix.h>
-#include <wlr/util/region.h>
-#include <wlr/util/edges.h>
-#undef static
-}
-
 static void reposition_relative_to_parent(wayfire_view view)
 {
     if (!view->parent)

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -2,10 +2,6 @@
 #define XDG_SHELL_HPP
 
 #include "view-impl.hpp"
-extern "C"
-{
-#include <wlr/types/wlr_xdg_shell.h>
-}
 
 /**
  * A class for xdg-shell popups

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -1,5 +1,6 @@
 #include "wayfire/debug.hpp"
 #include <wayfire/util/log.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 #include "wayfire/core.hpp"
 #include "wayfire/output.hpp"
 #include "wayfire/workspace-manager.hpp"
@@ -8,20 +9,6 @@
 #include "wayfire/signal-definitions.hpp"
 #include "../core/core-impl.hpp"
 #include "view-impl.hpp"
-
-extern "C"
-{
-#include <wlr/config.h>
-
-#if WF_HAS_XWAYLAND
- #define class class_t
- #define static
- #include <wlr/xwayland.h>
- #include <wlr/xcursor.h>
- #undef static
- #undef class
-#endif
-}
 
 #if WF_HAS_XWAYLAND
 

--- a/uncrustify.ini
+++ b/uncrustify.ini
@@ -1061,6 +1061,7 @@ mod_enum_last_comma             = force   # ignore/add/remove/force
 # Add or remove indentation of preprocessor directives inside #if blocks
 # at brace level 0 (file-level).
 pp_indent                       = add   # ignore/add/remove/force
+pp_indent_count                 = 4
 
 # Whether to indent the code between #if, #else and #endif.
 pp_if_indent_code               = false    # true/false


### PR DESCRIPTION
There are three reasons to do this:

- Having `#define` and `#undef` everywhere a wlroots header is included is
not nice.
- It is easy to forget to include `wlr/config.h` or `wayfire/config.h`,
which are needed for `WF_HAS_WAYLAND`/`WLR_HAS_X11_BACKEND`.
- `extern "C"` seems to not play nicely with clangd, making code
completions slow in files where it is present.
