### PR TITLE
core: Add option to focus a view on mouse click even if modifiers are pressed

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -58,15 +58,10 @@
 			<_long>Allow focusing the clicked view even if keyboard modifiers are pressed. Without this option, click-to-focus only works if no modifiers are pressed.</_long>
 			<default>false</default>
 		</option>
-		<option name="focus_btn_middle" type="bool">
-			<_short>Focus on click with middle mouse button</_short>
-			<_long>Allow focusing the clicked view with the middle mouse button.</_long>
-			<default>false</default>
-		</option>
-		<option name="focus_btn_right" type="bool">
-			<_short>Focus on click with right mouse button</_short>
-			<_long>Allow focusing the clicked view with the right mouse button.</_long>
-			<default>false</default>
+		<option name="focus_btns" type="activator">
+			<_short>Mouse buttons to focus views</_short>
+			<_long>Clicking on a view with any of the mouse buttons of these will focus it.</_long>
+			<default>BTN_LEFT | BTN_MIDDLE | BTN_RIGHT</default>
 		</option>
 	</plugin>
 </wayfire>

--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -53,12 +53,12 @@
 			<_long>Sets the compositor render delay in milliseconds, which allows applications to render with low latency.</_long>
 			<default>-1</default>
 		</option>
-		<option name="focus_btn_mod" type="bool">
+		<option name="focus_button_with_modifiers" type="bool">
 			<_short>Focus on click if keyboard modifiers are pressed</_short>
 			<_long>Allow focusing the clicked view even if keyboard modifiers are pressed. Without this option, click-to-focus only works if no modifiers are pressed.</_long>
 			<default>false</default>
 		</option>
-		<option name="focus_btns" type="activator">
+		<option name="focus_buttons" type="activator">
 			<_short>Mouse buttons to focus views</_short>
 			<_long>Clicking on a view with any of the mouse buttons of these will focus it.</_long>
 			<default>BTN_LEFT | BTN_MIDDLE | BTN_RIGHT</default>

--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -53,5 +53,20 @@
 			<_long>Sets the compositor render delay in milliseconds, which allows applications to render with low latency.</_long>
 			<default>-1</default>
 		</option>
+		<option name="focus_btn_mod" type="bool">
+			<_short>Focus on click if keyboard modifiers are pressed</_short>
+			<_long>Allow focusing the clicked view even if keyboard modifiers are pressed. Without this option, click-to-focus only works if no modifiers are pressed.</_long>
+			<default>false</default>
+		</option>
+		<option name="focus_btn_middle" type="bool">
+			<_short>Focus on click with middle mouse button</_short>
+			<_long>Allow focusing the clicked view with the middle mouse button.</_long>
+			<default>false</default>
+		</option>
+		<option name="focus_btn_right" type="bool">
+			<_short>Focus on click with right mouse button</_short>
+			<_long>Allow focusing the clicked view with the right mouse button.</_long>
+			<default>false</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -121,9 +121,10 @@ void wayfire_focus::init()
             return;
         }
 
+        /* focuse_btns->get_value() does not compile */
+        wf::option_sptr_t<wf::activatorbinding_t> tmp = focus_btns;
         if ((!focus_modifiers && wf::get_core().get_keyboard_modifiers()) ||
-            ((ev->event->button == BTN_MIDDLE) && !focus_btn_middle) ||
-            ((ev->event->button == BTN_RIGHT) && !focus_btn_right))
+            !tmp->get_value().has_match(wf::buttonbinding_t(0, ev->event->button)))
         {
             return;
         }

--- a/src/core/wm.hpp
+++ b/src/core/wm.hpp
@@ -30,8 +30,7 @@ class wayfire_focus : public wf::plugin_interface_t
     void check_focus_surface(wf::surface_interface_t *surface);
 
     wf::option_wrapper_t<bool> focus_modifiers{"core/focus_btn_mod"};
-    wf::option_wrapper_t<bool> focus_btn_middle{"core/focus_btn_middle"};
-    wf::option_wrapper_t<bool> focus_btn_right{"core/focus_btn_right"};
+    wf::option_wrapper_t<wf::activatorbinding_t> focus_btns{"core/focus_btns"};
 
   public:
     void init() override;

--- a/src/core/wm.hpp
+++ b/src/core/wm.hpp
@@ -29,8 +29,8 @@ class wayfire_focus : public wf::plugin_interface_t
     std::unique_ptr<wf::touch::gesture_t> tap_gesture;
     void check_focus_surface(wf::surface_interface_t *surface);
 
-    wf::option_wrapper_t<bool> focus_modifiers{"core/focus_btn_mod"};
-    wf::option_wrapper_t<wf::activatorbinding_t> focus_btns{"core/focus_btns"};
+    wf::option_wrapper_t<bool> focus_modifiers{"core/focus_button_with_modifiers"};
+    wf::option_wrapper_t<wf::activatorbinding_t> focus_btns{"core/focus_buttons"};
 
   public:
     void init() override;

--- a/src/core/wm.hpp
+++ b/src/core/wm.hpp
@@ -5,6 +5,7 @@
 #include "wayfire/bindings.hpp"
 #include "wayfire/view.hpp"
 #include "wayfire/touch/touch.hpp"
+#include "wayfire/option-wrapper.hpp"
 
 struct wm_focus_request : public wf::signal_data_t
 {
@@ -22,11 +23,15 @@ class wayfire_close : public wf::plugin_interface_t
 
 class wayfire_focus : public wf::plugin_interface_t
 {
-    wf::button_callback on_button;
+    wf::signal_connection_t on_button;
     wf::signal_callback_t on_wm_focus_request;
 
     std::unique_ptr<wf::touch::gesture_t> tap_gesture;
     void check_focus_surface(wf::surface_interface_t *surface);
+
+    wf::option_wrapper_t<bool> focus_modifiers{"core/focus_btn_mod"};
+    wf::option_wrapper_t<bool> focus_btn_middle{"core/focus_btn_middle"};
+    wf::option_wrapper_t<bool> focus_btn_right{"core/focus_btn_right"};
 
   public:
     void init() override;


### PR DESCRIPTION
This addresses the second part of my issue #891 by allowing a view to be focused by a modifier + mouse click. In my opinion, this behavior is more consistent. Also, this ensures that the clicked view receives the modifier state (since it is always focused).

I've implemented this as an option, with the old behavior being the default.

Depends on https://github.com/WayfireWM/wf-config/pull/36

Currently, click-to-focus only works for mouse clicks without keyboard modifiers. If a modifier is held down, the necessary button binding in the focus handler does not match, so the focus does not change. The view under the mouse receives the mouse click, but not the state of the keyboard modifiers (since it never receives keyboard focus).

This commit adds an option to essentially ignore pressed modifiers for the purpose of focusing the clicked view, so this will work consistently regardless of the state of keyboard modifiers.

Fixes #657 