### PR TITLE
switcher: remove expression with side effects from assert().

### DIFF
--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -201,7 +201,8 @@ class WayfireSwitcher : public wf::plugin_interface_t
             active = true;
 
             // grabs shouldn't fail if we could successfully activate plugin
-            assert(grab_interface->grab());
+            auto grab = grab_interface->grab();
+            assert(grab);
 
             focus_next(dir);
             arrange();

--- a/src/view/layer-shell.cpp
+++ b/src/view/layer-shell.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cstring>
+#include <cstdlib>
 
 #include "xdg-shell.hpp"
 #include "wayfire/core.hpp"
@@ -69,7 +70,7 @@ wf::workspace_manager::anchored_edge anchor_to_edge(uint32_t edges)
         return wf::workspace_manager::ANCHORED_EDGE_RIGHT;
     }
 
-    assert(false);
+    abort();
 }
 
 struct wf_layer_shell_manager


### PR DESCRIPTION
Since assert() is a macro, building wayfire with -DNDEBUG leads to the
entire expression being compiled out, which means it's never run. This
made it so that once the switcher plugin was launched, it wouldn't quit.

Fixes #879