### PR TITLE
seat: restore mod_binding_key support after 8bbbcc72a

### DIFF
--- a/src/core/seat/bindings-repository.cpp
+++ b/src/core/seat/bindings-repository.cpp
@@ -1,9 +1,14 @@
 #include "bindings-repository.hpp"
+#include "wayfire/util/log.hpp"
 #include <algorithm>
 
-bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed)
+bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed,
+    uint32_t mod_binding_key)
 {
     std::vector<std::function<bool()>> callbacks;
+    uint32_t actual_key = pressed.get_key() ==
+        0 ? mod_binding_key : pressed.get_key();
+
     for (auto& binding : this->keys)
     {
         if (binding->activated_by->get_value() == pressed)
@@ -11,9 +16,9 @@ bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed)
             /* We must be careful because the callback might be erased,
              * so force copy the callback into the lambda */
             auto callback = binding->callback;
-            callbacks.emplace_back([pressed, callback] ()
+            callbacks.emplace_back([actual_key, callback] ()
             {
-                return (*callback)(pressed.get_key());
+                return (*callback)(actual_key);
             });
         }
     }

--- a/src/core/seat/bindings-repository.hpp
+++ b/src/core/seat/bindings-repository.hpp
@@ -37,7 +37,7 @@ class bindings_repository_t
      *
      * @return true if any of the matching registered bindings consume the event.
      */
-    bool handle_key(const wf::keybinding_t& pressed);
+    bool handle_key(const wf::keybinding_t& pressed, uint32_t mod_binding_key);
 
     /** Handle an axis event. */
     bool handle_axis(uint32_t modifiers, wlr_event_pointer_axis *ev);

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -306,7 +306,7 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
         }
 
         handled_in_binding = input->get_active_bindings().handle_key(
-            wf::keybinding_t{get_modifiers(), key});
+            wf::keybinding_t{get_modifiers(), key}, mod_binding_key);
     } else
     {
         if (mod_binding_key != 0)
@@ -319,7 +319,7 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
             if ((timeout <= 0) || (time_elapsed < milliseconds(timeout)))
             {
                 handled_in_binding = input->get_active_bindings().handle_key(
-                    wf::keybinding_t{get_modifiers() | mod, 0});
+                    wf::keybinding_t{get_modifiers() | mod, 0}, mod_binding_key);
             }
         }
 


### PR DESCRIPTION
Currently this is the only way for plugins to e.g. distinguish whether the '<shift>' binding was pressed by the left or right Shift key.

This unbreaks my mod2key plugin after #806, though I'm planning on adding '<lshift>' etc. bindings for that.