### PR TITLE
layer-shell: adjust keyboard-interactivity

### DIFF
--- a/src/view/layer-shell.cpp
+++ b/src/view/layer-shell.cpp
@@ -303,7 +303,7 @@ struct wf_layer_shell_manager
             for (auto& v : layer)
             {
                 if (v->is_mapped() &&
-                    v->lsurface->client_pending.keyboard_interactive)
+                    (v->lsurface->client_pending.keyboard_interactive == 1))
                 {
                     focus_mask = std::max(focus_mask, (uint32_t)v->get_layer());
                 }


### PR DESCRIPTION
Implementation for https://github.com/swaywm/wlr-protocols/pull/100 -- requires https://github.com/swaywm/wlroots/pull/2555 to actually work.

Only a value of 1 is interpreted as a request for exclusive focus. Other > 0 values result in normal focus semantics.
