### PR TITLE
config: support environment variable for config file

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,7 +30,8 @@ static void print_help()
 {
     std::cout << "Wayfire " << WAYFIRE_VERSION << std::endl;
     std::cout << "Usage: wayfire [OPTION]...\n" << std::endl;
-    std::cout << " -c,  --config            specify config file to use" << std::endl;
+    std::cout << " -c,  --config            specify config file to use " <<
+        "(overrides WAYFIRE_CONFIG_FILE from the environment)" << std::endl;
     std::cout << " -B,  --config-backend    specify config backend to use" <<
         std::endl;
     std::cout << " -h,  --help              print this help" << std::endl;


### PR DESCRIPTION
Support setting the configuration file via `WAYFIRE_CONFIG_FILE`, to match WCM.
Also, export the used configuration file, so that WCM can pick up the configuration in Wayfire, even if
it is set via the command line.
