### PR TITLE
view: add ping and ping-timeout support

### DIFF
--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -510,6 +510,14 @@ using view_decoration_state_updated_signal = _view_signal;
  * argument: unused.
  */
 
+/**
+ * name: ping-timeout
+ * on: view
+ * when: Whenever the client fails to respond to a ping request within
+ *   the expected time(10 seconds).
+ */
+using view_ping_timeout_signal = _view_signal;
+
 /* ----------------------------------------------------------------------------/
  * View <-> output signals
  * -------------------------------------------------------------------------- */

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -142,6 +142,12 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
     virtual void close();
 
     /**
+     * Ping the view's client.
+     * If the ping request times out, `ping-timeout` event will be emitted.
+     */
+    virtual void ping();
+
+    /**
      * The wm geometry of the view is the portion of the view surface that
      * contains the actual contents, for example, without the view shadows, etc.
      *

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -348,6 +348,13 @@ void wf::emit_view_map_signal(wayfire_view view, bool has_position)
     view->emit_signal("mapped", &data);
 }
 
+void wf::emit_ping_timeout_signal(wayfire_view view)
+{
+    wf::view_ping_timeout_signal data;
+    data.view = view;
+    view->emit_signal("ping-timeout", &data);
+}
+
 void wf::view_interface_t::emit_view_map()
 {
     emit_view_map_signal(self(), false);

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -207,6 +207,7 @@ class wlr_view_t :
 
 /** Emit the map signal for the given view */
 void emit_view_map_signal(wayfire_view view, bool has_position);
+void emit_ping_timeout_signal(wayfire_view view);
 
 wf::surface_interface_t *wf_surface_from_void(void *handle);
 wf::view_interface_t *wf_view_from_void(void *handle);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -259,6 +259,11 @@ void wf::view_interface_t::request_native_size()
     /* no-op */
 }
 
+void wf::view_interface_t::ping()
+{
+    // Do nothing, specialized in the various shells
+}
+
 void wf::view_interface_t::close()
 {
     /* no-op */

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -9,7 +9,8 @@
 class wayfire_xdg_popup : public wf::wlr_view_t
 {
   protected:
-    wf::wl_listener_wrapper on_destroy, on_new_popup, on_map, on_unmap;
+    wf::wl_listener_wrapper on_destroy, on_new_popup,
+        on_map, on_unmap, on_ping_timeout;
     wf::signal_connection_t parent_geometry_changed,
         parent_title_changed, parent_app_id_changed;
 
@@ -29,6 +30,7 @@ class wayfire_xdg_popup : public wf::wlr_view_t
     virtual wf::point_t get_window_offset() override;
     virtual void destroy() override;
     virtual void close() override;
+    void ping() final;
 };
 
 void create_xdg_popup(wlr_xdg_popup *popup);
@@ -40,7 +42,7 @@ class wayfire_xdg_view : public wf::wlr_view_t
         on_request_move, on_request_resize,
         on_request_minimize, on_request_maximize,
         on_request_fullscreen, on_set_parent,
-        on_set_title, on_set_app_id;
+        on_set_title, on_set_app_id, on_ping_timeout;
 
     wf::point_t xdg_surface_offset = {0, 0};
     wlr_xdg_toplevel *xdg_toplevel;
@@ -67,6 +69,7 @@ class wayfire_xdg_view : public wf::wlr_view_t
 
     void destroy() final;
     void close() final;
+    void ping() final;
 };
 
 #endif /* end of include guard: XDG_SHELL_HPP */

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -243,6 +243,14 @@ class wayfire_xwayland_view_base : public wf::wlr_view_t
         wf::wlr_view_t::destroy();
     }
 
+    virtual void ping() override
+    {
+        if (xw)
+        {
+            wlr_xwayland_surface_ping(xw);
+        }
+    }
+
     /* Translates geometry from X client configure requests to wayfire
      * coordinate system. The X coordinate system treats all outputs
      * as one big desktop, whereas wayfire treats the current workspace

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -60,7 +60,8 @@ class wayfire_xwayland_view_base : public wf::wlr_view_t
 
   protected:
     wf::wl_listener_wrapper on_destroy, on_unmap, on_map, on_configure,
-        on_set_title, on_set_app_id, on_or_changed, on_set_decorations;
+        on_set_title, on_set_app_id, on_or_changed, on_set_decorations,
+        on_ping_timeout;
 
     wlr_xwayland_surface *xw;
     /** The geometry requested by the client */
@@ -198,6 +199,10 @@ class wayfire_xwayland_view_base : public wf::wlr_view_t
         {
             update_decorated();
         });
+        on_ping_timeout.set_callback([&] (void*)
+        {
+            wf::emit_ping_timeout_signal(self());
+        });
 
         handle_title_changed(nonull(xw->title));
         handle_app_id_changed(nonull(xw->class_t));
@@ -210,6 +215,7 @@ class wayfire_xwayland_view_base : public wf::wlr_view_t
         on_set_title.connect(&xw->events.set_title);
         on_set_app_id.connect(&xw->events.set_class);
         on_or_changed.connect(&xw->events.set_override_redirect);
+        on_ping_timeout.connect(&xw->events.ping_timeout);
         on_set_decorations.connect(&xw->events.set_decorations);
     }
 
@@ -231,6 +237,7 @@ class wayfire_xwayland_view_base : public wf::wlr_view_t
         on_set_title.disconnect();
         on_set_app_id.disconnect();
         on_or_changed.disconnect();
+        on_ping_timeout.disconnect();
         on_set_decorations.disconnect();
 
         wf::wlr_view_t::destroy();


### PR DESCRIPTION
These mechanisms are available for xdg-shell and Xwayland.

The idea is that plugins send a ping request to the client, and it should respond within 10 seconds. If it does, nothing happens, otherwise, the plugin(s) can guess that the client is unresponsive and thus present the user with an option to kill that client.

Fixes #140

@AdrianVovk I have not tested this API yet, however it is fairly simple so I hope it works fine.
