### PR TITLE
fix handling of keyboard when grab is active

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1017,6 +1017,8 @@ class wayfire_scale : public wf::plugin_interface_t
             {
                 output->focus_view(current_focus_view, true);
             }
+
+            layout_slots(get_views());
         }
     };
 

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -109,8 +109,8 @@ class wayfire_scale : public wf::plugin_interface_t
     void init() override
     {
         grab_interface->name = "scale";
-        grab_interface->capabilities = 0;
-
+        grab_interface->capabilities =
+            wf::CAPABILITY_MANAGE_DESKTOP | wf::CAPABILITY_GRAB_INPUT;
         active = hook_set = false;
 
         output->add_activator(
@@ -1142,8 +1142,6 @@ class wayfire_scale : public wf::plugin_interface_t
         {
             return false;
         }
-
-        grab_interface->capabilities = wf::CAPABILITY_GRAB_INPUT;
 
         if (!output->activate_plugin(grab_interface))
         {


### PR DESCRIPTION
- keyboard: correctly handle grabs when forwarding to client
- scale: drop `input_release_impending`

Core was handling keyboard events in a wrong way, and was not correctly calculating when a key is consumed by a plugin.
With that fix, scale no longer needs to keep track of `input_release_impending`, since `KEY_ENTER`/`KEY_ESC` are not forwarded to clients (because they happened during a grab).
Also, this means that scale can deactivate immediately, which also fixes the problem of skipping a workspace when using vswitch bindings while exiting scale.
