### PR TITLE
fix window rules destruction

### DIFF
--- a/plugins/single_plugins/alpha.cpp
+++ b/plugins/single_plugins/alpha.cpp
@@ -132,11 +132,14 @@ class wayfire_alpha : public wf::plugin_interface_t
 
     void fini() override
     {
-        for (auto& view : output->workspace->get_views_in_layer(wf::ALL_LAYERS))
+        for (auto& view : wf::get_core().get_all_views())
         {
-            if (view->get_transformer("alpha"))
+            if (!view->get_output() || (view->get_output() == output))
             {
-                view->pop_transformer("alpha");
+                if (view->get_transformer("alpha"))
+                {
+                    view->pop_transformer("alpha");
+                }
             }
         }
 

--- a/plugins/window-rules/lambda-rules-registration.hpp
+++ b/plugins/window-rules/lambda-rules-registration.hpp
@@ -123,9 +123,8 @@ class lambda_rules_registrations_t : public custom_data_t
         auto instance = get_core().get_data<lambda_rules_registrations_t>();
         if (instance == nullptr)
         {
-            get_core().store_data(std::unique_ptr<lambda_rules_registrations_t>(new
-                lambda_rules_registrations_t()));
-
+            get_core().store_data(std::unique_ptr<lambda_rules_registrations_t>(
+                new lambda_rules_registrations_t()));
             instance = get_core().get_data<lambda_rules_registrations_t>();
 
             if (instance == nullptr)
@@ -211,6 +210,10 @@ class lambda_rules_registrations_t : public custom_data_t
      * @brief _registrations The map holding all the current registrations.
      */
     map_type _registrations;
+
+    // Necessary for window-rules to manage the lifetime of the object
+    uint32_t window_rule_instances = 0;
+    friend class ::wayfire_window_rules_t;
 };
 } // End namespace wf.
 

--- a/plugins/window-rules/window-rules.cpp
+++ b/plugins/window-rules/window-rules.cpp
@@ -46,6 +46,7 @@ void wayfire_window_rules_t::init()
 {
     // Get the lambda rules registrations.
     _lambda_registrations = wf::lambda_rules_registrations_t::get_instance();
+    _lambda_registrations->window_rule_instances++;
 
     // Build rule list.
     auto section = wf::get_core().config.get_section("window-rules");
@@ -102,6 +103,12 @@ void wayfire_window_rules_t::fini()
     output->disconnect_signal("view-tiled", &_unmaximized);
     output->disconnect_signal("view-minimized", &_minimized);
     output->disconnect_signal("view-fullscreen", &_fullscreened);
+
+    _lambda_registrations->window_rule_instances--;
+    if (_lambda_registrations->window_rule_instances == 0)
+    {
+        wf::get_core().erase_data<wf::lambda_rules_registrations_t>();
+    }
 }
 
 void wayfire_window_rules_t::apply(const std::string & signal,


### PR DESCRIPTION
- window-rules: destroy global object
- alpha: fix shutdown crashes

Fixes the shutdown crash reported by @dkondor
