### PR TITLE
Error no longer logged for move and resize window rules

### DIFF
--- a/plugins/window-rules/view-action-interface.cpp
+++ b/plugins/window-rules/view-action-interface.cpp
@@ -148,14 +148,22 @@ bool view_action_interface_t::execute(const std::string & name,
         if (std::get<0>(position))
         {
             _move(std::get<1>(position), std::get<2>(position));
+            return false;
         }
+
+        LOGE("View action interface: invalid arguments for move");
+        return true;
     } else if (name == "resize")
     {
         auto size = _validate_size(args);
         if (std::get<0>(size))
         {
             _resize(std::get<1>(size), std::get<2>(size));
+            return false;
         }
+
+        LOGE("View action interface: invalid arguments for resize");
+        return true;
     }
 
     LOGE("View action interface: Unsupported action execution requested. Name: ",


### PR DESCRIPTION
Before this change, all move and resize window rules would wrongly log this error:

"View action interface: Unsupported action execution requested. Name: "