### PR TITLE
dynamic lists

### DIFF
--- a/metadata/autostart.xml
+++ b/metadata/autostart.xml
@@ -7,9 +7,10 @@
 		<group>
 			<_short>Autostart</_short>
 			<_long>Specifies the shell commands to run on startup.</_long>
-			<option name="autostart" type="dynamic_list">
+			<option name="autostart" type="dynamic-list">
 				<_short>Autostart</_short>
 				<_long>Executes shell command with `sh` on startup.  The program ID does not matter, but must be different for distinct commands.</_long>
+				<entry prefix="" type="string"/>
 				<type>string</type>
 				<hint>file</hint>
 			</option>

--- a/metadata/autostart.xml
+++ b/metadata/autostart.xml
@@ -9,7 +9,7 @@
 			<_long>Specifies the shell commands to run on startup.</_long>
 			<option name="autostart" type="dynamic-list">
 				<_short>Autostart</_short>
-				<_long>Executes shell command with `sh` on startup.  The program ID does not matter, but must be different for distinct commands.</_long>
+				<_long>Executes shell command with `sh` on startup. The program ID does not matter, but must be different for distinct commands.</_long>
 				<entry prefix="" type="string"/>
 				<type>string</type>
 				<hint>file</hint>

--- a/metadata/command.xml
+++ b/metadata/command.xml
@@ -7,11 +7,25 @@
 		<group>
 			<_short>Commands</_short>
 			<_long>Sets the command bindings.</_long>
-			<option name="command" type="dynamic_list">
+			<option name="bindings" type="dynamic-list">
 				<_short>Command</_short>
-				<_long>Sets the command binding.</_long>
-				<type>string</type>
-				<hint>file</hint>
+				<_long>Sets the command bindings.</_long>
+				<entry prefix="command_" type="string"/>
+				<entry prefix="binding_" type="activator"/>
+			</option>
+
+			<option name="repeatable_bindings" type="dynamic-list">
+				<_short>Command</_short>
+				<_long>Sets the repeatable bindings.</_long>
+				<entry prefix="command_" type="string"/>
+				<entry prefix="repeatable_binding_" type="activator"/>
+			</option>
+
+			<option name="always_bindings" type="dynamic-list">
+				<_short>Command</_short>
+				<_long>Sets the bindings which are always available, even when screen is locked.</_long>
+				<entry prefix="command_" type="string"/>
+				<entry prefix="always_binding_" type="activator"/>
 			</option>
 		</group>
 	</plugin>

--- a/metadata/command.xml
+++ b/metadata/command.xml
@@ -4,29 +4,46 @@
 		<_short>Command</_short>
 		<_long>A plugin to bind key combo (key, button, touch) to execute shell commands.</_long>
 		<category>General</category>
-		<group>
-			<_short>Commands</_short>
-			<_long>Sets the command bindings.</_long>
-			<option name="bindings" type="dynamic-list">
+		<option name="bindings" type="dynamic-list">
+			<_short>Regular bindings</_short>
+			<_long>Regular bindings</_long>
+			<entry prefix="command_" type="string">
 				<_short>Command</_short>
-				<_long>Sets the command bindings.</_long>
-				<entry prefix="command_" type="string"/>
-				<entry prefix="binding_" type="activator"/>
-			</option>
+				<_long>Sets the command to execute.</_long>
+				<hint>file</hint>
+			</entry>
+			<entry prefix="binding_" type="activator">
+				<_short>Binding</_short>
+				<_long>Sets the triggering activator binding.</_long>
+			</entry>
+		</option>
 
-			<option name="repeatable_bindings" type="dynamic-list">
+		<option name="repeatable_bindings" type="dynamic-list">
+			<_short>Repeatable bindings</_short>
+			<_long>Bindings which repeat their command if their key or button is held pressed.</_long>
+			<entry prefix="command_" type="string">
 				<_short>Command</_short>
-				<_long>Sets the repeatable bindings.</_long>
-				<entry prefix="command_" type="string"/>
-				<entry prefix="repeatable_binding_" type="activator"/>
-			</option>
+				<_long>Sets the command to execute.</_long>
+				<hint>file</hint>
+			</entry>
+			<entry prefix="repeatable_binding_" type="activator">
+				<_short>Binding</_short>
+				<_long>Sets the triggering activator binding.</_long>
+			</entry>
+		</option>
 
-			<option name="always_bindings" type="dynamic-list">
+		<option name="always_bindings" type="dynamic-list">
+			<_short>Always bindings</_short>
+			<_long>Sets the bindings which are always available, even when screen is locked.</_long>
+			<entry prefix="command_" type="string">
 				<_short>Command</_short>
-				<_long>Sets the bindings which are always available, even when screen is locked.</_long>
-				<entry prefix="command_" type="string"/>
-				<entry prefix="always_binding_" type="activator"/>
-			</option>
-		</group>
+				<_long>Sets the command to execute.</_long>
+				<hint>file</hint>
+			</entry>
+			<entry prefix="always_binding_" type="activator">
+				<_short>Binding</_short>
+				<_long>Sets the triggering activator binding.</_long>
+			</entry>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/expo.xml
+++ b/metadata/expo.xml
@@ -24,5 +24,9 @@
 			<_long>Sets the delimiter offset (in pixels) between workspaces.</_long>
 			<default>10</default>
 		</option>
+		<option name="workspace_bindings" type="dynamic-list">
+			<_short>Select workspace</_short>
+			<entry prefix="select_workspace_" type="activator"/>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/expo.xml
+++ b/metadata/expo.xml
@@ -26,7 +26,8 @@
 		</option>
 		<option name="workspace_bindings" type="dynamic-list">
 			<_short>Select workspace</_short>
-			<entry prefix="select_workspace_" type="activator"/>
+			<_long>When the binding is triggered while expo is active, the corresponding workspace will be focused and Expo will exit.</_long>
+      <entry prefix="select_workspace_" type="activator"/>
 		</option>
 	</plugin>
 </wayfire>

--- a/plugins/single_plugins/autostart.cpp
+++ b/plugins/single_plugins/autostart.cpp
@@ -7,6 +7,8 @@
 class wayfire_autostart
 {
     wf::option_wrapper_t<bool> autostart_wf_shell{"autostart/autostart_wf_shell"};
+    wf::option_wrapper_t<wf::config::compound_list_t<std::string>>
+    autostart_entries{"autostart/autostart"};
 
   public:
     wayfire_autostart()
@@ -17,17 +19,22 @@ class wayfire_autostart
         bool panel_manually_started = false;
         bool background_manually_started = false;
 
-        for (const auto& command : section->get_registered_options())
+        for (const auto& [name, command] : autostart_entries.value())
         {
-            auto cmd = command->get_value_str();
-            wf::get_core().run(cmd);
+            // Because we accept any option names, we should ignore regular
+            // options
+            if (name == "autostart_wf_shell")
+            {
+                continue;
+            }
 
-            if (cmd.find("wf-panel") != std::string::npos)
+            wf::get_core().run(command);
+            if (command.find("wf-panel") != std::string::npos)
             {
                 panel_manually_started = true;
             }
 
-            if (cmd.find("wf-background") != std::string::npos)
+            if (command.find("wf-background") != std::string::npos)
             {
                 background_manually_started = true;
             }


### PR DESCRIPTION
Use the new compound_list option type in wf-config for easier parsing of options which are generated on-the-fly by matching options
with prefixes in the same section.
