### PR TITLE
subsurfaces: add new subsurface-added/removed signals

### DIFF
--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -73,7 +73,7 @@ class simple_decoration_surface : public wf::surface_interface_t,
     {
         this->view = view;
         view->connect_signal("title-changed", &title_set);
-        view->connect_signal("unmapped", &on_base_view_unmap);
+        view->connect_signal("subsurface-removed", &on_subsurface_removed);
 
         // make sure to hide frame if the view is fullscreen
         update_decoration_size();
@@ -249,11 +249,13 @@ class simple_decoration_surface : public wf::surface_interface_t,
         target_height = std::max(target_height, 1);
     }
 
-    wf::signal_connection_t on_base_view_unmap = [&] (wf::signal_data_t *data)
+    wf::signal_connection_t on_subsurface_removed = [&] (auto data)
     {
-        unmap();
-        // remove self
-        view->set_decoration(nullptr);
+        auto ev = static_cast<wf::subsurface_removed_signal*>(data);
+        if (ev->subsurface.get() == this)
+        {
+            unmap();
+        }
     };
 
     void unmap()

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'05;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'05'1;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -300,6 +300,29 @@ struct workarea_changed_signal : public wf::signal_data_t
 using stack_order_changed_signal = _output_signal;
 
 /* ----------------------------------------------------------------------------/
+ * Surface signals
+ * -------------------------------------------------------------------------- */
+struct _subsurface_signal : public wf::signal_data_t
+{
+    nonstd::observer_ptr<surface_interface_t> main_surface;
+    nonstd::observer_ptr<surface_interface_t> subsurface;
+};
+
+/**
+ * name: subsurface-added
+ * on: surface
+ * when: Emitted when a subsurface is added to the given surface.
+ */
+using subsurface_added_signal = _subsurface_signal;
+
+/**
+ * name: subsurface-removed
+ * on: surface
+ * when: Emitted immediately before removing a subsurface from the surface.
+ */
+using subsurface_removed_signal = _subsurface_signal;
+
+/* ----------------------------------------------------------------------------/
  * View signals
  * -------------------------------------------------------------------------- */
 

--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -9,6 +9,7 @@
 #include <wayfire/nonstd/wlroots.hpp>
 #include <wayfire/nonstd/observer_ptr.h>
 #include <wayfire/geometry.hpp>
+#include <wayfire/object.hpp>
 
 namespace wf
 {
@@ -35,7 +36,7 @@ struct surface_iterator_t
  * surface_interface_t is the base class for everything that can be displayed
  * on the screen. It is the closest thing there is in Wayfire to a Window in X11.
  */
-class surface_interface_t
+class surface_interface_t : public wf::object_base_t
 {
   public:
     virtual ~surface_interface_t();

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -4,7 +4,6 @@
 #include <vector>
 #include <wayfire/nonstd/observer_ptr.h>
 
-#include "wayfire/object.hpp"
 #include "wayfire/surface.hpp"
 #include "wayfire/geometry.hpp"
 #include <wayfire/nonstd/wlroots.hpp>
@@ -48,7 +47,7 @@ constexpr uint32_t TILED_EDGES_ALL =
  * view_interface_t is the base class for all "toplevel windows", i.e surfaces
  * which have no parent.
  */
-class view_interface_t : public surface_interface_t, public wf::object_base_t
+class view_interface_t : public surface_interface_t
 {
   public:
     /**

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -26,7 +26,13 @@ void wf::surface_interface_t::add_subsurface(
     subsurface->set_output(get_output());
     auto& container = is_below_parent ?
         priv->surface_children_below : priv->surface_children_above;
+
+    wf::subsurface_added_signal ev;
+    ev.main_surface = this;
+    ev.subsurface   = {subsurface};
+
     container.insert(container.begin(), std::move(subsurface));
+    this->emit_signal("subsurface-added", &ev);
 }
 
 void wf::surface_interface_t::remove_subsurface(
@@ -38,6 +44,11 @@ void wf::surface_interface_t::remove_subsurface(
             [=] (const auto& ptr) { return ptr.get() == subsurface.get(); });
         container.erase(it, container.end());
     };
+
+    wf::subsurface_removed_signal ev;
+    ev.main_surface = this;
+    ev.subsurface   = subsurface;
+    this->emit_signal("subsurface-removed", &ev);
 
     remove_from(priv->surface_children_above);
     remove_from(priv->surface_children_below);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1257,8 +1257,23 @@ void wf::view_interface_t::deinitialize()
     }
 
     set_decoration(nullptr);
-    this->priv->surface_children_below.clear();
-    this->priv->surface_children_above.clear();
+
+    subsurface_removed_signal ev;
+    ev.main_surface = this;
+    const auto& finish_subsurfaces = [&] (auto& container)
+    {
+        for (auto& surface : container)
+        {
+            ev.subsurface = {surface};
+            this->emit_signal("subsurface-removed", &ev);
+        }
+
+        container.clear();
+    };
+
+    finish_subsurfaces(priv->surface_children_above);
+    finish_subsurfaces(priv->surface_children_below);
+
     this->view_impl->transforms.clear();
     this->_clear_data();
 


### PR DESCRIPTION
These are useful for plugins which have subsurfaces. In this way, they
can emit the unmap signal at the correct time.

Fixes #837
