### PR TITLE
fix view geometry with multiple outputs and workspaces

### DIFF
--- a/plugins/common/wayfire/plugins/common/move-snap-helper.hpp
+++ b/plugins/common/wayfire/plugins/common/move-snap-helper.hpp
@@ -138,6 +138,8 @@ class move_snap_helper_t : public wf::custom_data_t
         {
             end_wobbly(v);
         }
+
+        view->disconnect_signal("geometry-changed", &view_geometry_changed);
     }
 
     /** @return Whether the view is freely moving or stays at the same place */

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -399,6 +399,16 @@ class wayfire_grid : public wf::plugin_interface_t
         handle_slot(data->view, data->slot);
     };
 
+    wf::geometry_t adjust_for_workspace(wf::geometry_t geometry,
+        wf::point_t workspace)
+    {
+        auto delta_ws = workspace - output->workspace->get_current_workspace();
+        auto scr_size = output->get_screen_size();
+        geometry.x += delta_ws.x * scr_size.width;
+        geometry.y += delta_ws.y * scr_size.height;
+        return geometry;
+    }
+
     wf::signal_callback_t on_maximize_signal = [=] (wf::signal_data_t *ddata)
     {
         auto data = static_cast<wf::view_tile_request_signal*>(ddata);
@@ -417,7 +427,8 @@ class wayfire_grid : public wf::plugin_interface_t
         }
 
         data->view->get_data_safe<wf_grid_slot_data>()->slot = slot;
-        ensure_grid_view(data->view)->adjust_target_geometry(data->desired_size,
+        ensure_grid_view(data->view)->adjust_target_geometry(
+            adjust_for_workspace(data->desired_size, data->workspace),
             get_tiled_edges_for_slot(slot));
     };
 
@@ -434,7 +445,7 @@ class wayfire_grid : public wf::plugin_interface_t
 
         data->carried_out = true;
         ensure_grid_view(data->view)->adjust_target_geometry(
-            data->desired_size, -1);
+            adjust_for_workspace(data->desired_size, data->workspace), -1);
     };
 
     void fini() override

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -311,7 +311,6 @@ class wayfire_move : public wf::plugin_interface_t
         }
 
         MOVE_HELPER->handle_input_released();
-        view->erase_data<wf::move_snap_helper_t>();
 
         /* Delete any mirrors we have left, showing an animation */
         delete_mirror_views(true);
@@ -319,8 +318,8 @@ class wayfire_move : public wf::plugin_interface_t
         /* Don't do snapping, etc for shell views */
         if (view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT)
         {
+            view->erase_data<wf::move_snap_helper_t>();
             this->view = nullptr;
-
             return;
         }
 
@@ -342,6 +341,7 @@ class wayfire_move : public wf::plugin_interface_t
         workspace_may_changed.old_viewport_invalid = false;
         output->emit_signal("view-change-viewport", &workspace_may_changed);
 
+        view->erase_data<wf::move_snap_helper_t>();
         this->view = nullptr;
     }
 

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -24,6 +24,9 @@ struct dimensions_t
 
 using geometry_t = wlr_box;
 
+point_t origin(const geometry_t& geometry);
+dimensions_t dimensions(const geometry_t& geometry);
+
 /* Returns the intersection of the two boxes, if the boxes don't intersect,
  * the resulting geometry has undefined (x,y) and width == height == 0 */
 geometry_t geometry_intersection(const geometry_t& r1,

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'19;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'20;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -412,6 +412,11 @@ struct view_tile_request_signal : public _view_signal
     wf::geometry_t desired_size;
 
     /**
+     * The target workspace of the operation.
+     */
+    wf::point_t workspace;
+
+    /**
      * Whether some plugin will service the tile request, in which case other
      * plugins and core should ignore the request.
      */
@@ -445,6 +450,13 @@ struct view_fullscreen_signal : public _view_signal
      * by core and plugins may override it. It may also be undefined (0,0 0x0).
      */
     wf::geometry_t desired_size;
+
+    /**
+     * For view-fullscreen-request:
+     *
+     * The target workspace of the operation.
+     */
+    wf::point_t workspace;
 };
 
 /**

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -219,7 +219,7 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
      * set_activated() or focus_request() */
     bool activated = false;
     /** Whether the view is in minimized state, usually you want to use either
-     * set_minizied() or minimize_request() */
+     * set_minimized() or minimize_request() */
     bool minimized = false;
     /** Whether the view is sticky. If a view is sticky it will not be affected
      * by changes of the current workspace. */
@@ -250,12 +250,28 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
     /**
      * Request that the view is (un)tiled.
      *
+     * If the view is being tiled, the caller should ensure thaat the view is on
+     * the correct workspace.
+     *
      * Note: by default, any tiled edges means that the view gets the full
      * workarea.
      */
     virtual void tile_request(uint32_t tiled_edges);
+
+    /**
+     * Request that the view is (un)tiled on the given workspace.
+     */
+    virtual void tile_request(uint32_t tiled_edges, wf::point_t ws);
+
     /** Request that the view is (un)fullscreened on the given output */
     virtual void fullscreen_request(wf::output_t *output, bool state);
+
+    /**
+     * Request that the view is (un)fullscreened on the given output
+     * and workspace.
+     */
+    virtual void fullscreen_request(wf::output_t *output, bool state,
+        wf::point_t ws);
 
     /** @return true if the view is visible */
     virtual bool is_visible();

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -217,29 +217,7 @@ void transfer_views(wf::output_t *from, wf::output_t *to)
 
         for (auto& view : views)
         {
-            wf::get_core().move_view_to_output(view, to, false);
-            to->workspace->move_to_workspace(view,
-                to->workspace->get_current_workspace());
-
-            if (view->is_mapped())
-            {
-                if (view->tiled_edges)
-                {
-                    view->tile_request(view->tiled_edges);
-                }
-
-                if (view->fullscreen)
-                {
-                    view->fullscreen_request(to, true);
-                }
-
-                if (!view->fullscreen && !view->tiled_edges)
-                {
-                    auto geometry = wf::clamp(view->get_wm_geometry(),
-                        to->workspace->get_workarea());
-                    view->set_geometry(geometry);
-                }
-            }
+            wf::get_core().move_view_to_output(view, to, true);
         }
     }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -31,6 +31,16 @@ std::ostream& operator <<(std::ostream& stream, const wf::pointf_t& pointf)
     return stream;
 }
 
+wf::point_t wf::origin(const geometry_t& geometry)
+{
+    return {geometry.x, geometry.y};
+}
+
+wf::dimensions_t wf::dimensions(const geometry_t& geometry)
+{
+    return {geometry.width, geometry.height};
+}
+
 bool operator ==(const wf::dimensions_t& a, const wf::dimensions_t& b)
 {
     return a.width == b.width && a.height == b.height;
@@ -622,4 +632,4 @@ void wl_timer::execute()
         call();
     }
 }
-}
+} // namespace wf

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -46,7 +46,8 @@ class view_interface_t::view_priv_impl
     wf::geometry_t calculate_windowed_geometry(wf::output_t *output);
 
     /**
-     * Update the stored window geometry and workarea.
+     * Update the stored window geometry and workarea, if the current view
+     * state is not-tiled and not-moving.
      */
     void update_windowed_geometry(wayfire_view self, wf::geometry_t geometry);
 

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -40,10 +40,15 @@ class view_interface_t::view_priv_impl
 
     bool keyboard_focus_enabled = true;
 
-    /* For window restoration from maximized or fullscreen
-     * -1 means that no such geometry has been stored. */
-    wf::geometry_t last_windowed_geometry  = {0, 0, -1, -1};
-    wf::geometry_t last_maximized_geometry = {0, 0, -1, -1};
+    /**
+     * Calculate the windowed geometry relative to the output's workarea.
+     */
+    wf::geometry_t calculate_windowed_geometry(wf::output_t *output);
+
+    /**
+     * Update the stored window geometry and workarea.
+     */
+    void update_windowed_geometry(wayfire_view self, wf::geometry_t geometry);
 
     /* those two point to the same object. Two fields are used to avoid
      * constant casting to and from types */
@@ -67,6 +72,18 @@ class view_interface_t::view_priv_impl
     } offscreen_buffer;
 
     wlr_box minimize_hint = {0, 0, 0, 0};
+
+  private:
+    /** Last geometry the view has had in non-tiled and non-fullscreen state.
+     * -1 as width/height means that no such geometry has been stored. */
+    wf::geometry_t last_windowed_geometry = {0, 0, -1, -1};
+
+    /**
+     * The workarea when last_windowed_geometry was stored. This is used
+     * for ex. when untiling a view to determine its geometry relative to the
+     * (potentially changed) workarea of its output.
+     */
+    wf::geometry_t windowed_geometry_workarea = {0, 0, -1, -1};
 };
 
 /**

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -639,10 +639,11 @@ void wf::view_interface_t::minimize_request(bool state)
 
 void wf::view_interface_t::fullscreen_request(wf::output_t *out, bool state)
 {
-    if (get_output())
+    auto wo = (out ?: (get_output() ?: wf::get_core().get_active_output()));
+    if (wo)
     {
-        fullscreen_request(out, state,
-            out->workspace->get_current_workspace());
+        fullscreen_request(wo, state,
+            wo->workspace->get_current_workspace());
     }
 }
 

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -309,6 +309,8 @@ void wayfire_xdg_view::commit()
          * old geometry */
         set_position(wm.x, wm.y, wm, true);
     }
+
+    this->last_size_request = wf::dimensions(xdg_g);
 }
 
 wf::point_t wayfire_xdg_view::get_window_offset()
@@ -327,10 +329,10 @@ wf::geometry_t wayfire_xdg_view::get_wm_geometry()
     auto xdg_geometry = get_xdg_geometry(xdg_toplevel);
 
     wf::geometry_t wm = {
-        output_g.x + xdg_surface_offset.x,
-        output_g.y + xdg_surface_offset.y,
-        xdg_geometry.width,
-        xdg_geometry.height
+        .x     = output_g.x + xdg_surface_offset.x,
+        .y     = output_g.y + xdg_surface_offset.y,
+        .width = xdg_geometry.width,
+        .height = xdg_geometry.height
     };
 
     if (view_impl->frame)

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -599,7 +599,7 @@ class wayfire_xwayland_view : public wayfire_xwayland_view_base
                 /* Make sure geometry is properly visible on the view output */
                 save_geometry = wf::clamp(save_geometry,
                     get_output()->workspace->get_workarea());
-                this->view_impl->last_windowed_geometry = save_geometry;
+                view_impl->update_windowed_geometry(self(), save_geometry);
             }
 
             tile_request(wf::TILED_EDGES_ALL);
@@ -632,8 +632,7 @@ class wayfire_xwayland_view : public wayfire_xwayland_view_base
 
         /* Avoid loops where the client wants to have a certain size but the
          * compositor keeps trying to resize it */
-        last_size_request.width  = geometry.width;
-        last_size_request.height = geometry.height;
+        last_size_request = wf::dimensions(geometry);
     }
 
     void set_moving(bool moving) override


### PR DESCRIPTION
- view: consider workspaces for tiling and fullscreening
- output-layout: fix moving views when output is disconnected
- grid: add support for maximizing on a workspace
- view: store windowed geometry before starting move

Fixes #606
Fixes #625
