### PR TITLE
scale: fix title filter being stuck

### DIFF
--- a/plugins/scale/scale-title-filter.cpp
+++ b/plugins/scale/scale-title-filter.cpp
@@ -192,6 +192,7 @@ class scale_title_filter : public wf::plugin_interface_t
         wf::get_core().disconnect_signal(&scale_key);
         title_filter.clear();
         char_len.clear();
+        keys.clear();
         clear_overlay();
         scale_running = false;
     };


### PR DESCRIPTION
This is a fix for the first issue in #980  -- key repeat can become stuck if scale ends while a key is pressed.