### PR TITLE
Revert "render-manager: Use normal transform type for headless path"

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -282,7 +282,7 @@ struct postprocessing_manager_t
         }
 
         fb.wl_transform = wlr_output_transform_compose(
-            (wl_output_transform)fb.wl_transform, WL_OUTPUT_TRANSFORM_NORMAL);
+            (wl_output_transform)fb.wl_transform, WL_OUTPUT_TRANSFORM_FLIPPED_180);
         fb.transform = get_output_matrix_from_transform(
             (wl_output_transform)fb.wl_transform);
     }


### PR DESCRIPTION
Reverts WayfireWM/wayfire#790

Swapchain has been merged in wlroots master, we need this code.

If anyone is using Intel, there may be bugs (affects newer GPUs): https://github.com/swaywm/wlroots/pull/2240#issue-426128653
At least there are workarounds in the mentioned wlroots PR.