### PR TITLE
decoration: Add decorations to views on init

### DIFF
--- a/plugins/decor/decoration.cpp
+++ b/plugins/decor/decoration.cpp
@@ -39,6 +39,11 @@ class wayfire_decoration :
 
         output->connect_signal("view-mapped", &view_updated);
         output->connect_signal("view-decoration-state-updated", &view_updated);
+        for (auto& view :
+             output->workspace->get_views_in_layer(wf::ALL_LAYERS))
+        {
+            update_view_decoration(view);
+        }
     }
 
     /**


### PR DESCRIPTION
When wayfire starts with decoration plugin loaded, newly created views are decorated.
If the plugin is unloaded, the decorations are destroyed. This patch makes it so
existing views are decorated when the plugin is loaded.