### PR TITLE
view: add last_focus_timestamp

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'21;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'22;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -458,6 +458,12 @@ class view_interface_t : public surface_interface_t, public wf::object_base_t
     class view_priv_impl;
     std::unique_ptr<view_priv_impl> view_impl;
 
+    /**
+     * The last time(nanoseconds since epoch) when the view was focused.
+     * Updated automatically by core.
+     */
+    uint64_t last_focus_timestamp = 0;
+
   protected:
     view_interface_t();
 


### PR DESCRIPTION
Also make refocus use the last focused view, not the topmost one.
Fixes #664
