### PR TITLE
output-layout: ensure noop output is in the output list when it exists

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1560,12 +1560,9 @@ class output_layout_t::impl
             }
         }
 
-        if (result.empty())
+        if (noop_output && noop_output->output)
         {
-            if (noop_output && noop_output->output)
-            {
-                result.push_back(noop_output->output.get());
-            }
+            result.push_back(noop_output->output.get());
         }
 
         return result;


### PR DESCRIPTION
This makes it possible for plugins like primary-output-switch to restore views from NOOP outputs.

Will merge this after 0.6.0 release because it may have other unintended consequences, so this needs more testing.

