### PR TITLE
view: make sure view-focus-request is emitted on the view and on core

### DIFF
--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -470,7 +470,7 @@ using view_fullscreen_request_signal = view_fullscreen_signal;
 
 /**
  * name: view-focus-request
- * on: output, core
+ * on: view, core
  * when: Emitted whenever some entity (typically a panel) wants to focus the view.
  */
 struct view_focus_request_signal : public _view_signal

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -499,7 +499,7 @@ void wf::view_interface_t::focus_request()
         data.view = self();
         data.self_request = false;
 
-        get_output()->emit_signal("view-focus-request", &data);
+        emit_signal("view-focus-request", &data);
         wf::get_core().emit_signal("view-focus-request", &data);
         if (!data.carried_out)
         {


### PR DESCRIPTION
This is the same way view-self-request-focus used to work.
