### PR TITLE
add compositor stages

### DIFF
--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -34,6 +34,29 @@ class output_t;
 class output_layout_t;
 class input_device_t;
 
+/** Describes the state of the compositor */
+enum class compositor_state_t
+{
+    /** Not started */
+    UNKNOWN,
+    /**
+     * The compositor core has finished initializing.
+     * Now the wlroots backends are being started, which results in
+     * adding of new input and output devices, as well as starting the
+     * plugins on each output.
+     */
+    START_BACKEND,
+    /**
+     * The compositor has loaded the initial devices and plugins and is
+     * running the main loop.
+     */
+    RUNNING,
+    /**
+     * The compositor has stopped the main loop and is shutting down.
+     */
+    SHUTDOWN,
+};
+
 class compositor_core_t : public wf::object_base_t
 {
   public:
@@ -270,6 +293,11 @@ class compositor_core_t : public wf::object_base_t
      * @return The PID of the started client, or -1 on failure.
      */
     virtual pid_t run(std::string command) = 0;
+
+    /**
+     * @return The current state of the compositor.
+     */
+    virtual compositor_state_t get_current_state() = 0;
 
     /**
      * Shut down the whole compositor.

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'16;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'19;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -32,9 +32,17 @@ class compositor_core_impl_t : public compositor_core_t
     std::unique_ptr<input_method_relay> im_relay;
 
     /**
-     * Initialize the compositor core. Called only by main()
+     * Initialize the compositor core.
+     * Called only by main().
      */
     void init();
+
+    /**
+     * Finish initialization of core after the backend has started.
+     * Called only by main().
+     */
+    void post_init();
+
     wayfire_shell *wf_shell;
     wf_gtk_shell *gtk_shell;
 
@@ -84,6 +92,7 @@ class compositor_core_impl_t : public compositor_core_t
     std::string get_xwayland_display() override;
     pid_t run(std::string command) override;
     void shutdown() override;
+    compositor_state_t get_current_state() override;
 
   private:
     wf::wl_listener_wrapper decoration_created;
@@ -108,6 +117,8 @@ class compositor_core_impl_t : public compositor_core_t
      * The view might not actually have focus, because of plugin grabs.
      */
     wayfire_view last_active_view;
+
+    compositor_state_t state = compositor_state_t::UNKNOWN;
 
     compositor_core_impl_t();
     virtual ~compositor_core_impl_t();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -295,6 +295,25 @@ void wf::compositor_core_impl_t::init()
 
     image_io::init();
     OpenGL::init();
+
+    this->state = compositor_state_t::START_BACKEND;
+}
+
+void wf::compositor_core_impl_t::post_init()
+{
+    this->state = compositor_state_t::RUNNING;
+}
+
+void wf::compositor_core_impl_t::shutdown()
+{
+    this->state = compositor_state_t::SHUTDOWN;
+    wf::get_core().emit_signal("shutdown", nullptr);
+    wl_display_terminate(wf::get_core().display);
+}
+
+wf::compositor_state_t wf::compositor_core_impl_t::get_current_state()
+{
+    return this->state;
 }
 
 wlr_seat*wf::compositor_core_impl_t::get_current_seat()
@@ -720,12 +739,6 @@ pid_t wf::compositor_core_impl_t::run(std::string command)
 
         return child_pid;
     }
-}
-
-void wf::compositor_core_impl_t::shutdown()
-{
-    wf::get_core().emit_signal("shutdown", nullptr);
-    wl_display_terminate(wf::get_core().display);
 }
 
 std::string wf::compositor_core_impl_t::get_xwayland_display()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -306,6 +306,9 @@ void wf::compositor_core_impl_t::post_init()
 
     // Refresh device mappings when we have all outputs and devices
     input->refresh_device_mappings();
+
+    // Start processing cursor events
+    input->cursor->setup_listeners();
 }
 
 void wf::compositor_core_impl_t::shutdown()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -301,7 +301,11 @@ void wf::compositor_core_impl_t::init()
 
 void wf::compositor_core_impl_t::post_init()
 {
+    this->emit_signal("_backend_started", nullptr);
     this->state = compositor_state_t::RUNNING;
+
+    // Refresh device mappings when we have all outputs and devices
+    input->refresh_device_mappings();
 }
 
 void wf::compositor_core_impl_t::shutdown()

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -19,8 +19,6 @@ wf_cursor::wf_cursor()
 
     wlr_cursor_map_to_output(cursor, NULL);
     wlr_cursor_warp(cursor, NULL, cursor->x, cursor->y);
-
-    setup_listeners();
     init_xcursor();
 
     config_reloaded = [=] (wf::signal_data_t*)

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -93,6 +93,13 @@ void input_manager::handle_new_input(wlr_input_device *dev)
 
 void input_manager::refresh_device_mappings()
 {
+    // Might trigger motion events which we want to avoid at other stages
+    auto state = wf::get_core().get_current_state();
+    if (state != wf::compositor_state_t::RUNNING)
+    {
+        return;
+    }
+
     for (auto& device : this->input_devices)
     {
         wlr_input_device *dev = device->get_wlr_handle();

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -89,9 +89,9 @@ class input_manager
 
     wf::signal_callback_t output_added;
 
+  public:
     void refresh_device_mappings();
 
-  public:
     /* TODO: move this in a wf_keyboard struct,
      * This might not work with multiple keyboards */
     uint32_t mod_binding_key = 0; /* The keycode which triggered the modifier binding

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -389,6 +389,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
+    core.post_init();
     setenv("WAYLAND_DISPLAY", core.wayland_display.c_str(), 1);
     wl_display_run(core.display);
 

--- a/uncrustify.ini
+++ b/uncrustify.ini
@@ -647,7 +647,7 @@ nl_enum_brace                   = force   # ignore/add/remove/force
 nl_enum_class                   = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'enum class' and the identifier.
-nl_enum_class_identifier        = force   # ignore/add/remove/force
+nl_enum_class_identifier        = remove   # ignore/add/remove/force
 
 # Add or remove newline between 'enum class' type and ':'.
 nl_enum_identifier_colon        = remove   # ignore/add/remove/force


### PR DESCRIPTION
- uncrustify: fix wrongly added newline between enum class and ident
- core: add information about compositor state to API
- core: refresh device mappings after the backend has started

This should fix #671, @myfreeweb do you have a way to verify the crash is fixed?
