### PR TITLE
core: add support for wp-viewporter

### DIFF
--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -113,8 +113,8 @@ class FireTransformer : public wf::view_transformer_t
         gl_geometry src_geometry = {x, y, x + w, y + h * progress_line};
 
         gl_geometry tex_geometry = {
-            0, 1,
-            1, 1 - progress_line,
+            0, 1 - progress_line,
+            1, 1,
         };
 
         OpenGL::render_transformed_texture(src_tex, src_geometry, tex_geometry,

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -109,6 +109,7 @@ class compositor_core_t : public wf::object_base_t
         wlr_presentation *presentation;
         wlr_gtk_primary_selection_device_manager *gtk_primary_selection;
         wlr_primary_selection_v1_device_manager *primary_selection_v1;
+        wlr_viewporter *viewporter;
     } protocols;
 
     std::string to_string() const

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -29,6 +29,7 @@ extern "C"
 #include <wlr/types/wlr_matrix.h>
 #undef static
 #include <wlr/types/wlr_buffer.h>
+#include <wlr/types/wlr_viewporter.h>
 
 #include <wlr/types/wlr_output_damage.h>
 #include <wlr/types/wlr_presentation_time.h>

--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -40,6 +40,7 @@ extern "C"
     struct wlr_output_layout;
     struct wlr_surface;
     struct wlr_texture;
+    struct wlr_viewporter;
 
 #include <wlr/types/wlr_input_device.h>
 #include <wlr/types/wlr_pointer.h>

--- a/src/api/wayfire/opengl.hpp
+++ b/src/api/wayfire/opengl.hpp
@@ -142,11 +142,19 @@ struct texture_t
     texture_type_t type = TEXTURE_TYPE_RGBA;
     /* Texture target */
     GLenum target = GL_TEXTURE_2D;
-    /* Invert Y? */
-    bool invert_y = false;
-
     /* Actual texture ID */
     GLuint tex_id;
+
+    /** Invert Y? */
+    bool invert_y = false;
+    /** Has viewport? */
+    bool has_viewport = false;
+
+    /**
+     * Part of the texture which is used for rendering.
+     * Valid only if has_viewport is true.
+     */
+    gl_geometry viewport_box;
 
     /* tex_id will be initialized later */
     texture_t();
@@ -154,6 +162,8 @@ struct texture_t
     texture_t(GLuint tex);
     /** Initialize a texture with the attributes of the wlr texture */
     explicit texture_t(wlr_texture*);
+    /** Initialize a texture with the attributes of a mapped surface */
+    explicit texture_t(wlr_surface*);
 };
 }
 
@@ -196,7 +206,9 @@ enum texture_rendering_flags_t
  * @param g         The initial coordinates of the quad.
  * @param texg      A rectangle containing the subtexture of @texture to render.
  *                    To enable rendering a subtexture, use
- *                    TEXTURE_USE_TEX_GEOMETRY.
+ *                    TEXTURE_USE_TEX_GEOMETRY. Texture coordinates are in the
+ *                    usual coordinate system [0,1]x[0,1]. x1/y1 describe the
+ *                    lower-left corner, and x2/y2 - the upper-right corner.
  * @param transform The matrix transformation to apply to the quad.
  * @param color     A color multiplier for each channel of the texture.
  * @param bits      A bitwise OR of texture_rendering_flags_t.
@@ -288,7 +300,7 @@ class program_t : public noncopyable_t
      * restrictions about where to place `@builtin@`.
      *
      * The following identifiers should not be defined in the user source:
-     *   _wayfire_texture, _wayfire_y_mult, _wayfire_y_base, get_pixel
+     *   _wayfire_texture, _wayfire_uv_scale, _wayfire_y_base, get_pixel
      */
     void compile(const std::string& vertex_source,
         const std::string& fragment_source);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -294,6 +294,7 @@ void wf::compositor_core_impl_t::init()
     im_relay = std::make_unique<input_method_relay>();
 
     protocols.presentation = wlr_presentation_create(display, backend);
+    protocols.viewporter   = wlr_viewporter_create(display);
 
     wf_shell  = wayfire_shell_create(display);
     gtk_shell = wf_gtk_shell_create(display);

--- a/src/core/shaders.tpp
+++ b/src/core/shaders.tpp
@@ -42,11 +42,11 @@ void main()
 static const char *builtin_rgba_source =
 R"(
 uniform sampler2D _wayfire_texture;
-uniform mediump float _wayfire_y_base;
-uniform mediump float _wayfire_y_mult;
+uniform mediump vec2 _wayfire_uv_base;
+uniform mediump vec2 _wayfire_uv_scale;
 
 mediump vec4 get_pixel(highp vec2 uv) {
-    uv = vec2(uv.x, _wayfire_y_base + _wayfire_y_mult * uv.y);
+    uv = _wayfire_uv_base + _wayfire_uv_scale * uv;
     return texture2D(_wayfire_texture, uv);
 }
 )";
@@ -54,11 +54,11 @@ mediump vec4 get_pixel(highp vec2 uv) {
 static const char *builtin_rgbx_source =
 R"(
 uniform sampler2D _wayfire_texture;
-uniform mediump float _wayfire_y_base;
-uniform mediump float _wayfire_y_mult;
+uniform mediump vec2 _wayfire_uv_base;
+uniform mediump vec2 _wayfire_uv_scale;
 
 mediump vec4 get_pixel(highp vec2 uv) {
-    uv = vec2(uv.x, _wayfire_y_base + _wayfire_y_mult * uv.y);
+    uv = _wayfire_uv_base + _wayfire_uv_scale * uv;
     return vec4(texture2D(_wayfire_texture, uv).rgb, 1.0);
 }
 )";
@@ -66,12 +66,12 @@ mediump vec4 get_pixel(highp vec2 uv) {
 static const char *builtin_external_source =
 R"(
 uniform samplerExternalOES _wayfire_texture;
-uniform mediump float _wayfire_y_base;
-uniform mediump float _wayfire_y_mult;
+uniform mediump vec2 _wayfire_uv_base;
+uniform mediump vec2 _wayfire_uv_scale;
 
 mediump vec4 get_pixel(highp vec2 uv) {
-   uv = vec2(uv.x, _wayfire_y_base + _wayfire_y_mult * uv.y);
-   return texture2D(_wayfire_texture, uv);
+    uv = _wayfire_uv_base + _wayfire_uv_scale * uv;
+    return texture2D(_wayfire_texture, uv);
 }
 )";
 

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -383,7 +383,7 @@ void wf::wlr_surface_base_t::_simple_render(const wf::framebuffer_t& fb,
 
     auto size = this->_get_size();
     wf::geometry_t geometry = {x, y, size.width, size.height};
-    wf::texture_t texture{surface->buffer->texture};
+    wf::texture_t texture{surface};
 
     OpenGL::render_begin(fb);
     for (const auto& rect : damage)

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1062,9 +1062,8 @@ bool wf::view_interface_t::render_transformed(const wf::framebuffer_t& framebuff
     {
         /* Optimized case: there is a single mapped surface.
          * We can directly start with its texture */
-        previous_texture =
-            wf::texture_t{this->get_wlr_surface()->buffer->texture};
-        texture_scale = this->get_wlr_surface()->current.scale;
+        previous_texture = wf::texture_t{this->get_wlr_surface()};
+        texture_scale    = this->get_wlr_surface()->current.scale;
     } else
     {
         take_snapshot();


### PR DESCRIPTION
This is not a breaking change, because all the needed calculations can be put behind the texture_t and program_t abstractions (the calculations are done inside get_pixel()).

Fixes #553
