### PR TITLE
signal-definitions: use correct name for pointer_motion_absolute

### DIFF
--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -63,7 +63,7 @@ struct switch_signal : public wf::signal_data_t
 
 /**
  * name:
- *   pointer_motion, pointer_motion_abs, pointer_button, pointer_axis,
+ *   pointer_motion, pointer_motion_absolute, pointer_button, pointer_axis,
  *   pointer_swipe_begin, pointer_swipe_update, pointer_swipe_end,
  *   pointer_pinch_begin, pointer_pinch_update, pointer_pinch_end,
  *   keyboard_key,


### PR DESCRIPTION
It is currently not consistent with what is used in cursor.cpp