### PR TITLE
wm-actions: Add binding to show desktop

### DIFF
--- a/metadata/wm-actions.xml
+++ b/metadata/wm-actions.xml
@@ -29,5 +29,10 @@
 			<_long>Minimize the active view.</_long>
 			<default>disabled</default>
 		</option>
+		<option name="toggle_showdesktop" type="activator">
+			<_short>Toggle Show Desktop</_short>
+			<_long>Show the desktop.</_long>
+			<default>disabled</default>
+		</option>
 	</plugin>
 </wayfire>


### PR DESCRIPTION
This is a simple implementation that relies on minimize to show the desktop.
Closes #340.