### PR TITLE
Emit focus-view signal when focus is lost

### DIFF
--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -261,10 +261,13 @@ void wf::output_impl_t::focus_view(wayfire_view v, uint32_t flags)
         return;
     }
 
+    focus_view_signal data;
+
     if (!v || !v->is_mapped())
     {
         update_active_view(nullptr, flags);
-
+        data.view = nullptr;
+        emit_signal("focus-view", &data);
         return;
     }
 
@@ -278,8 +281,6 @@ void wf::output_impl_t::focus_view(wayfire_view v, uint32_t flags)
     {
         make_view_visible(v);
         update_active_view(v, flags);
-
-        focus_view_signal data;
         data.view = v;
         emit_signal("view-focused", &data);
     }


### PR DESCRIPTION
There are currently no signals emitted when a view or output loses focus.
This emits focus-view with view set to null when an output loses focus.
Useful for scale to know to set inactive opacity when scale is active
on more than one output.

Cherry-picked from #555
