### PR TITLE
startup finished signal

### DIFF
--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -22,6 +22,13 @@ namespace wf
 /* ----------------------------------------------------------------------------/
  * Core signals
  * -------------------------------------------------------------------------- */
+/**
+ * name: startup-finished
+ * on: core
+ * when: Emitted when the Wayfire initialization has been completed and the main
+ *   loop is about to start.
+ * argument: unused
+ */
 
 /**
  * name: shutdown

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -347,6 +347,8 @@ void wf::compositor_core_impl_t::post_init()
 
     // Start processing cursor events
     seat->cursor->setup_listeners();
+
+    this->emit_signal("startup-finished", nullptr);
 }
 
 void wf::compositor_core_impl_t::shutdown()
@@ -869,6 +871,7 @@ wf::compositor_core_impl_t::~compositor_core_impl_t()
      * then we destroy the input manager, and finally the rest is auto-freed */
     views.clear();
     input.reset();
+    output_layout.reset();
 }
 
 wf::compositor_core_impl_t& wf::compositor_core_impl_t::get()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,8 +302,9 @@ int main(int argc, char *argv[])
         return -1;
     }
 
-    core.post_init();
     setenv("WAYLAND_DISPLAY", core.wayland_display.c_str(), 1);
+    core.post_init();
+
     wl_display_run(core.display);
 
     /* Teardown */


### PR DESCRIPTION
- output-layout: deinitialize noop output on renderer destroy
- core: add startup-finished signal to signal the start of main loop

The new signal can be used to override Wayfire's main loop.

~~An example plugin is coming soon.~~ See https://github.com/WayfireWM/wayfire-plugins-extra/pull/74
