### PR TITLE
blur optimizations

### DIFF
--- a/metadata/blur.xml
+++ b/metadata/blur.xml
@@ -51,7 +51,7 @@
 			<_long>Sets the degrade value for the box method.</_long>
 			<default>1</default>
 			<min>1</min>
-			<max>5</max>
+			<max>10</max>
 		</option>
 		<option name="box_iterations" type="int">
 			<_short>Box iterations</_short>
@@ -73,7 +73,7 @@
 			<_long>Sets the degrade value for the gaussian method.</_long>
 			<default>1</default>
 			<min>1</min>
-			<max>5</max>
+			<max>10</max>
 		</option>
 		<option name="gaussian_iterations" type="int">
 			<_short>Gaussian iterations</_short>
@@ -95,7 +95,7 @@
 			<_long>Sets the degrade value for the kawase method.</_long>
 			<default>1</default>
 			<min>1</min>
-			<max>5</max>
+			<max>10</max>
 		</option>
 		<option name="kawase_iterations" type="int">
 			<_short>Kawase iterations</_short>
@@ -117,7 +117,7 @@
 			<_long>Sets the degrade value for the bokeh method.</_long>
 			<default>1</default>
 			<min>1</min>
-			<max>5</max>
+			<max>10</max>
 		</option>
 		<option name="bokeh_iterations" type="int">
 			<_short>Bokeh iterations</_short>

--- a/metadata/blur.xml
+++ b/metadata/blur.xml
@@ -86,14 +86,14 @@
 		<option name="kawase_offset" type="double">
 			<_short>Kawase offset</_short>
 			<_long>Sets the offset value for the kawase method.</_long>
-			<default>5</default>
+			<default>2</default>
 			<min>0</min>
 			<max>25</max>
 		</option>
 		<option name="kawase_degrade" type="int">
 			<_short>Kawase degrade</_short>
 			<_long>Sets the degrade value for the kawase method.</_long>
-			<default>1</default>
+			<default>8</default>
 			<min>1</min>
 			<max>10</max>
 		</option>

--- a/metadata/blur.xml
+++ b/metadata/blur.xml
@@ -5,18 +5,10 @@
 		<_long>A plugin to blur windows.</_long>
 		<category>Effects</category>
 		<!-- Mode -->
-		<option name="mode" type="string">
-			<_short>Mode</_short>
-			<_long>Specifies whether blurring should be automatic or manual.  Possible values are `normal` and `toggle`.  `normal` means automatic and `toggle` manual.</_long>
-			<default>normal</default>
-			<desc>
-				<value>normal</value>
-				<_name>Normal</_name>
-			</desc>
-			<desc>
-				<value>toggle</value>
-				<_name>Toggle</_name>
-			</desc>
+		<option name="blur_by_default" type="string">
+			<_short>Blur by default</_short>
+			<_long>Criteria for which apps to be blurred when they are opened</_long>
+			<default>type is "toplevel"</default>
 		</option>
 		<!-- Key-bindings -->
 		<option name="toggle" type="button">

--- a/plugins/blur/blur-base.cpp
+++ b/plugins/blur/blur-base.cpp
@@ -70,7 +70,7 @@ wf_blur_base::~wf_blur_base()
 
 int wf_blur_base::calculate_blur_radius()
 {
-    return offset_opt * degrade_opt * iterations_opt;
+    return offset_opt * degrade_opt * std::max(1, (int)iterations_opt);
 }
 
 void wf_blur_base::render_iteration(wf::region_t blur_region,

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -341,10 +341,10 @@ class wayfire_blur : public wf::plugin_interface_t
             const auto& ws = static_cast<wf::stream_signal_t*>(data)->ws;
             const auto& target_fb = static_cast<wf::stream_signal_t*>(data)->fb;
 
-            wf::region_t expanded_damage = expand_region(damage, target_fb.scale);
+            wf::region_t expanded_damage =
+                expand_region(damage & get_blur_region(ws), target_fb.scale);
 
             /* Keep rects on screen */
-            expanded_damage &= expand_region(get_blur_region(ws), target_fb.scale);
             expanded_damage &= output->render->get_ws_box(ws);
 
             /* Compute padded region and store result in padded_region.

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -325,7 +325,6 @@ class wayfire_blur : public wf::plugin_interface_t
 
             output->render->damage(expand_region(
                 damage & this->blur_region, fb.scale));
-            return;
         };
         output->render->add_effect(&frame_pre_paint, wf::OUTPUT_EFFECT_DAMAGE);
 


### PR DESCRIPTION
- blur: add option to configure which views should be blurred
- blur: calculate blur region

The new option is called `blur/blur_by_default` and has type criteria. If you want a bit more efficient blur, set only views that you want to blur.

I believe we can close #669 with this PR.