### PR TITLE
make minimized views per-workspace

### DIFF
--- a/plugins/vswitch/vswitch.cpp
+++ b/plugins/vswitch/vswitch.cpp
@@ -132,7 +132,7 @@ class vswitch : public wf::plugin_interface_t
 
         /* Make sure that when we add this direction, we won't go outside
          * of the workspace grid */
-        auto target = algorithm->get_target_workspace();
+        auto target = output->workspace->get_current_workspace();
         auto wsize  = output->workspace->get_workspace_grid_size();
         int tvx     = wf::clamp(target.x + delta.x, 0, wsize.width - 1);
         int tvy     = wf::clamp(target.y + delta.y, 0, wsize.height - 1);
@@ -154,11 +154,7 @@ class vswitch : public wf::plugin_interface_t
         wf::signal_data_t *data)
     {
         auto ev = static_cast<wf::workspace_change_request_signal*>(data);
-
-        auto old_ws = is_active() ?
-            algorithm->get_target_workspace() : ev->old_viewport;
-
-        if (old_ws == ev->new_viewport)
+        if (ev->old_viewport == ev->new_viewport)
         {
             // nothing to do
             ev->carried_out = true;
@@ -168,7 +164,7 @@ class vswitch : public wf::plugin_interface_t
 
         if (is_active())
         {
-            ev->carried_out = add_direction(ev->new_viewport - old_ws);
+            ev->carried_out = add_direction(ev->new_viewport - ev->old_viewport);
         } else
         {
             if (this->set_capabilities(0))
@@ -179,7 +175,7 @@ class vswitch : public wf::plugin_interface_t
                         "changing workspace with more than 1 fixed view");
                 }
 
-                ev->carried_out = add_direction(ev->new_viewport - old_ws,
+                ev->carried_out = add_direction(ev->new_viewport - ev->old_viewport,
                     ev->fixed_views.empty() ? nullptr : ev->fixed_views[0]);
             }
         }

--- a/plugins/vswitch/wayfire/plugins/vswitch.hpp
+++ b/plugins/vswitch/wayfire/plugins/vswitch.hpp
@@ -75,20 +75,12 @@ class workspace_switch_t
     virtual void set_target_workspace(point_t workspace)
     {
         point_t cws = output->workspace->get_current_workspace();
-        animation.dx.restart_with_end(workspace.x - cws.x);
-        animation.dy.restart_with_end(workspace.y - cws.y);
+
+        animation.dx.set(animation.dx + cws.x - workspace.x, 0);
+        animation.dy.set(animation.dy + cws.y - workspace.y, 0);
         animation.start();
-    }
 
-    /** @return The current target workspace. */
-    virtual point_t get_target_workspace()
-    {
-        point_t ws = output->workspace->get_current_workspace();
-
-        return {
-            (int)std::round(ws.x + animation.dx.end),
-            (int)std::round(ws.y + animation.dy.end),
-        };
+        output->workspace->set_workspace(workspace);
     }
 
     /**
@@ -152,7 +144,6 @@ class workspace_switch_t
             }
 
             auto old_ws = output->workspace->get_current_workspace();
-            output->workspace->set_workspace(get_target_workspace(), fixed_views);
             adjust_overlay_view_switch_done(old_ws);
         }
 

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'20;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'21;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -469,6 +469,20 @@ struct view_fullscreen_signal : public _view_signal
 using view_fullscreen_request_signal = view_fullscreen_signal;
 
 /**
+ * name: view-focus-request
+ * on: output, core
+ * when: Emitted whenever some entity (typically a panel) wants to focus the view.
+ */
+struct view_focus_request_signal : public _view_signal
+{
+    /** Set to true if core and other plugins should not handle this request. */
+    bool carried_out = false;
+
+    /** Set to true if the request comes from the view client itself */
+    bool self_request;
+};
+
+/**
  * name: set-sticky
  * on: view, output(view-)
  * when: Whenever the view's sticky state changes.
@@ -640,13 +654,6 @@ struct view_hints_changed_signal : public _view_signal
 {
     bool demands_attention = false;
 };
-
-/**
- * name: self-request-focus
- * on: view, core(view-)
- * when: Whenever the client requests that a view be focused.
- */
-using view_self_request_focus_signal = _view_signal;
 
 /**
  * name: view-system-bell

--- a/src/output/gtk-shell.cpp
+++ b/src/output/gtk-shell.cpp
@@ -82,10 +82,11 @@ static void handle_gtk_surface_present(wl_client *client, wl_resource *resource,
     wayfire_view view = wf::wl_surface_to_wayfire_view(surface);
     if (view)
     {
-        wf::view_self_request_focus_signal data;
+        wf::view_focus_request_signal data;
         data.view = view;
-        view->emit_signal("self-request-focus", &data);
-        wf::get_core().emit_signal("view-self-request-focus", &data);
+        data.self_request = true;
+        view->emit_signal("view-focus-request", &data);
+        wf::get_core().emit_signal("view-focus-request", &data);
     }
 }
 
@@ -103,10 +104,11 @@ static void handle_gtk_surface_request_focus(struct wl_client *client,
     wayfire_view view = wf::wl_surface_to_wayfire_view(surface);
     if (view)
     {
-        wf::view_self_request_focus_signal data;
+        wf::view_focus_request_signal data;
         data.view = view;
-        view->emit_signal("self-request-focus", &data);
-        wf::get_core().emit_signal("view-self-request-focus", &data);
+        data.self_request = true;
+        view->emit_signal("view-focus-request", &data);
+        wf::get_core().emit_signal("view-focus-request", &data);
     }
 }
 

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -658,7 +658,8 @@ class output_viewport_manager_t
         auto dx     = (data.old_viewport.x - nws.x) * screen.width;
         auto dy     = (data.old_viewport.y - nws.y) * screen.height;
 
-        for (auto& view : output->workspace->get_views_in_layer(MIDDLE_LAYERS))
+        for (auto& view : output->workspace->get_views_in_layer(
+            MIDDLE_LAYERS | LAYER_MINIMIZED))
         {
             auto it = std::find(fixed_views.cbegin(), fixed_views.cend(), view);
             if ((it == fixed_views.end()) && !view->sticky)

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -376,15 +376,6 @@ void wf::view_interface_t::set_minimized(bool minim)
         data.view = self();
         get_output()->emit_signal("view-disappeared", &data);
         get_output()->workspace->add_view(self(), wf::LAYER_MINIMIZED);
-
-        /* We want to be sure that when we restore the view, it will be visible
-         * on the then current workspace
-         *
-         * Because the minimized layer doesn't move when switching workspaces,
-         * we know that making it "visible" in the minimize layer will ensure
-         * it is visible when we restore it */
-        get_output()->workspace->move_to_workspace(self(),
-            get_output()->workspace->get_current_workspace());
     } else
     {
         get_output()->workspace->add_view(self(), wf::LAYER_WORKSPACE);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -493,8 +493,9 @@ void wf::view_interface_t::move_request()
 
 void wf::view_interface_t::focus_request()
 {
-    wf::get_core().focus_view(self());
+    wf::get_core().focus_output(get_output());
     get_output()->ensure_visible(self());
+    get_output()->focus_view(self(), true);
 }
 
 void wf::view_interface_t::resize_request(uint32_t edges)

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -493,9 +493,21 @@ void wf::view_interface_t::move_request()
 
 void wf::view_interface_t::focus_request()
 {
-    wf::get_core().focus_output(get_output());
-    get_output()->ensure_visible(self());
-    get_output()->focus_view(self(), true);
+    if (get_output())
+    {
+        view_focus_request_signal data;
+        data.view = self();
+        data.self_request = false;
+
+        get_output()->emit_signal("view-focus-request", &data);
+        wf::get_core().emit_signal("view-focus-request", &data);
+        if (!data.carried_out)
+        {
+            wf::get_core().focus_output(get_output());
+            get_output()->ensure_visible(self());
+            get_output()->focus_view(self(), true);
+        }
+    }
 }
 
 void wf::view_interface_t::resize_request(uint32_t edges)

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -491,10 +491,11 @@ class wayfire_xwayland_view : public wayfire_xwayland_view_base
         {
             if (!this->activated)
             {
-                wf::view_self_request_focus_signal data;
-                data.view = this;
-                wf::get_core().emit_signal("view-self-request-focus", &data);
-                this->emit_signal("self-request-focus", &data);
+                wf::view_focus_request_signal data;
+                data.view = self();
+                data.self_request = true;
+                emit_signal("view-focus-request", &data);
+                wf::get_core().emit_signal("view-focus-request", &data);
             }
         });
 


### PR DESCRIPTION
- core: make minimized layer behave like the others
- view: make focus_request work better
- vswitch: switch workspace before starting animation

This has been requested in IRC before, and in #178.

With these changes, minimized views are "per-workspace". Clicking on a minimized view in wf-panel will go to the view's original workspace.

Fixes #178 (the view is focused on its original output and we switch to its original workspace).

@AdrianVovk if you want to override this behavior, you can create a plugin to do so:

1. Connect to view-focus-request.
2. If the view is on the focused output, let core handle the request.
3. Otherwise, set carried_out to false to block other plugins and core.
4. Move the view to the output and workspace you want it to be.
5. Call view->focus_request() there.

@damianatorrpm Sorry for the breaking change, but `view-self-focus-request` has been replaced with the more generic `view-focus-request`. You still have a flag to differentiate between a call from wf-panel and a call from gtk-shell.
