### PR TITLE
Show views' title as an overlay during scale

### DIFF
--- a/metadata/scale.xml
+++ b/metadata/scale.xml
@@ -4,50 +4,105 @@
 		<_short>Scale</_short>
 		<_long>Show all views on screen.</_long>
 		<category>Accessibility</category>
-		<option name="toggle" type="activator">
-			<_short>Toggle</_short>
-			<_long>Toggles scale with the specified activator.</_long>
-			<default>&lt;super&gt; KEY_P</default>
-		</option>
-		<option name="toggle_all" type="activator">
-			<_short>Toggle for all workspaces</_short>
-			<_long>Toggles scale showing windows from all workspaces.</_long>
-			<default></default>
-		</option>
-		<option name="spacing" type="int">
-			<_short>Spacing</_short>
-			<_long>Sets the spacing between the views.</_long>
-			<default>50</default>
-			<min>0</min>
-		</option>
-		<option name="duration" type="int">
-			<_short>Animation Transition Time</_short>
-			<_long>Time it takes for views to transition. Units are in milliseconds.</_long>
-			<default>750</default>
-			<min>0</min>
-		</option>
-		<option name="interact" type="bool">
-			<_short>Interact With Views</_short>
-			<_long>If this option is set, views will accept input in scale state. Otherwise, all events will be ignored except left click, which will activate the clicked view and terminate scale.</_long>
-			<default>false</default>
-		</option>
-		<option name="inactive_alpha" type="double">
-			<_short>Inactive Opacity</_short>
-			<_long>Set the opacity value of the inactive windows.</_long>
-			<default>0.75</default>
-			<precision>0.05</precision>
-			<min>0.0</min>
-			<max>1.0</max>
-		</option>
-		<option name="allow_zoom" type="bool">
-			<_short>Allow Zoomed Views</_short>
-			<_long>Whether scaled views can have a size larger than their original size.</_long>
-			<default>false</default>
-		</option>
-		<option name="middle_click_close" type="bool">
-			<_short>Close views with middle click</_short>
-			<_long>Use the middle mouse button to close views in the scale state. Only applies if interactive mode is not enabled.</_long>
-			<default>false</default>
-		</option>
+		<group>
+			<_short>Behavior</_short>
+			<option name="toggle" type="activator">
+				<_short>Toggle</_short>
+				<_long>Toggles scale with the specified activator.</_long>
+				<default>&lt;super&gt; KEY_P</default>
+			</option>
+			<option name="toggle_all" type="activator">
+				<_short>Toggle for all workspaces</_short>
+				<_long>Toggles scale showing windows from all workspaces.</_long>
+				<default></default>
+			</option>
+			<option name="duration" type="int">
+				<_short>Animation Transition Time</_short>
+				<_long>Time it takes for views to transition. Units are in milliseconds.</_long>
+				<default>750</default>
+				<min>0</min>
+			</option>
+			<option name="interact" type="bool">
+				<_short>Interact With Views</_short>
+				<_long>If this option is set, views will accept input in scale state. Otherwise, all events will be ignored except left click, which will activate the clicked view and terminate scale.</_long>
+				<default>false</default>
+			</option>
+			<option name="allow_zoom" type="bool">
+				<_short>Allow Zoomed Views</_short>
+				<_long>Whether scaled views can have a size larger than their original size.</_long>
+				<default>false</default>
+			</option>
+			<option name="middle_click_close" type="bool">
+				<_short>Close views with middle click</_short>
+				<_long>Use the middle mouse button to close views in the scale state. Only applies if interactive mode is not enabled.</_long>
+				<default>false</default>
+			</option>
+		</group>
+		<group>
+			<_short>Appearance</_short>
+			<option name="spacing" type="int">
+				<_short>Spacing</_short>
+				<_long>Sets the spacing between the views.</_long>
+				<default>50</default>
+				<min>0</min>
+			</option>
+			<option name="inactive_alpha" type="double">
+				<_short>Inactive Opacity</_short>
+				<_long>Set the opacity value of the inactive windows.</_long>
+				<default>0.75</default>
+				<precision>0.05</precision>
+				<min>0.0</min>
+				<max>1.0</max>
+			</option>
+			<option name="title_overlay" type="string">
+				<_short>Show views' title</_short>
+				<_long>Whether to display the title of each view as an overlay.</_long>
+				<default>all</default>
+				<desc>
+					<value>never</value>
+					<_name>Never</_name>
+				</desc>
+				<desc>
+					<value>mouse</value>
+					<_name>Only for the view under the pointer</_name>
+				</desc>
+				<desc>
+					<value>all</value>
+					<_name>For all views</_name>
+				</desc>
+			</option>
+			<option name="title_font_size" type="int">
+				<_short>Font size for title</_short>
+				<_long>Size of font used to display an overlay of each view's title.</_long>
+				<default>16</default>
+			</option>
+			<option name="title_position" type="string">
+				<_short>Position for title</_short>
+				<_long>Position for overlays of views' titles when shown.</_long>
+				<default>center</default>
+				<desc>
+					<value>top</value>
+					<_name>Top</_name>
+				</desc>
+				<desc>
+					<value>center</value>
+					<_name>Center</_name>
+				</desc>
+				<desc>
+					<value>bottom</value>
+					<_name>Bottom</_name>
+				</desc>
+			</option>
+			<option name="bg_color" type="color">
+				<_short>Background color</_short>
+				<_long>Background color for title overlay text.</_long>
+				<default>0.1 0.1 0.1 0.9</default>
+			</option>
+			<option name="text_color" type="color">
+				<_short>Text color</_short>
+				<_long>Text color for title overlay.</_long>
+				<default>0.8 0.8 0.8 1.0</default>
+			</option>
+		</group>
 	</plugin>
 </wayfire>

--- a/plugins/common/wayfire/plugins/common/cairo-util.hpp
+++ b/plugins/common/wayfire/plugins/common/cairo-util.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <string>
 #include <wayfire/plugins/common/simple-texture.hpp>
+#include <wayfire/config/types.hpp>
 #include <cairo.h>
 
 namespace wf
@@ -33,4 +35,256 @@ static void cairo_surface_upload_to_texture(
     GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED));
     GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA,
         buffer.width, buffer.height, 0, GL_RGBA, GL_UNSIGNED_BYTE, src));
+}
+
+namespace wf
+{
+/**
+ * Simple wrapper around rendering text with Cairo. This object can be
+ * kept around to avoid reallocation of the cairo surface and OpenGL
+ * texture on repeated renders.
+ */
+struct cairo_text_t
+{
+    wf::simple_texture_t tex;
+
+    /* parameters used for rendering */
+    struct params
+    {
+        /* font size */
+        int font_size = 12;
+        /* color for background rectangle (only used if bg_rect == true) */
+        wf::color_t bg_color;
+        /* text color */
+        wf::color_t text_color;
+        /* scale everything by this amount */
+        float output_scale = 1.f;
+        /* crop result to this size (if nonzero);
+         * note that this is multiplied by output_scale */
+        wf::dimensions_t max_size{0, 0};
+        /* draw a rectangle in the background with bg_color */
+        bool bg_rect = true;
+        /* round the corners of the background rectangle */
+        bool rounded_rect = true;
+        /* if true, the resulting surface will be cropped to the
+         * minimum size necessary to fit the text; otherwise, the
+         * resulting surface might be bigger than necessary and the
+         * text is centered in it */
+        bool exact_size = false;
+
+        params()
+        {}
+        params(int font_size_, const wf::color_t& bg_color_,
+            const wf::color_t& text_color_, float output_scale_ = 1.f,
+            const wf::dimensions_t& max_size_ = {0, 0},
+            bool bg_rect_ = true, bool exact_size_ = false) :
+            font_size(font_size_), bg_color(bg_color_),
+            text_color(text_color_), output_scale(output_scale_),
+            max_size(max_size_), bg_rect(bg_rect_),
+            exact_size(exact_size_)
+        {}
+    };
+
+    /**
+     * Render the given text in the texture tex.
+     *
+     * @param text         text to render
+     * @param par          parameters for rendering
+     *
+     * @return The size needed to render in scaled coordinates. If this is larger
+     *   than the size of tex, it means the result was cropped (due to the constraint
+     *   given in par.max_size). If it is smaller, than the result is centered along
+     *   that dimension.
+     */
+    wf::dimensions_t render_text(const std::string& text, const params& par)
+    {
+        if (!cr)
+        {
+            /* create with default size */
+            cairo_create_surface();
+        }
+
+        cairo_text_extents_t extents;
+        cairo_font_extents_t font_extents;
+        /* TODO: font properties could be made parameters! */
+        cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL,
+            CAIRO_FONT_WEIGHT_BOLD);
+        cairo_set_font_size(cr, par.font_size * par.output_scale);
+        cairo_text_extents(cr, text.c_str(), &extents);
+        cairo_font_extents(cr, &font_extents);
+
+        double xpad = par.bg_rect ? 10.0 * par.output_scale : 0.0;
+        double ypad = par.bg_rect ? 0.2 * (font_extents.ascent +
+            font_extents.descent) : 0.0;
+        int w = (int)(extents.width + 2 * xpad);
+        int h = (int)(font_extents.ascent + font_extents.descent + 2 * ypad);
+        wf::dimensions_t ret = {w, h};
+        if (par.max_size.width && (w > par.max_size.width * par.output_scale))
+        {
+            w = (int)std::floor(par.max_size.width * par.output_scale);
+        }
+
+        if (par.max_size.height && (h > par.max_size.height * par.output_scale))
+        {
+            h = (int)std::floor(par.max_size.height * par.output_scale);
+        }
+
+        if ((w != surface_size.width) || (h != surface_size.height))
+        {
+            if (par.exact_size || (w > surface_size.width) ||
+                (h > surface_size.height))
+            {
+                surface_size.width  = w;
+                surface_size.height = h;
+                cairo_create_surface();
+            }
+        }
+
+        cairo_set_operator(cr, CAIRO_OPERATOR_CLEAR);
+        cairo_paint(cr);
+
+        int x = (surface_size.width - w) / 2;
+        int y = (surface_size.height - h) / 2;
+
+        if (par.bg_rect)
+        {
+            int min_r = (int)(20 * par.output_scale);
+            int r     = par.rounded_rect ? (h > min_r ? min_r : (h - 2) / 2) : 0;
+
+            cairo_move_to(cr, x + r, y);
+            cairo_line_to(cr, x + w - r, y);
+            if (par.rounded_rect)
+            {
+                cairo_curve_to(cr, x + w, y, x + w, y, x + w, y + r);
+            }
+
+            cairo_line_to(cr, x + w, y + h - r);
+            if (par.rounded_rect)
+            {
+                cairo_curve_to(cr, x + w, y + h, x + w, y + h, x + w - r, y + h);
+            }
+
+            cairo_line_to(cr, x + r, y + h);
+            if (par.rounded_rect)
+            {
+                cairo_curve_to(cr, x, y + h, x, y + h, x, y + h - r);
+            }
+
+            cairo_line_to(cr, x, y + r);
+            if (par.rounded_rect)
+            {
+                cairo_curve_to(cr, x, y, x, y, x + r, y);
+            }
+
+            cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+            cairo_set_source_rgba(cr, par.bg_color.r, par.bg_color.g,
+                par.bg_color.b, par.bg_color.a);
+            cairo_fill(cr);
+        }
+
+        x += xpad;
+        y += ypad + font_extents.ascent;
+        cairo_select_font_face(cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL,
+            CAIRO_FONT_WEIGHT_BOLD);
+        cairo_set_font_size(cr, par.font_size * par.output_scale);
+        cairo_move_to(cr, x - extents.x_bearing, y);
+        cairo_set_source_rgba(cr, par.text_color.r, par.text_color.g,
+            par.text_color.b, par.text_color.a);
+        cairo_show_text(cr, text.c_str());
+
+        cairo_surface_flush(surface);
+        OpenGL::render_begin();
+        cairo_surface_upload_to_texture(surface, tex);
+        OpenGL::render_end();
+
+        return ret;
+    }
+
+    /**
+     * Standalone function version to render text to an OpenGL texture
+     */
+    static wf::dimensions_t cairo_render_text_to_texture(const std::string& text,
+        const wf::cairo_text_t::params& par, wf::simple_texture_t& tex)
+    {
+        wf::cairo_text_t ct;
+        /* note: we "borrow" the texture from what was supplied (if any) */
+        ct.tex.tex = tex.tex;
+        auto ret = ct.render_text(text, par);
+        if (tex.tex == (GLuint) - 1)
+        {
+            tex.tex = ct.tex.tex;
+        }
+
+        tex.width  = ct.tex.width;
+        tex.height = ct.tex.height;
+        ct.tex.tex = -1;
+        return ret;
+    }
+
+    ~cairo_text_t()
+    {
+        cairo_free();
+    }
+
+    /**
+     * Calculate the height of text rendered with a given font size.
+     *
+     * @param font_size  Desired font size.
+     * @param bg_rect    Whether a background rectangle should be taken into account.
+     *
+     * @returns Required height of the surface.
+     */
+    static unsigned int measure_height(int font_size, bool bg_rect = true)
+    {
+        cairo_text_t dummy;
+        dummy.surface_size.width  = 1;
+        dummy.surface_size.height = 1;
+        dummy.cairo_create_surface();
+
+        cairo_font_extents_t font_extents;
+        /* TODO: font properties could be made parameters! */
+        cairo_select_font_face(dummy.cr, "sans-serif", CAIRO_FONT_SLANT_NORMAL,
+            CAIRO_FONT_WEIGHT_BOLD);
+        cairo_set_font_size(dummy.cr, font_size);
+        cairo_font_extents(dummy.cr, &font_extents);
+
+        double ypad = bg_rect ? 0.2 * (font_extents.ascent +
+            font_extents.descent) : 0.0;
+        unsigned int h = (unsigned int)std::ceil(font_extents.ascent +
+            font_extents.descent + 2 * ypad);
+        return h;
+    }
+
+  protected:
+    /* cairo context and surface for the text */
+    cairo_t *cr = nullptr;
+    cairo_surface_t *surface = nullptr;
+    /* current width and height of the above surface */
+    wf::dimensions_t surface_size = {400, 100};
+
+
+    void cairo_free()
+    {
+        if (cr)
+        {
+            cairo_destroy(cr);
+        }
+
+        if (surface)
+        {
+            cairo_surface_destroy(surface);
+        }
+
+        cr = nullptr;
+        surface = nullptr;
+    }
+
+    void cairo_create_surface()
+    {
+        cairo_free();
+        surface = cairo_image_surface_create(CAIRO_FORMAT_ARGB32, surface_size.width,
+            surface_size.height);
+        cr = cairo_create(surface);
+    }
+};
 }

--- a/plugins/scale/meson.build
+++ b/plugins/scale/meson.build
@@ -1,7 +1,7 @@
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, vswitch_inc, wobbly_inc, include_directories('.')]
-all_deps = [wlroots, pixman, wfconfig, wftouch]
+all_deps = [wlroots, pixman, wfconfig, wftouch, cairo]
 
-shared_module('scale', 'scale.cpp',
+shared_module('scale', ['scale.cpp', 'scale-title-overlay.cpp'],
         include_directories: all_include_dirs,
         dependencies: all_deps,
         install: true,
@@ -9,7 +9,7 @@ shared_module('scale', 'scale.cpp',
 
 shared_module('scale-title-filter', 'scale-title-filter.cpp',
         include_directories: all_include_dirs,
-        dependencies: [wlroots, pixman, wfconfig, wftouch, cairo],
+        dependencies: all_deps,
         install: true,
         install_dir: conf_data.get('PLUGIN_PATH'))
 

--- a/plugins/scale/meson.build
+++ b/plugins/scale/meson.build
@@ -13,4 +13,4 @@ shared_module('scale-title-filter', 'scale-title-filter.cpp',
         install: true,
         install_dir: conf_data.get('PLUGIN_PATH'))
 
-install_headers(['wayfire/plugins/scale-signal.hpp'], subdir: 'wayfire/plugins')
+install_headers(['wayfire/plugins/scale-signal.hpp', 'wayfire/plugins/scale-transform.hpp'], subdir: 'wayfire/plugins')

--- a/plugins/scale/scale-title-overlay.cpp
+++ b/plugins/scale/scale-title-overlay.cpp
@@ -1,0 +1,557 @@
+#include "scale-title-overlay.hpp"
+
+#include <wayfire/opengl.hpp>
+#include <wayfire/util/log.hpp>
+#include <wayfire/plugins/common/cairo-util.hpp>
+#include <wayfire/plugins/common/simple-texture.hpp>
+
+/**
+ * Get the topmost parent of a view.
+ */
+static wayfire_view find_toplevel_parent(wayfire_view view)
+{
+    while (view->parent)
+    {
+        view = view->parent;
+    }
+
+    return view;
+}
+
+/**
+ * Class storing an overlay with a view's title, only stored for parent views.
+ */
+struct view_title_texture_t : public wf::custom_data_t
+{
+    wayfire_view view;
+    wf::cairo_text_t overlay;
+    wf::cairo_text_t::params par;
+    bool overflow = false;
+    wayfire_view dialog; /* the texture should be rendered on top of this dialog */
+
+    /**
+     * Render the overlay text in our texture, cropping it to the size by
+     * the given box.
+     */
+    void update_overlay_texture(wf::dimensions_t dim)
+    {
+        par.max_size = dim;
+        update_overlay_texture();
+    }
+
+    void update_overlay_texture()
+    {
+        auto res = overlay.render_text(view->get_title(), par);
+        overflow = res.width > overlay.tex.width;
+    }
+
+    wf::signal_connection_t view_changed = [this] (auto)
+    {
+        if (overlay.tex.tex != (GLuint) - 1)
+        {
+            update_overlay_texture();
+        }
+    };
+
+    view_title_texture_t(wayfire_view v, int font_size, const wf::color_t& bg_color,
+        const wf::color_t& text_color, float output_scale) : view(v)
+    {
+        par.font_size    = font_size;
+        par.bg_color     = bg_color;
+        par.text_color   = text_color;
+        par.exact_size   = true;
+        par.output_scale = output_scale;
+
+        view->connect_signal("title-changed", &view_changed);
+    }
+};
+
+/**
+ * Class with the overlay hooks, added to scale's transformer.
+ */
+class view_title_overlay_t : public wf::scale_transformer_t::overlay_t
+{
+  public:
+    enum class position
+    {
+        TOP,
+        CENTER,
+        BOTTOM,
+    };
+
+  protected:
+    /* the transformer we are attached to */
+    wf::scale_transformer_t& tr;
+    /* save the transformed view, since we need it in the destructor */
+    wayfire_view view;
+    /* the position on the screen we currently render to */
+    wf::geometry_t geometry;
+    scale_show_title_t& parent;
+    unsigned int text_height; /* set in the constructor, should not change */
+    position pos = position::CENTER;
+    /* Whether we are currently rendering the overlay by this transformer.
+     * Set in the pre-render hook and used in the render function. */
+    bool overlay_shown = false;
+
+    /**
+     * Get the transformed WM geometry of the view transformed by the given
+     * transformer, including the current transform, but not any padding.
+     */
+    wlr_box get_transformed_wm_geometry(wf::scale_transformer_t& tr)
+    {
+        wlr_box box = tr.get_transformed_view()->get_wm_geometry();
+        return tr.trasform_box_without_padding(box);
+    }
+
+    wlr_box get_transformed_wm_geometry()
+    {
+        return get_transformed_wm_geometry(tr);
+    }
+
+    /**
+     * Get the transformed WM geometry of the given view,
+     * including the current transform, but not any padding.
+     */
+    wlr_box get_transformed_wm_geometry(wayfire_view view)
+    {
+        auto tmp =
+            view->get_transformer(wf::scale_transformer_t::transformer_name());
+        if (!tmp)
+        {
+            /* This might happen if view is a newly created dialog that does not
+             * yet have a transformed added to it. In this case, return a zero
+             * size box that will never overlap with the overlay. */
+            return {0, 0, 0, 0};
+        }
+
+        /* TODO: can we use static_cast in this case? */
+        auto tr = dynamic_cast<wf::scale_transformer_t*>(tmp.get());
+        assert(tr);
+
+        return get_transformed_wm_geometry(*tr);
+    }
+
+    /**
+     * Gets the overlay texture stored with the given view.
+     */
+    view_title_texture_t& get_overlay_texture(wayfire_view view)
+    {
+        auto data = view->get_data<view_title_texture_t>();
+        if (!data)
+        {
+            auto new_data = new view_title_texture_t(view, parent.title_font_size,
+                parent.bg_color, parent.text_color, parent.output->handle->scale);
+            view->store_data<view_title_texture_t>(std::unique_ptr<view_title_texture_t>(
+                new_data));
+            return *new_data;
+        }
+
+        return *data.get();
+    }
+
+    /**
+     * Get the bounding box of the topmost parent of this view without and
+     * padding added by scale's transformer.
+     */
+    wlr_box get_parent_box()
+    {
+        auto view = tr.get_transformed_view();
+        auto box  = get_transformed_wm_geometry(find_toplevel_parent(view));
+        if ((box.width == 0) || (box.height == 0))
+        {
+            /* This is the case if the parent does not have a transformer. This
+             * should normally not happen, but might be the case if this view is
+             * assigned as the child of a newly created view that does not yet
+             * have a transformer.
+             * TODO: check if this case is actually possible! */
+            return get_transformed_wm_geometry();
+        }
+
+        return box;
+    }
+
+    /**
+     * Check if this view should display an overlay.
+     */
+    bool should_have_overlay(view_title_texture_t& title)
+    {
+        if (this->parent.show_view_title_overlay ==
+            scale_show_title_t::title_overlay_t::NEVER)
+        {
+            return false;
+        }
+
+        auto parent = find_toplevel_parent(view);
+
+        if ((this->parent.show_view_title_overlay ==
+             scale_show_title_t::title_overlay_t::MOUSE) &&
+            (this->parent.last_title_overlay != parent))
+        {
+            return false;
+        }
+
+        if (view == parent)
+        {
+            /* Check if the overlay overlaps with any dialogs. */
+
+            /* Update maximum possible extents of the overlay */
+            auto max_geom = get_transformed_wm_geometry();
+            switch (pos)
+            {
+              case position::CENTER:
+                max_geom.y += (max_geom.height - text_height) / 2;
+                break;
+
+              case position::TOP:
+                max_geom.y -= (text_height + 1);
+                break;
+
+              case position::BOTTOM:
+                max_geom.y += max_geom.height;
+                break;
+            }
+
+            max_geom.height = text_height + 1;
+
+            title.dialog = view;
+            for (auto dialog : view->enumerate_views(false))
+            {
+                if ((dialog == view) || !dialog->is_visible())
+                {
+                    continue;
+                }
+
+                auto dialog_box = get_transformed_wm_geometry(dialog);
+                if (dialog_box & max_geom)
+                {
+                    title.dialog = dialog;
+                    break;
+                }
+            }
+        }
+
+        return view == title.dialog;
+    }
+
+    /**
+     * Pre-render hook: calculates new position and optionally re-renders the text.
+     */
+    bool pre_render()
+    {
+        bool ret  = false;
+        auto& tex = get_overlay_texture(find_toplevel_parent(view));
+        if (!should_have_overlay(tex))
+        {
+            if (overlay_shown)
+            {
+                ret = true;
+                overlay_shown = false;
+            }
+
+            view_padding = {0, 0, 0, 0};
+            return ret;
+        }
+
+        if (!overlay_shown)
+        {
+            overlay_shown = true;
+            ret = true;
+        }
+
+        auto box = get_parent_box(); // will return our box if there is no parent
+        auto output_scale = parent.output->handle->scale;
+
+        /**
+         * regenerate the overlay texture in the following cases:
+         * 1. Output's scale changed
+         * 2. The overlay does not fit anymore
+         * 3. The overlay previously did not fit, but there is more space now
+         * TODO: check if this wastes too high CPU power when views are being
+         * animated and maybe redraw less frequently
+         */
+        if ((tex.overlay.tex.tex == (GLuint) - 1) ||
+            (output_scale != tex.par.output_scale) ||
+            (tex.overlay.tex.width > box.width * output_scale) ||
+            (tex.overflow &&
+             (tex.overlay.tex.width < std::floor(box.width * output_scale))))
+        {
+            tex.par.output_scale = output_scale;
+            tex.update_overlay_texture({box.width, box.height});
+            ret = true;
+        }
+
+        int w = tex.overlay.tex.width;
+        int h = tex.overlay.tex.height;
+        int y = 0;
+        switch (pos)
+        {
+          case position::TOP:
+            y = box.y - (int)(h / output_scale);
+            break;
+
+          case position::CENTER:
+            y = box.y + box.height / 2 - (int)(h / output_scale / 2);
+            break;
+
+          case position::BOTTOM:
+            y = box.y + box.height;
+            break;
+        }
+
+        geometry = {box.x + box.width / 2 - (int)(w / output_scale / 2),
+            y, (int)(w / output_scale), (int)(h / output_scale)};
+
+        /* We need to ensure that geometry is within our box. */
+        if (view->parent || (pos != position::CENTER))
+        {
+            /* get out own box (previously we might have had the parent's box */
+            if (view->parent)
+            {
+                box = get_transformed_wm_geometry();
+            }
+
+            view_padding = {0, 0, 0, 0};
+            if (geometry.x < box.x)
+            {
+                view_padding.left = box.x - geometry.x;
+            }
+
+            if (geometry.x + geometry.width > box.x + box.width)
+            {
+                view_padding.right = (geometry.x + geometry.width) -
+                    (box.x + box.width);
+            }
+
+            if (geometry.y < box.y)
+            {
+                view_padding.top = box.y - geometry.y;
+            }
+
+            if (geometry.y + geometry.height > box.y + box.height)
+            {
+                view_padding.bottom = (geometry.y + geometry.height) -
+                    (box.y + box.height);
+            }
+
+            /* note: no need to call damage, the transformer will check if the
+             * padding has changed and will damage the view accordingly */
+        } else
+        {
+            view_padding = {0, 0, 0, 0};
+        }
+
+        return ret;
+    }
+
+    void render(const wf::framebuffer_t& fb, const wf::region_t& damage)
+    {
+        if (!overlay_shown)
+        {
+            return;
+        }
+
+        view_title_texture_t& title = get_overlay_texture(find_toplevel_parent(
+            tr.get_transformed_view()));
+
+        GLuint tex = title.overlay.tex.tex;
+
+        if (tex == (GLuint) - 1)
+        {
+            /* this should not happen */
+            return;
+        }
+
+        auto ortho = fb.get_orthographic_projection();
+        OpenGL::render_begin(fb);
+        for (const auto& box : damage)
+        {
+            fb.logic_scissor(wlr_box_from_pixman_box(box));
+            OpenGL::render_transformed_texture(tex, geometry, ortho,
+                {1.0f, 1.0f, 1.0f, tr.alpha}, OpenGL::TEXTURE_TRANSFORM_INVERT_Y);
+        }
+
+        OpenGL::render_end();
+    }
+
+  public:
+    view_title_overlay_t(wf::scale_transformer_t& tr_, position pos_,
+        scale_show_title_t& parent_) : tr(tr_), view(tr.get_transformed_view()),
+        parent(parent_), pos(pos_)
+    {
+        auto parent = find_toplevel_parent(view);
+        auto& title = get_overlay_texture(parent);
+
+        if (title.overlay.tex.tex != (GLuint) - 1)
+        {
+            text_height = (unsigned int)std::ceil(
+                title.overlay.tex.height / title.par.output_scale);
+        } else
+        {
+            text_height =
+                wf::cairo_text_t::measure_height(title.par.font_size, true);
+        }
+
+        /* add padding required by scale */
+        if (pos == position::BOTTOM)
+        {
+            scale_padding.bottom = text_height;
+        } else if (pos == position::TOP)
+        {
+            scale_padding.top = text_height;
+        }
+
+        pre_hook = [this] ()
+        {
+            return pre_render();
+        };
+        render_hook = [this] (
+            const wf::framebuffer_t& fb,
+            const wf::region_t& damage)
+        {
+            render(fb, damage);
+        };
+    }
+
+    ~view_title_overlay_t()
+    {
+        view->erase_data<view_title_texture_t>();
+        if (view->parent && overlay_shown)
+        {
+            auto parent = find_toplevel_parent(view);
+            /* we need to recalculate which dialog should show the overlay */
+            auto tmp = parent->get_transformer(
+                wf::scale_transformer_t::transformer_name());
+            auto tr = dynamic_cast<wf::scale_transformer_t*>(tmp.get());
+            if (tr)
+            {
+                tr->call_pre_hooks(false);
+            }
+        }
+    }
+};
+
+scale_show_title_t::scale_show_title_t() :
+    view_filter{[this] (auto)
+    {
+        update_title_overlay_opt();
+    }},
+
+    scale_end{[this] (wf::signal_data_t*)
+    {
+        show_view_title_overlay = title_overlay_t::NEVER;
+        last_title_overlay = nullptr;
+        mouse_update.disconnect();
+    }
+},
+
+add_title_overlay{[this] (wf::signal_data_t *data)
+    {
+        const std::string& opt = show_view_title_overlay_opt;
+        if (opt == "never")
+        {
+            /* TODO: support changing this option while scale is running! */
+            return;
+        }
+
+        const std::string& pos_opt = title_position;
+        view_title_overlay_t::position pos = view_title_overlay_t::position::CENTER;
+        if (pos_opt == "top")
+        {
+            pos = view_title_overlay_t::position::TOP;
+        } else if (pos_opt == "bottom")
+        {
+            pos = view_title_overlay_t::position::BOTTOM;
+        }
+
+        auto signal = static_cast<scale_transformer_added_signal*>(data);
+        auto tr     = signal->transformer;
+        auto ol     = new view_title_overlay_t(*tr, pos, *this);
+
+        tr->add_overlay(std::unique_ptr<wf::scale_transformer_t::overlay_t>(ol), 1);
+    }
+},
+
+mouse_update{[this] (auto)
+    {
+        update_title_overlay_mouse();
+    }
+}
+
+{}
+
+void scale_show_title_t::init(wf::output_t *output)
+{
+    this->output = output;
+    output->connect_signal("scale-filter", &view_filter);
+    output->connect_signal("scale-transformer-added", &add_title_overlay);
+    output->connect_signal("scale-end", &scale_end);
+}
+
+void scale_show_title_t::fini()
+{
+    mouse_update.disconnect();
+}
+
+void scale_show_title_t::update_title_overlay_opt()
+{
+    const std::string& tmp = show_view_title_overlay_opt;
+    if (tmp == "all")
+    {
+        show_view_title_overlay = title_overlay_t::ALL;
+    } else if (tmp == "mouse")
+    {
+        show_view_title_overlay = title_overlay_t::MOUSE;
+    } else
+    {
+        show_view_title_overlay = title_overlay_t::NEVER;
+    }
+
+    if (show_view_title_overlay == title_overlay_t::MOUSE)
+    {
+        update_title_overlay_mouse();
+        mouse_update.disconnect();
+        wf::get_core().connect_signal("pointer_motion_absolute_post", &mouse_update);
+        wf::get_core().connect_signal("pointer_motion_post", &mouse_update);
+    }
+}
+
+void scale_show_title_t::update_title_overlay_mouse()
+{
+    wayfire_view v;
+
+    wf::option_wrapper_t<bool> interact{"scale/interact"};
+
+    if (interact)
+    {
+        /* we can use normal focus tracking */
+        v = wf::get_core().get_cursor_focus_view();
+    } else
+    {
+        auto& core = wf::get_core();
+        v = core.get_view_at(core.get_cursor_position());
+    }
+
+    if (v)
+    {
+        v = find_toplevel_parent(v);
+
+        if (v->role != wf::VIEW_ROLE_TOPLEVEL)
+        {
+            v = nullptr;
+        }
+    }
+
+    if (v != last_title_overlay)
+    {
+        if (last_title_overlay)
+        {
+            last_title_overlay->damage();
+        }
+
+        last_title_overlay = v;
+        if (v)
+        {
+            v->damage();
+        }
+    }
+}

--- a/plugins/scale/scale-title-overlay.hpp
+++ b/plugins/scale/scale-title-overlay.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <string>
+
+#include <wayfire/plugin.hpp>
+#include <wayfire/output.hpp>
+
+#include <wayfire/plugins/scale-signal.hpp>
+#include <wayfire/plugins/scale-transform.hpp>
+
+
+class scale_show_title_t
+{
+  protected:
+    /* Overlays for showing the title of each view */
+    wf::option_wrapper_t<wf::color_t> bg_color{"scale/bg_color"};
+    wf::option_wrapper_t<wf::color_t> text_color{"scale/text_color"};
+    wf::option_wrapper_t<std::string> show_view_title_overlay_opt{
+        "scale/title_overlay"};
+    wf::option_wrapper_t<int> title_font_size{"scale/title_font_size"};
+    wf::option_wrapper_t<std::string> title_position{"scale/title_position"};
+    wf::output_t *output;
+
+  public:
+    scale_show_title_t();
+
+    void init(wf::output_t *output);
+
+    void fini();
+
+  protected:
+    /* signals */
+    wf::signal_connection_t view_filter;
+    wf::signal_connection_t scale_end;
+    wf::signal_connection_t add_title_overlay;
+    wf::signal_connection_t mouse_update;
+
+    enum class title_overlay_t
+    {
+        NEVER,
+        MOUSE,
+        ALL,
+    };
+
+    friend class view_title_overlay_t;
+
+    title_overlay_t show_view_title_overlay;
+    /* only used if title overlay is set to follow the mouse */
+    wayfire_view last_title_overlay = nullptr;
+
+    void update_title_overlay_opt();
+    void update_title_overlay_mouse();
+};

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -20,6 +20,8 @@
 
 #include <linux/input-event-codes.h>
 
+#include "scale-title-overlay.hpp"
+
 using namespace wf::animation;
 
 class scale_animation_t : public duration_t
@@ -56,6 +58,8 @@ struct view_scale_data
 
 class wayfire_scale : public wf::plugin_interface_t
 {
+    /* helper class for optionally showing title overlays */
+    scale_show_title_t show_title;
     std::vector<int> current_row_sizes;
     wf::point_t initial_workspace;
     bool active, hook_set;
@@ -144,6 +148,8 @@ class wayfire_scale : public wf::plugin_interface_t
 
         drag_helper->connect_signal("focus-output", &on_drag_output_focus);
         drag_helper->connect_signal("done", &on_drag_done);
+
+        show_title.init(output);
     }
 
     void setup_workspace_switching()
@@ -1454,6 +1460,7 @@ class wayfire_scale : public wf::plugin_interface_t
         finalize();
         output->rem_binding(&toggle_cb);
         output->rem_binding(&toggle_all_cb);
+        show_title.fini();
     }
 };
 

--- a/plugins/scale/wayfire/plugins/scale-signal.hpp
+++ b/plugins/scale/wayfire/plugins/scale-signal.hpp
@@ -5,6 +5,7 @@
 
 #include <wayfire/object.hpp>
 #include <wayfire/view.hpp>
+#include <wayfire/plugins/scale-transform.hpp>
 #include <vector>
 #include <algorithm>
 
@@ -72,5 +73,17 @@ void scale_filter_views(scale_filter_signal *signal, pred&& p)
  *   the filter is changed. It is a no-op if scale is not currently running.
  * argument: unused
  */
+
+/**
+ * name: scale-transformer-added
+ * on: output
+ * when: This signal is emitted when scale adds a transformer to a view, so
+ *   plugins extending its functionality can add their overlays to it.
+ * argument: pointer to the newly added transformer
+ */
+struct scale_transformer_added_signal : public wf::signal_data_t
+{
+    wf::scale_transformer_t *transformer;
+};
 
 #endif

--- a/plugins/scale/wayfire/plugins/scale-transform.hpp
+++ b/plugins/scale/wayfire/plugins/scale-transform.hpp
@@ -1,0 +1,308 @@
+#pragma once
+
+#include <wayfire/view-transform.hpp>
+#include <wayfire/nonstd/observer_ptr.h>
+#include <wayfire/render-manager.hpp>
+#include <string>
+#include <list>
+#include <algorithm>
+
+namespace wf
+{
+/**
+ * transformer used by scale -- it is an extension of the 2D transformer
+ * with the ability to add overlays
+ */
+class scale_transformer_t : public wf::view_2D
+{
+  public:
+    scale_transformer_t(wayfire_view view) : wf::view_2D(view)
+    {}
+    ~scale_transformer_t()
+    {}
+
+    struct padding_t
+    {
+        unsigned int top    = 0;
+        unsigned int left   = 0;
+        unsigned int bottom = 0;
+        unsigned int right  = 0;
+
+        /**
+         * Compare paddings. Returns true if ANY of the dimensions in this
+         * is smaller than other. Note that this does not define an ordering
+         * on paddings.
+         */
+        bool any_smaller_than(const padding_t& other) const
+        {
+            return (top < other.top) || (left < other.left) ||
+                   (bottom < other.bottom) || (right < other.right);
+        }
+
+        /**
+         * Helper function to extend padding to ensure it is at least as
+         * large as other.
+         */
+        void extend(const padding_t& other)
+        {
+            top    = std::max(top, other.top);
+            left   = std::max(left, other.left);
+            bottom = std::max(bottom, other.bottom);
+            right  = std::max(right, other.right);
+        }
+    };
+
+    uint32_t get_z_order() override
+    {
+        return wf::TRANSFORMER_HIGHLEVEL - 10;
+    }
+
+    /**
+     * Effect hook called in the following circumstances:
+     *  (1) as pre-render hooks while this transformer is attached to the view
+     *  (2) if another transformer changed the view's size, so the overlay and
+     * padding might need to be updated
+     *
+     * The second case can happen just during rendering the view (from
+     * view::render_transformed()), so it should not call damage.
+     *
+     * @return Whether the overlay changed. In this case damage will be
+     * scheduled for the view.
+     *
+     * Damage will also be scheduled if the size of the combined padding from
+     * all overlays have changed.
+     */
+    using pre_hook_t = std::function<bool (void)>;
+
+    /**
+     * Render hook for drawing on top of the surface after the transform, during
+     * rendering the view.
+     *
+     * @param fb     The framebuffer to render to.
+     * @param damage Damaged region to render.
+     */
+    using render_hook_t = std::function<void (const wf::framebuffer_t& fb,
+        const wf::region_t& damage)>;
+
+    /**
+     * Overlays that can be added to this transformer. Hooks are called
+     * similarly to render-manager.
+     */
+    struct overlay_t
+    {
+        /* Pre hook; called just before rendering, can adjust padding. Return
+         * value indicates if damage should be scheduled for the view. */
+        pre_hook_t pre_hook;
+        /* Render hook; called during rendering, after this transform has been
+         * applied to the view. This can only render to the view's texture. */
+        render_hook_t render_hook;
+        /* Extra padding around the transformed view required by this overlay.
+         * This is added to the view's bounding box */
+        padding_t view_padding;
+        /* Extra padding taken to be taken into consideration by scale's layout.
+         * This can differ from view_padding e.g. if this overlay is rendering
+         * directly to the end framebuffer */
+        padding_t scale_padding;
+
+        virtual ~overlay_t() = default;
+    };
+
+    /* render the transformed view and then add all overlays */
+    void render_with_damage(wf::texture_t src_tex, wlr_box src_box,
+        const wf::region_t& damage, const wf::framebuffer_t& target_fb) override
+    {
+        /* render the transformed view first */
+        view_transformer_t::render_with_damage(src_tex, src_box, damage, target_fb);
+
+        /* call all overlays */
+        for (auto& p : overlays)
+        {
+            auto& ol = *(p.second);
+            if (ol.render_hook)
+            {
+                ol.render_hook(target_fb, damage);
+            }
+        }
+    }
+
+    /**
+     * Call pre-render hooks.
+     *
+     * Will also damage the view if either the parameter is true or if the
+     * total padding changes or if any of the overlays explicitly requests it.
+     */
+    void call_pre_hooks(bool damage_request)
+    {
+        call_pre_hooks(damage_request, true);
+    }
+
+    /**
+     * Add a new overlay that is rendered after this transform.
+     *
+     * @param ol      The overlay object to be added.
+     * @param z_order Relative order; overlays are called in order.
+     */
+    void add_overlay(std::unique_ptr<overlay_t>&& ol, int z_order)
+    {
+        auto it = std::find_if(overlays.begin(), overlays.end(),
+            [z_order] (const auto& other)
+        {
+            return other.first >= z_order;
+        });
+
+        view_padding.extend(ol->view_padding);
+        scale_padding.extend(ol->scale_padding);
+        overlays.insert(it, std::pair<int, std::unique_ptr<overlay_t>>(z_order,
+            std::move(ol)));
+        view->damage();
+    }
+
+    /* remove an existing overlay */
+    void rem_overlay(nonstd::observer_ptr<overlay_t> ol)
+    {
+        view->damage();
+        overlays.remove_if([ol] (const auto& other)
+        {
+            return other.second.get() == ol.get();
+        });
+
+        recalculate_padding();
+        view->damage();
+    }
+
+    /* get the view being transformed (it is protected in view_2D) */
+    wayfire_view get_transformed_view() const
+    {
+        return view;
+    }
+
+    /**
+     * Transformer name used by scale. This can be used by other plugins to find
+     * scale's transformer on a view.
+     */
+    static std::string transformer_name()
+    {
+        return "scale";
+    }
+
+    /**
+     * Transform a box, including the current transform, but not the padding.
+     */
+    wlr_box trasform_box_without_padding(wlr_box box)
+    {
+        box = view->transform_region(box, this);
+        wlr_box view_box = view->get_bounding_box(this);
+        return view_transformer_t::get_bounding_box(view_box, box);
+    }
+
+    /**
+     * Transform the view's bounding box, including the current transform, but not
+     * the padding.
+     */
+    wlr_box transform_bounding_box_without_padding()
+    {
+        auto box = view->get_bounding_box(this);
+        return view_transformer_t::get_bounding_box(box, box);
+    }
+
+    /**
+     * Transform a region and add padding to it.
+     * Note: this will pad any transformed region, not only if it corresponds to
+     * the view's bounding box.
+     */
+    wlr_box get_bounding_box(wf::geometry_t view, wlr_box region) override
+    {
+        if (view != last_view_box)
+        {
+            /* box changed, we might need to update our padding;
+             * this can happen if another transformer was removed between
+             * pre-render hooks and rendering; in this case, the code removing
+             * the other transformer should call damage() before and after,
+             * which in turn will call this function; there is no need to
+             * call damage() here */
+            last_view_box = view;
+            call_pre_hooks(false, false);
+        }
+
+        region    = view_transformer_t::get_bounding_box(view, region);
+        region.x -= view_padding.left;
+        region.y -= view_padding.top;
+        region.width  += view_padding.left + view_padding.right;
+        region.height += view_padding.top + view_padding.bottom;
+        return region;
+    }
+
+    const padding_t& get_scale_padding() const
+    {
+        return scale_padding;
+    }
+
+  protected:
+    /* list of active overlays */
+    std::list<std::pair<int, std::unique_ptr<overlay_t>>> overlays;
+    padding_t view_padding; /* combined padding added to the view's bounding box */
+    padding_t scale_padding; /* combined padding to be used by scale's layout */
+
+    /* recalculate padding */
+    void recalculate_padding()
+    {
+        view_padding  = {0, 0, 0, 0};
+        scale_padding = {0, 0, 0, 0};
+        for (const auto& p : overlays)
+        {
+            view_padding.extend(p.second->view_padding);
+            scale_padding.extend(p.second->scale_padding);
+        }
+    }
+
+    void call_pre_hooks(bool damage_request, bool can_damage)
+    {
+        padding_t new_view_pad;
+        scale_padding = {0, 0, 0, 0};
+        for (auto& p : overlays)
+        {
+            auto& ol = *(p.second);
+            if (ol.pre_hook)
+            {
+                damage_request |= ol.pre_hook();
+
+                new_view_pad.extend(ol.view_padding);
+                scale_padding.extend(ol.scale_padding);
+            }
+        }
+
+        /* Note: if some dimensions of the padding have shrunk, while others
+        * have grown, we need to call damage() twice (once with the old, once
+        * with the new padding), to include the whole box. This could be
+        * avoided by calculating a box that contains both old and new padding
+        * and calling damage directly on the output (after transforming). */
+        bool padding_shrunk = new_view_pad.any_smaller_than(view_padding);
+        bool padding_grown  = view_padding.any_smaller_than(new_view_pad);
+
+        if (padding_shrunk)
+        {
+            if (can_damage)
+            {
+                view->damage();
+            }
+
+            view_padding = new_view_pad;
+            /* no need to damage in the next step unless some dimensions
+             * have grown */
+            damage_request = false;
+        }
+
+        if (padding_grown || damage_request)
+        {
+            view_padding = new_view_pad;
+            if (can_damage)
+            {
+                view->damage();
+            }
+        }
+    }
+
+    wf::geometry_t last_view_box = {0, 0, 0, 0};
+    wf::wl_idle_call idle_call;
+};
+}


### PR DESCRIPTION
This is an implementation for #990 

Some notes:
 - I've made this part of the title filter plugin, since I'm unsure if it makes sense to add and extra plugin and also to share code more easily; maybe the title filter plugin could be renamed to "Scale addons" or something similar?
 - The helper classes: `cairo_text_t` and `view_overlay` could be part of some common tools. This way, other plugins can re-use them to render text and to add overlays to views.
 - The `view_overlay` transformer is not efficient in its current form, since there is no need to copy the view's texture to a new framebuffer. I wonder if there is a way to add a transformer that renders to the latest framebuffer without copying that I missed, or if it would make sense to add this functionality?
 - I could not find an easy way so far to take output scaling into account; this should probably be fixed before merging, so any suggestion on this is welcome :)
 - Also, this would benefit from better damage tracking. For the current case, it is not really a problem, since the transformers added by scale will need to damage the whole view anyway.

Fixes #990