### PR TITLE
Add OpenGL::program_t::uniform3f

### DIFF
--- a/src/api/wayfire/opengl.hpp
+++ b/src/api/wayfire/opengl.hpp
@@ -320,6 +320,8 @@ class program_t : public noncopyable_t
     /** Set the given uniform for the currently used program. */
     void uniform2f(const std::string& name, float x, float y);
     /** Set the given uniform for the currently used program. */
+    void uniform3f(const std::string& name, float x, float y, float z);
+    /** Set the given uniform for the currently used program. */
     void uniform4f(const std::string& name, const glm::vec4& value);
     /** Set the given uniform for the currently used program. */
     void uniformMatrix4f(const std::string& name, const glm::mat4& value);

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -688,6 +688,12 @@ void program_t::uniform2f(const std::string& name, float x, float y)
     GL_CALL(glUniform2f(loc, x, y));
 }
 
+void program_t::uniform3f(const std::string& name, float x, float y, float z)
+{
+    int loc = priv->find_uniform_loc(name);
+    GL_CALL(glUniform3f(loc, x, y, z));
+}
+
 void program_t::uniform4f(const std::string& name, const glm::vec4& value)
 {
     int loc = priv->find_uniform_loc(name);


### PR DESCRIPTION
For plugin usage; maybe also `find_uniform_loc` should be exposed in the outer non-private object but for now I just need this one