### PR TITLE
scale: make fade animation use the animation duration

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -779,8 +779,8 @@ class wayfire_scale : public wf::plugin_interface_t
         view_data.animation.scale_animation.translation_y.set(
             view_data.transformer->translation_y, translation_y);
         view_data.animation.scale_animation.start();
-        view_data.fade_animation =
-            wf::animation::simple_animation_t(wf::create_option<int>(1000));
+        view_data.fade_animation = wf::animation::simple_animation_t(
+            wf::option_wrapper_t<int>{"scale/duration"});
         view_data.fade_animation.animate(view_data.transformer->alpha,
             target_alpha);
     }


### PR DESCRIPTION
I think making it the same as the initial animation makes sense (for ex. I want faster animation and fast scale startup but slow fade looks pretty bad). If anyone wants to control the two animation durations separately, then a PR would be welcome.
