### PR TITLE
render-manager: Use normal transform type for headless path

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -273,7 +273,7 @@ struct postprocessing_manager_t
         }
 
         fb.wl_transform = wlr_output_transform_compose(
-            (wl_output_transform)fb.wl_transform, WL_OUTPUT_TRANSFORM_FLIPPED_180);
+            (wl_output_transform)fb.wl_transform, WL_OUTPUT_TRANSFORM_NORMAL);
         fb.transform = get_output_matrix_from_transform(
             (wl_output_transform)fb.wl_transform);
     }


### PR DESCRIPTION
Flip headless backend to be right-side-up while we wait for wlroots
swapchain work to be merged.