### PR TITLE
grid crossfade

### DIFF
--- a/metadata/grid.xml
+++ b/metadata/grid.xml
@@ -12,14 +12,14 @@
 		<option name="type" type="string">
 			<_short>Type</_short>
 			<_long>Sets the type of the animation.</_long>
-			<default>simple</default>
+			<default>crossfade</default>
 			<desc>
 				<value>none</value>
 				<_name>None</_name>
 			</desc>
 			<desc>
-				<value>simple</value>
-				<_name>Simple</_name>
+				<value>crossfade</value>
+				<_name>Crossfade</_name>
 			</desc>
 			<desc>
 				<value>wobbly</value>


### PR DESCRIPTION
I have started to experiment a bit with a crossfade animation instead of the default move+resize for grid.
There are still a few things left that should be fixed, but I think it should already be much smoother than the current animation.

~~Opening as a draft because it seems easy to get Grid into a state where it flips between fullscreen and unfullscreen each frame, making the window unusable. Will investigate further on that.~~ Seems a bug in GTK3, it happens on gnome too.

Note if someone is testing this: it requires the dynamic-list branch of wf-config, otherwise, it won't compile. This is necessary for a small addition I made there.

Fixes #991 