### PR TITLE
core: put xwayland surfaces on top when giving them pointer focus

### DIFF
--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -129,6 +129,8 @@ void wf::pointer_t::update_cursor_focus(
     }
 
     cursor_focus = focus;
+    seat->ensure_input_surface(focus);
+
     wlr_surface *next_focus_wlr_surface = nullptr;
     if (focus && focus->get_wlr_surface())
     {

--- a/src/core/seat/seat.hpp
+++ b/src/core/seat/seat.hpp
@@ -96,6 +96,12 @@ class seat_t
     /** Update the position of the drag icon, if it exists */
     void update_drag_icon();
 
+    /**
+     * Make sure that the surface can receive input focus.
+     * If it is a xwayland surface, it will be restacked to the top.
+     */
+    void ensure_input_surface(wf::surface_interface_t *surface);
+
   private:
     wf::wl_listener_wrapper request_start_drag, start_drag, end_drag,
         request_set_selection, request_set_primary_selection;
@@ -115,6 +121,9 @@ class seat_t
 
     /** Send updated capabilities to clients */
     void update_capabilities();
+
+    // The surface which has last received input focus
+    wlr_surface *last_focus_surface = NULL;
 };
 }
 

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -146,6 +146,7 @@ void wf::tablet_tool_t::set_focus(wf::surface_interface_t *surface)
     }
 
     /* Set the new focus, if it is a wlr surface */
+    wf::get_core_impl().seat->ensure_input_surface(surface);
     wlr_surface *next_focus = surface ? surface->get_wlr_surface() : nullptr;
     if (next_focus && wlr_surface_accepts_tablet_v2(tablet_v2, next_focus))
     {

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -146,6 +146,7 @@ void wf::touch_interface_t::set_touch_focus(wf::surface_interface_t *surface,
 {
     bool focus_compositor_surface = wf::compositor_surface_from_surface(surface);
     bool had_focus = wlr_seat_touch_get_point(seat, id);
+    wf::get_core_impl().seat->ensure_input_surface(surface);
 
     wlr_surface *next_focus = NULL;
     if (surface && !focus_compositor_surface)

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -243,6 +243,9 @@ void init_layer_shell();
 std::string xwayland_get_display();
 void xwayland_update_default_cursor();
 
+/* Ensure that the given surface is on top of the Xwayland stack order. */
+void xwayland_bring_to_front(wlr_surface *surface);
+
 void init_desktop_apis();
 }
 

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -54,7 +54,6 @@ class wayfire_xwayland_view_base : public wf::wlr_view_t
             "_NET_WM_WINDOW_TYPE_DIALOG");
 
         xcb_disconnect(connection);
-
         return true;
     }
 
@@ -984,6 +983,18 @@ void wf::xwayland_update_default_cursor()
         wlr_xwayland_set_cursor(xwayland_handle, image->buffer,
             image->width * 4, image->width, image->height,
             image->hotspot_x, image->hotspot_y);
+    }
+
+#endif
+}
+
+void wf::xwayland_bring_to_front(wlr_surface *surface)
+{
+#if WF_HAS_XWAYLAND
+    if (wlr_surface_is_xwayland_surface(surface))
+    {
+        auto xw = wlr_xwayland_surface_from_wlr_surface(surface);
+        wlr_xwayland_surface_restack(xw, NULL, XCB_STACK_MODE_ABOVE);
     }
 
 #endif


### PR DESCRIPTION
Fixes #666

Unfortunately, this does not work yet.
The problem is restacking - the `xwayland_bring_to_front` function doesn't seem to do anything.

I'll try to look into it later, but any hints why it doesn't work are much appeciated.
