### PR TITLE
Set cursor to default pointer when over no surface

### DIFF
--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -156,6 +156,11 @@ void wf::LogicalPointer::update_cursor_focus(wf::surface_interface_t *focus,
 
         set_pointer_constraint(constraint);
     }
+
+    if (!cursor_focus)
+    {
+        wf::get_core().set_cursor("default");
+    }
 }
 
 wf::surface_interface_t*wf::LogicalPointer::get_focus() const

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -157,6 +157,11 @@ void wf::tablet_tool_t::set_focus(wf::surface_interface_t *surface)
         wlr_tablet_v2_tablet_tool_notify_proximity_in(
             tool_v2, tablet_v2, next_focus);
     }
+
+    if (!next_focus)
+    {
+        wf::get_core().set_cursor("default");
+    }
 }
 
 void wf::tablet_tool_t::passthrough_axis(wlr_event_tablet_tool_axis *ev)


### PR DESCRIPTION
This makes it so the cursor is reset to default when not over any surface.
This can happen if there is no background application running, for example.