### PR TITLE
scale: emit end signal earlier

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1308,11 +1308,18 @@ class wayfire_scale : public wf::plugin_interface_t
         }
 
         refocus();
+        output->emit_signal("scale-end", nullptr);
     }
 
     /* Completely end scale, including animation */
     void finalize()
     {
+        if (active)
+        {
+            /* only emit the signal if deactivate() was not called before */
+            output->emit_signal("scale-end", nullptr);
+        }
+
         active = false;
 
         unset_hook();
@@ -1328,7 +1335,6 @@ class wayfire_scale : public wf::plugin_interface_t
         workspace_changed.disconnect();
         view_geometry_changed.disconnect();
         output->deactivate_plugin(grab_interface);
-        output->emit_signal("scale-end", nullptr);
     }
 
     /* Utility hook setter */


### PR DESCRIPTION
With this change, the "scale-end" signal is emitted earlier, when scale starts to exit (whenever possible). This way, filters that display an overlay (such as the title filter) can deactivate earlier instead of only after the animation is finished.

This fixes the second issue in #980 (overlay displayed too long).