### PR TITLE
programmable activators

### DIFF
--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -254,7 +254,7 @@ class wayfire_blur : public wf::plugin_interface_t
         method_opt.set_callback(blur_method_changed);
 
         /* Toggles the blur state of the view the user clicked on */
-        button_toggle = [=] (uint32_t, int, int)
+        button_toggle = [=] (auto)
         {
             if (!output->can_activate_plugin(grab_interface))
             {

--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -113,17 +113,17 @@ class wayfire_cube : public wf::plugin_interface_t
 
         reload_background();
 
-        activate_binding = [=] (uint32_t, int, int)
+        activate_binding = [=] (auto)
         {
             return input_grabbed();
         };
 
-        rotate_left = [=] (wf::activator_source_t, uint32_t)
+        rotate_left = [=] (auto)
         {
             return move_vp(-1);
         };
 
-        rotate_right = [=] (wf::activator_source_t, uint32_t)
+        rotate_right = [=] (auto)
         {
             return move_vp(1);
         };

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -238,7 +238,7 @@ class wayfire_scale : public wf::plugin_interface_t
     }
 
     /* Activate scale for views on the current workspace */
-    wf::activator_callback toggle_cb = [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback toggle_cb = [=] (auto)
     {
         if (handle_toggle(false))
         {
@@ -251,7 +251,7 @@ class wayfire_scale : public wf::plugin_interface_t
     };
 
     /* Activate scale for views on all workspaces */
-    wf::activator_callback toggle_all_cb = [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback toggle_all_cb = [=] (auto)
     {
         if (handle_toggle(true))
         {

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -66,8 +66,7 @@ class wayfire_command : public wf::plugin_interface_t
     };
 
     bool on_binding(std::string command, binding_mode mode,
-        wf::activator_source_t source,
-        uint32_t value)
+        const wf::activator_data_t& data)
     {
         /* We already have a repeatable command, do not accept further bindings */
         if (repeat.pressed_key || repeat.pressed_button)
@@ -89,8 +88,9 @@ class wayfire_command : public wf::plugin_interface_t
         wf::get_core().run(command.c_str());
 
         /* No repeat necessary in any of those cases */
-        if ((mode != BINDING_REPEAT) || (source == wf::ACTIVATOR_SOURCE_GESTURE) ||
-            (value == 0))
+        if ((mode != BINDING_REPEAT) ||
+            (data.source == wf::activator_source_t::GESTURE) ||
+            (data.activation_data == 0))
         {
             output->deactivate_plugin(grab_interface);
 
@@ -98,12 +98,12 @@ class wayfire_command : public wf::plugin_interface_t
         }
 
         repeat.repeat_command = command;
-        if (source == wf::ACTIVATOR_SOURCE_KEYBINDING)
+        if (data.source == wf::activator_source_t::KEYBINDING)
         {
-            repeat.pressed_key = value;
+            repeat.pressed_key = data.activation_data;
         } else
         {
-            repeat.pressed_button = value;
+            repeat.pressed_button = data.activation_data;
         }
 
         repeat_delay_source = wl_event_loop_add_timer(wf::get_core().ev_loop,
@@ -234,17 +234,17 @@ class wayfire_command : public wf::plugin_interface_t
             if (repeatable_opt)
             {
                 bindings[i] = std::bind(std::mem_fn(&wayfire_command::on_binding),
-                    this, executable, BINDING_REPEAT, _1, _2);
+                    this, executable, BINDING_REPEAT, _1);
                 output->add_activator(repeatable_opt, &bindings[i]);
             } else if (always_opt)
             {
                 bindings[i] = std::bind(std::mem_fn(&wayfire_command::on_binding),
-                    this, executable, BINDING_ALWAYS, _1, _2);
+                    this, executable, BINDING_ALWAYS, _1);
                 output->add_activator(always_opt, &bindings[i]);
             } else if (regular_opt)
             {
                 bindings[i] = std::bind(std::mem_fn(&wayfire_command::on_binding),
-                    this, executable, BINDING_NORMAL, _1, _2);
+                    this, executable, BINDING_NORMAL, _1);
                 output->add_activator(regular_opt, &bindings[i]);
             }
         }

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -35,7 +35,7 @@ class wayfire_expo : public wf::plugin_interface_t
         return wf::point_t{x, y};
     }
 
-    wf::activator_callback toggle_cb = [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback toggle_cb = [=] (auto)
     {
         if (!state.active)
         {
@@ -115,7 +115,7 @@ class wayfire_expo : public wf::plugin_interface_t
                 opt->get_value_str());
             keyboard_select_options.push_back(wf::create_option(value.value()));
 
-            keyboard_select_cbs.push_back([=] (wf::activator_source_t, uint32_t)
+            keyboard_select_cbs.push_back([=] (auto)
             {
                 if (!state.active)
                 {

--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -123,7 +123,7 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
         view->damage();
     }
 
-    wf::key_callback fast_switch = [=] (uint32_t)
+    wf::key_callback fast_switch = [=] (auto)
     {
         if (active)
         {

--- a/plugins/single_plugins/fisheye.cpp
+++ b/plugins/single_plugins/fisheye.cpp
@@ -134,7 +134,7 @@ class wayfire_fisheye : public wf::plugin_interface_t
         OpenGL::render_end();
     }
 
-    wf::activator_callback toggle_cb = [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback toggle_cb = [=] (auto)
     {
         if (!output->can_activate_plugin(grab_interface))
         {

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -237,7 +237,7 @@ class wayfire_grid : public wf::plugin_interface_t
     wf::option_wrapper_t<wf::activatorbinding_t> keys[10];
     wf::option_wrapper_t<wf::activatorbinding_t> restore_opt{"grid/restore"};
 
-    wf::activator_callback restore = [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback restore = [=] (auto)
     {
         if (!output->can_activate_plugin(grab_interface))
         {
@@ -269,7 +269,7 @@ class wayfire_grid : public wf::plugin_interface_t
         for (int i = 1; i < 10; i++)
         {
             keys[i].load_option("grid/slot_" + slots[i]);
-            bindings[i] = [=] (wf::activator_source_t, uint32_t)
+            bindings[i] = [=] (auto)
             {
                 auto view = output->get_active_view();
                 if (!view || (view->role != wf::VIEW_ROLE_TOPLEVEL))

--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -129,7 +129,7 @@ class wayfire_idle_singleton : public wf::singleton_plugin_t<wayfire_idle>
     wlr_idle_timeout *timeout_screensaver = NULL;
     wf::wl_listener_wrapper on_idle_screensaver, on_resume_screensaver;
 
-    wf::activator_callback toggle = [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback toggle = [=] (auto)
     {
         if (!output->can_activate_plugin(grab_interface))
         {

--- a/plugins/single_plugins/invert.cpp
+++ b/plugins/single_plugins/invert.cpp
@@ -55,7 +55,7 @@ class wayfire_invert_screen : public wf::plugin_interface_t
             render(source, destination);
         };
 
-        toggle_cb = [=] (wf::activator_source_t, uint32_t)
+        toggle_cb = [=] (auto)
         {
             if (!output->can_activate_plugin(grab_interface))
             {

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -96,7 +96,7 @@ class wayfire_move : public wf::plugin_interface_t
         grab_interface->capabilities =
             wf::CAPABILITY_GRAB_INPUT | wf::CAPABILITY_MANAGE_DESKTOP;
 
-        activate_binding = [=] (uint32_t, int, int)
+        activate_binding = [=] (auto)
         {
             is_using_touch     = false;
             was_client_request = false;

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -8,7 +8,7 @@ class wayfire_output_manager : public wf::plugin_interface_t
 {
     wf::wl_idle_call idle_next_output;
 
-    wf::activator_callback switch_output = [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback switch_output = [=] (auto)
     {
         /* when we switch the output, the oswitch keybinding
          * may be activated for the next output, which we don't want,
@@ -23,8 +23,7 @@ class wayfire_output_manager : public wf::plugin_interface_t
         return true;
     };
 
-    wf::activator_callback switch_output_with_window =
-        [=] (wf::activator_source_t, uint32_t)
+    wf::activator_callback switch_output_with_window = [=] (auto)
     {
         auto next =
             wf::get_core().output_layout->get_next_output(output);
@@ -32,7 +31,7 @@ class wayfire_output_manager : public wf::plugin_interface_t
 
         if (!view)
         {
-            switch_output(wf::ACTIVATOR_SOURCE_KEYBINDING, 0);
+            switch_output(wf::activator_data_t{});
 
             return true;
         }

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -31,7 +31,7 @@ class wayfire_resize : public wf::plugin_interface_t
         grab_interface->capabilities =
             wf::CAPABILITY_GRAB_INPUT | wf::CAPABILITY_MANAGE_DESKTOP;
 
-        activate_binding = [=] (uint32_t, int, int)
+        activate_binding = [=] (auto)
         {
             auto view = wf::get_core().get_cursor_focus_view();
             if (view)

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -128,12 +128,12 @@ class WayfireSwitcher : public wf::plugin_interface_t
         grab_interface->callbacks.cancel = [=] () {deinit_switcher();};
     }
 
-    wf::key_callback next_view_binding = [=] (uint32_t)
+    wf::key_callback next_view_binding = [=] (auto)
     {
         return handle_switch_request(-1);
     };
 
-    wf::key_callback prev_view_binding = [=] (uint32_t)
+    wf::key_callback prev_view_binding = [=] (auto)
     {
         return handle_switch_request(1);
     };

--- a/plugins/single_plugins/wrot.cpp
+++ b/plugins/single_plugins/wrot.cpp
@@ -20,7 +20,7 @@ class wf_wrot : public wf::plugin_interface_t
     wf::button_callback call;
     wf::option_wrapper_t<double> reset_radius{"wrot/reset_radius"};
 
-    int last_x, last_y;
+    wf::pointf_t last_position;
     wayfire_view current_view;
 
   public:
@@ -29,7 +29,7 @@ class wf_wrot : public wf::plugin_interface_t
         grab_interface->name = "wrot";
         grab_interface->capabilities = wf::CAPABILITY_GRAB_INPUT;
 
-        call = [=] (uint32_t, int x, int y)
+        call = [=] (auto)
         {
             if (!output->activate_plugin(grab_interface))
             {
@@ -47,9 +47,7 @@ class wf_wrot : public wf::plugin_interface_t
             output->focus_view(current_view, true);
             grab_interface->grab();
 
-            last_x = x;
-            last_y = y;
-
+            last_position = output->get_cursor_position();
             return true;
         };
 
@@ -75,7 +73,7 @@ class wf_wrot : public wf::plugin_interface_t
             double cx = g.x + g.width / 2.0;
             double cy = g.y + g.height / 2.0;
 
-            double x1 = last_x - cx, y1 = last_y - cy;
+            double x1 = last_position.x - cx, y1 = last_position.y - cy;
             double x2 = x - cx, y2 = y - cy;
 
             if (vlen(x2, y2) <= reset_radius)
@@ -89,8 +87,7 @@ class wf_wrot : public wf::plugin_interface_t
 
             current_view->damage();
 
-            last_x = x;
-            last_y = y;
+            last_position = {1.0 * x, 1.0 * y};
         };
 
         grab_interface->callbacks.pointer.button = [=] (uint32_t, uint32_t s)

--- a/plugins/vswitch/wayfire/plugins/vswitch.hpp
+++ b/plugins/vswitch/wayfire/plugins/vswitch.hpp
@@ -287,36 +287,36 @@ class control_bindings_t
      */
     void setup(binding_callback_t callback)
     {
-        callback_left = [=] (wf::activator_source_t, uint32_t)
+        callback_left = [=] (const wf::activator_data_t&)
         {
             return handle_dir({-1, 0}, nullptr, callback);
         };
-        callback_right = [=] (wf::activator_source_t, uint32_t)
+        callback_right = [=] (const wf::activator_data_t&)
         {
             return handle_dir({1, 0}, nullptr, callback);
         };
-        callback_up = [=] (wf::activator_source_t, uint32_t)
+        callback_up = [=] (const wf::activator_data_t&)
         {
             return handle_dir({0, -1}, nullptr, callback);
         };
-        callback_down = [=] (wf::activator_source_t, uint32_t)
+        callback_down = [=] (const wf::activator_data_t&)
         {
             return handle_dir({0, 1}, nullptr, callback);
         };
 
-        callback_win_left = [=] (wf::activator_source_t, uint32_t)
+        callback_win_left = [=] (const wf::activator_data_t&)
         {
             return handle_dir({-1, 0}, get_top_view(), callback);
         };
-        callback_win_right = [=] (wf::activator_source_t, uint32_t)
+        callback_win_right = [=] (const wf::activator_data_t&)
         {
             return handle_dir({1, 0}, get_top_view(), callback);
         };
-        callback_win_up = [=] (wf::activator_source_t, uint32_t)
+        callback_win_up = [=] (const wf::activator_data_t&)
         {
             return handle_dir({0, -1}, get_top_view(), callback);
         };
-        callback_win_down = [=] (wf::activator_source_t, uint32_t)
+        callback_win_down = [=] (const wf::activator_data_t&)
         {
             return handle_dir({0, 1}, get_top_view(), callback);
         };

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -53,7 +53,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
     wayfire_view choose_view(wf::activator_source_t source)
     {
         wayfire_view view;
-        if (source == wf::ACTIVATOR_SOURCE_BUTTONBINDING)
+        if (source == wf::activator_source_t::BUTTONBINDING)
         {
             view = wf::get_core().get_cursor_focus_view();
         }
@@ -156,28 +156,25 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
     /**
      * The default activator bindings.
      */
-    wf::activator_callback on_toggle_above =
-        [=] (wf::activator_source_t source, uint32_t) -> bool
+    wf::activator_callback on_toggle_above = [=] (auto ev) -> bool
     {
-        auto view = choose_view(source);
+        auto view = choose_view(ev.source);
 
         return toggle_keep_above(view);
     };
 
-    wf::activator_callback on_minimize =
-        [=] (wf::activator_source_t source, uint32_t) -> bool
+    wf::activator_callback on_minimize = [=] (auto ev) -> bool
     {
-        return execute_for_selected_view(source, [] (wayfire_view view)
+        return execute_for_selected_view(ev.source, [] (wayfire_view view)
         {
             view->minimize_request(!view->minimized);
             return true;
         });
     };
 
-    wf::activator_callback on_toggle_maximize =
-        [=] (wf::activator_source_t source, uint32_t) -> bool
+    wf::activator_callback on_toggle_maximize = [=] (auto ev) -> bool
     {
-        return execute_for_selected_view(source, [] (wayfire_view view)
+        return execute_for_selected_view(ev.source, [] (wayfire_view view)
         {
             view->tile_request(view->tiled_edges ==
                 wf::TILED_EDGES_ALL ? 0 : wf::TILED_EDGES_ALL);
@@ -185,20 +182,18 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
         });
     };
 
-    wf::activator_callback on_toggle_fullscreen =
-        [=] (wf::activator_source_t source, uint32_t) -> bool
+    wf::activator_callback on_toggle_fullscreen = [=] (auto ev) -> bool
     {
-        return execute_for_selected_view(source, [] (wayfire_view view)
+        return execute_for_selected_view(ev.source, [] (wayfire_view view)
         {
             view->fullscreen_request(view->get_output(), !view->fullscreen);
             return true;
         });
     };
 
-    wf::activator_callback on_toggle_sticky =
-        [=] (wf::activator_source_t source, uint32_t) -> bool
+    wf::activator_callback on_toggle_sticky = [=] (auto ev) -> bool
     {
-        return execute_for_selected_view(source, [] (wayfire_view view)
+        return execute_for_selected_view(ev.source, [] (wayfire_view view)
         {
             view->set_sticky(view->sticky ^ 1);
             return true;

--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -150,6 +150,19 @@ class output_t : public wf::object_base_t
     virtual bool is_plugin_active(std::string owner_name) const = 0;
 
     /**
+     * Call a plugin's registered activator binding.
+     *
+     * @param activator The name of the activator binding, for ex. "expo/toggle"
+     * @param data The activator data to pass to the view.
+     *   Supports also custom data types.
+     *
+     * @return True if a plugin's binding matches the given name and the plugin
+     *   consumes the event, False otherwise.
+     */
+    virtual bool call_plugin(const std::string& activator,
+        const wf::activator_data_t& data) const = 0;
+
+    /**
      * @return The topmost view in the workspace layer
      */
     wayfire_view get_top_view() const;

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'10'22;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'11'01;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/core/seat/bindings-repository.cpp
+++ b/src/core/seat/bindings-repository.cpp
@@ -1,4 +1,5 @@
 #include "bindings-repository.hpp"
+#include <wayfire/core.hpp>
 #include <algorithm>
 
 bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed)
@@ -135,6 +136,21 @@ void wf::bindings_repository_t::handle_gesture(const wf::touchgesture_t& gesture
     {
         cb();
     }
+}
+
+bool wf::bindings_repository_t::handle_activator(
+    const std::string& activator, const wf::activator_data_t& data)
+{
+    auto opt = wf::get_core().config.get_option(activator);
+    for (auto& act : this->activators)
+    {
+        if (act->activated_by == opt)
+        {
+            return (*act->callback)(data);
+        }
+    }
+
+    return false;
 }
 
 void wf::bindings_repository_t::rem_binding(void *callback)

--- a/src/core/seat/bindings-repository.cpp
+++ b/src/core/seat/bindings-repository.cpp
@@ -2,7 +2,8 @@
 #include <wayfire/core.hpp>
 #include <algorithm>
 
-bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed)
+bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed,
+    uint32_t mod_binding_key)
 {
     std::vector<std::function<bool()>> callbacks;
     for (auto& binding : this->keys)
@@ -26,12 +27,19 @@ bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed)
             /* We must be careful because the callback might be erased,
              * so force copy the callback into the lambda */
             auto callback = binding->callback;
-            callbacks.emplace_back([pressed, callback] ()
+            callbacks.emplace_back([pressed, callback, mod_binding_key] ()
             {
                 wf::activator_data_t ev = {
                     .source = activator_source_t::KEYBINDING,
                     .activation_data = pressed.get_key()
                 };
+
+                if (mod_binding_key)
+                {
+                    ev.source = activator_source_t::MODIFIERBINDING;
+                    ev.activation_data = mod_binding_key;
+                }
+
                 return (*callback)(ev);
             });
         }

--- a/src/core/seat/bindings-repository.cpp
+++ b/src/core/seat/bindings-repository.cpp
@@ -13,7 +13,7 @@ bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed)
             auto callback = binding->callback;
             callbacks.emplace_back([pressed, callback] ()
             {
-                return (*callback)(pressed.get_key());
+                return (*callback)(pressed);
             });
         }
     }
@@ -27,7 +27,11 @@ bool wf::bindings_repository_t::handle_key(const wf::keybinding_t& pressed)
             auto callback = binding->callback;
             callbacks.emplace_back([pressed, callback] ()
             {
-                return (*callback)(ACTIVATOR_SOURCE_KEYBINDING, pressed.get_key());
+                wf::activator_data_t ev = {
+                    .source = activator_source_t::KEYBINDING,
+                    .activation_data = pressed.get_key()
+                };
+                return (*callback)(ev);
             });
         }
     }
@@ -62,8 +66,7 @@ bool wf::bindings_repository_t::handle_axis(uint32_t modifiers,
     return !callbacks.empty();
 }
 
-bool wf::bindings_repository_t::handle_button(const wf::buttonbinding_t& pressed,
-    const wf::pointf_t& cursor)
+bool wf::bindings_repository_t::handle_button(const wf::buttonbinding_t& pressed)
 {
     std::vector<std::function<bool()>> callbacks;
     for (auto& binding : this->buttons)
@@ -75,7 +78,7 @@ bool wf::bindings_repository_t::handle_button(const wf::buttonbinding_t& pressed
             auto callback = binding->callback;
             callbacks.emplace_back([=] ()
             {
-                return (*callback)(pressed.get_button(), cursor.x, cursor.y);
+                return (*callback)(pressed);
             });
         }
     }
@@ -89,8 +92,11 @@ bool wf::bindings_repository_t::handle_button(const wf::buttonbinding_t& pressed
             auto callback = binding->callback;
             callbacks.emplace_back([=] ()
             {
-                return (*callback)(wf::ACTIVATOR_SOURCE_BUTTONBINDING,
-                    pressed.get_button());
+                wf::activator_data_t data = {
+                    .source = activator_source_t::BUTTONBINDING,
+                    .activation_data = pressed.get_button(),
+                };
+                return (*callback)(data);
             });
         }
     }
@@ -116,7 +122,11 @@ void wf::bindings_repository_t::handle_gesture(const wf::touchgesture_t& gesture
             auto callback = binding->callback;
             callbacks.emplace_back([=] ()
             {
-                (*callback)(ACTIVATOR_SOURCE_GESTURE, 0);
+                wf::activator_data_t data = {
+                    .source = activator_source_t::GESTURE,
+                    .activation_data = 0
+                };
+                (*callback)(data);
             });
         }
     }

--- a/src/core/seat/bindings-repository.hpp
+++ b/src/core/seat/bindings-repository.hpp
@@ -39,6 +39,9 @@ class bindings_repository_t
     /** Handle a gesture from the user. */
     void handle_gesture(const wf::touchgesture_t& gesture);
 
+    /** Handle a direct call to an activator binding */
+    bool handle_activator(
+        const std::string& activator, const wf::activator_data_t& data);
 
     /** Erase binding of any type by callback */
     void rem_binding(void *callback);

--- a/src/core/seat/bindings-repository.hpp
+++ b/src/core/seat/bindings-repository.hpp
@@ -34,8 +34,7 @@ class bindings_repository_t
      *
      * @return true if any of the matching registered bindings consume the event.
      */
-    bool handle_button(const wf::buttonbinding_t& pressed,
-        const wf::pointf_t& cursor);
+    bool handle_button(const wf::buttonbinding_t& pressed);
 
     /** Handle a gesture from the user. */
     void handle_gesture(const wf::touchgesture_t& gesture);

--- a/src/core/seat/bindings-repository.hpp
+++ b/src/core/seat/bindings-repository.hpp
@@ -22,9 +22,12 @@ class bindings_repository_t
     /**
      * Handle a keybinding pressed by the user.
      *
+     * @param pressed The keybinding which was triggered.
+     * @param mod_binding_key The modifier which triggered the binding, if any.
+     *
      * @return true if any of the matching registered bindings consume the event.
      */
-    bool handle_key(const wf::keybinding_t& pressed);
+    bool handle_key(const wf::keybinding_t& pressed, uint32_t mod_binding_key);
 
     /** Handle an axis event. */
     bool handle_axis(uint32_t modifiers, wlr_event_pointer_axis *ev);

--- a/src/core/seat/hotspot-manager.cpp
+++ b/src/core/seat/hotspot-manager.cpp
@@ -122,7 +122,11 @@ void wf::hotspot_manager_t::update_hotspots(const container_t& activators)
             auto activator_cb = opt->callback;
             auto callback = [activator_cb] (uint32_t edges)
             {
-                (*activator_cb)(ACTIVATOR_SOURCE_HOTSPOT, edges);
+                wf::activator_data_t data = {
+                    .source = activator_source_t::HOTSPOT,
+                    .activation_data = edges,
+                };
+                (*activator_cb)(data);
             };
 
             auto instance = std::make_unique<hotspot_instance_t>(output,

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -306,7 +306,7 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
         }
 
         handled_in_binding = input->get_active_bindings().handle_key(
-            wf::keybinding_t{get_modifiers(), key});
+            wf::keybinding_t{get_modifiers(), key}, mod_binding_key);
     } else
     {
         if (mod_binding_key != 0)
@@ -319,7 +319,7 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
             if ((timeout <= 0) || (time_elapsed < milliseconds(timeout)))
             {
                 handled_in_binding = input->get_active_bindings().handle_key(
-                    wf::keybinding_t{get_modifiers() | mod, 0});
+                    wf::keybinding_t{get_modifiers() | mod, 0}, mod_binding_key);
             }
         }
 

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -332,8 +332,7 @@ void wf::pointer_t::handle_pointer_button(wlr_event_pointer_button *ev)
         }
 
         handled_in_binding = input->get_active_bindings().handle_button(
-            wf::buttonbinding_t{seat->get_modifiers(), ev->button},
-            seat->cursor->get_cursor_position());
+            wf::buttonbinding_t{seat->get_modifiers(), ev->button});
     } else
     {
         count_pressed_buttons--;

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -18,7 +18,7 @@ static void idle_shutdown(void *data)
 
 void wayfire_exit::init()
 {
-    key = [] (uint32_t key)
+    key = [] (const wf::keybinding_t&)
     {
         auto output_impl =
             static_cast<wf::output_impl_t*>(wf::get_core().get_active_output());
@@ -72,7 +72,7 @@ void wayfire_close::init()
 {
     grab_interface->capabilities = wf::CAPABILITY_GRAB_INPUT;
     wf::option_wrapper_t<wf::activatorbinding_t> key("core/close_top_view");
-    callback = [=] (wf::activator_source_t, uint32_t)
+    callback = [=] (const wf::activator_data_t& ev)
     {
         if (!output->activate_plugin(grab_interface))
         {
@@ -109,7 +109,7 @@ void wayfire_focus::init()
     };
     output->connect_signal("wm-focus-request", &on_wm_focus_request);
 
-    on_button = [=] (uint32_t button, int x, int y)
+    on_button = [=] (const wf::buttonbinding_t&)
     {
         this->check_focus_surface(wf::get_core().get_cursor_focus());
 

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -64,6 +64,8 @@ class output_impl_t : public output_t
     bool deactivate_plugin(const plugin_grab_interface_uptr& owner) override;
     void cancel_active_plugins() override;
     bool is_plugin_active(std::string owner_name) const override;
+    bool call_plugin(const std::string& activator,
+        const wf::activator_data_t& data) const override;
     wayfire_view get_active_view() const override;
     void focus_view(wayfire_view v, bool raise) override;
     void refocus(wayfire_view skip_view, uint32_t layers) override;

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -543,6 +543,12 @@ bindings_repository_t& output_impl_t::get_bindings()
     return *bindings;
 }
 
+bool output_impl_t::call_plugin(
+    const std::string& activator, const wf::activator_data_t& data) const
+{
+    return this->bindings->handle_activator(activator, data);
+}
+
 uint32_t all_layers_not_below(uint32_t layer)
 {
     uint32_t mask = 0;
@@ -556,4 +562,4 @@ uint32_t all_layers_not_below(uint32_t layer)
 
     return mask;
 }
-}
+} // namespace wf


### PR DESCRIPTION
~~Still WIP, but should eventually:~~

fix #655
fix #833

This PR adds the long-awaited support for calling arbitrary plugins via their activator bindings. Example patch to make Expo activate on all workspaces at the same time (although I recommend actually doing an external plugin which activates all Expos on all outputs):

```diff
diff --git a/plugins/single_plugins/expo.cpp b/plugins/single_plugins/expo.cpp
index 2d4e11b6..8092898b 100644
--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -35,8 +35,23 @@ class wayfire_expo : public wf::plugin_interface_t
         return wf::point_t{x, y};
     }
 
-    wf::activator_callback toggle_cb = [=] (auto)
+    wf::activator_callback toggle_cb = [=] (auto ev)
     {
+        // Avoid self-loop
+        if (ev.source != wf::activator_source_t::PLUGIN)
+        {
+            wf::activator_data_t data;
+            data.source = wf::activator_source_t::PLUGIN;
+
+            for (auto& wo : wf::get_core().output_layout->get_outputs())
+            {
+                if (wo != output) {
+                    wo->call_plugin("expo/toggle", data);
+                }
+            }
+        }
+
         if (!state.active)
         {
             return activate();
```
