### PR TITLE
core: add command line arguments

### DIFF
--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -67,6 +67,12 @@ class compositor_core_t : public wf::object_base_t
     wf::config::config_manager_t config;
 
     /**
+     * Command line arguments.
+     */
+    int argc;
+    char **argv;
+
+    /**
      * The wayland display and its event loop
      */
     wl_display *display;

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'05'1;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'05'2;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -254,6 +254,9 @@ int main(int argc, char *argv[])
 
     auto& core = wf::get_core_impl();
 
+    core.argc = argc;
+    core.argv = argv;
+
     /** TODO: move this to core_impl constructor */
     core.display  = display;
     core.ev_loop  = wl_display_get_event_loop(core.display);


### PR DESCRIPTION
They are visible for all plugins.

Fixes #658
