### PR TITLE
xdg-shell: keep track of last serial

### DIFF
--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -329,7 +329,10 @@ void wayfire_xdg_view::commit()
         set_position(wm.x, wm.y, wm, true);
     }
 
-    this->last_size_request = wf::dimensions(xdg_g);
+    if (xdg_toplevel->base->configure_serial == this->last_configure_serial)
+    {
+        this->last_size_request = wf::dimensions(xdg_g);
+    }
 }
 
 wf::point_t wayfire_xdg_view::get_window_offset()
@@ -371,14 +374,15 @@ void wayfire_xdg_view::set_activated(bool act)
         act = true;
     }
 
-    wlr_xdg_toplevel_set_activated(xdg_toplevel->base, act);
+    last_configure_serial =
+        wlr_xdg_toplevel_set_activated(xdg_toplevel->base, act);
     wf::wlr_view_t::set_activated(act);
 }
 
 void wayfire_xdg_view::set_tiled(uint32_t edges)
 {
     wlr_xdg_toplevel_set_tiled(xdg_toplevel->base, edges);
-    wlr_xdg_toplevel_set_maximized(xdg_toplevel->base,
+    last_configure_serial = wlr_xdg_toplevel_set_maximized(xdg_toplevel->base,
         (edges == wf::TILED_EDGES_ALL));
     wlr_view_t::set_tiled(edges);
 }
@@ -386,7 +390,8 @@ void wayfire_xdg_view::set_tiled(uint32_t edges)
 void wayfire_xdg_view::set_fullscreen(bool full)
 {
     wf::wlr_view_t::set_fullscreen(full);
-    wlr_xdg_toplevel_set_fullscreen(xdg_toplevel->base, full);
+    last_configure_serial =
+        wlr_xdg_toplevel_set_fullscreen(xdg_toplevel->base, full);
 }
 
 void wayfire_xdg_view::resize(int w, int h)
@@ -401,13 +406,15 @@ void wayfire_xdg_view::resize(int w, int h)
     if (should_resize_client({w, h}, current_size))
     {
         this->last_size_request = {w, h};
-        wlr_xdg_toplevel_set_size(xdg_toplevel->base, w, h);
+        last_configure_serial   =
+            wlr_xdg_toplevel_set_size(xdg_toplevel->base, w, h);
     }
 }
 
 void wayfire_xdg_view::request_native_size()
 {
-    wlr_xdg_toplevel_set_size(xdg_toplevel->base, 0, 0);
+    last_configure_serial =
+        wlr_xdg_toplevel_set_size(xdg_toplevel->base, 0, 0);
 }
 
 void wayfire_xdg_view::close()

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -47,6 +47,7 @@ class wayfire_xdg_view : public wf::wlr_view_t
 
     wf::point_t xdg_surface_offset = {0, 0};
     wlr_xdg_toplevel *xdg_toplevel;
+    uint32_t last_configure_serial = 0;
 
   protected:
     void initialize() override final;


### PR DESCRIPTION
As discussed in #923, there are certain races when a view is resized multiple times, for example in the following case:

1. Client has size 100x100
2. We send a configure for 50x50. Set pending compositor size to 50x50.
3. Clients commits before ACKing 50x50, reset pending compositor size to 100x100.
4. Plugin tries to resize to 100x100 again, but this is the same as compositor pending size (per 3.) so this fails
5. Client commits again and ACKs our configure request and has size 50x50.

In the end, the client has the wrong size. The solution is to keep track of which the last configure sent by Wayfire is, and on commit, to check if the client has caught up with us already.
