### PR TITLE
workarounds: add support for non-modal dialogs.

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -21,5 +21,10 @@
 				<_name>Full</_name>
 			</desc>
 		</option>
+		<option name="all_dialogs_modal" type="bool">
+			<_short>Make all dialogs modal</_short>
+			<_long>If false, the main window can be focused even if it has a dialog. The dialog is nevertheless kept on top of the main window. Kwin defaults to false.</_long>
+			<default>true</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -655,15 +655,21 @@ std::vector<wayfire_view> wf::compositor_core_impl_t::get_all_views()
  */
 void wf::compositor_core_impl_t::set_active_view(wayfire_view new_focus)
 {
+    static wf::option_wrapper_t<bool>
+    all_dialogs_modal{"workarounds/all_dialogs_modal"};
+
     if (new_focus && !new_focus->is_mapped())
     {
         new_focus = nullptr;
     }
 
-    /* Descend into frontmost child view */
-    new_focus = new_focus ? new_focus->enumerate_views().front() : nullptr;
-    bool refocus = (last_active_view == new_focus);
+    if (all_dialogs_modal)
+    {
+        /* Descend into frontmost child view */
+        new_focus = new_focus ? new_focus->enumerate_views().front() : nullptr;
+    }
 
+    bool refocus = (last_active_view == new_focus);
     /* don't deactivate view if the next focus is not a toplevel */
     if ((new_focus == nullptr) || (new_focus->role == VIEW_ROLE_TOPLEVEL))
     {

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -316,9 +316,13 @@ void wf::wlr_view_t::map(wlr_surface *surface)
 
     update_size();
 
-    if ((role == VIEW_ROLE_TOPLEVEL) && !parent)
+    if (role == VIEW_ROLE_TOPLEVEL)
     {
-        get_output()->workspace->add_view(self(), wf::LAYER_WORKSPACE);
+        if (!parent)
+        {
+            get_output()->workspace->add_view(self(), wf::LAYER_WORKSPACE);
+        }
+
         get_output()->focus_view(self(), true);
     }
 


### PR DESCRIPTION
Fixes #869

Wayland does not have the concept of modal and non-modal dialogs. This might come as a future extension to the xdg-shell protocol. In the meantime, we can provide users with an option to choose whether dialogs should all be modal (as it was up to now) or non-modal.

If all dialogs are modal: whenever a dialog is open, it will always be focused, and the main window will not be able to receive keyboard focus until the dialog is closed.

If all dialogs are non-modal: dialogs are still kept on top of their respective main window. However, the main window can still be focused. Some toolkits like Qt apply certain hacks - Qt will ignore events on the main window if it has opened a dialog it thinks is modal.

Overall, setting `workarounds/all_dialogs_modal` to `true` (which is the default) will keep the current behavior in Wayfire.
Setting it to `false` makes Wayfire behave like Kwin and Mutter, practically forcing applications to take care of whether they have a modal or a non-modal dialog.
