### PR TITLE
window-rules: add assign-workspace rule

### DIFF
--- a/plugins/window-rules/view-action-interface.hpp
+++ b/plugins/window-rules/view-action-interface.hpp
@@ -39,10 +39,14 @@ class view_action_interface_t : public action_interface_t
         const std::vector<variant_t> & args);
     std::tuple<bool, int, int> _validate_size(const std::vector<variant_t> & args);
 
+    std::tuple<bool, wf::point_t> _validate_ws(const std::vector<variant_t>& args);
+
     void _set_alpha(float alpha);
     void _set_geometry(int x, int y, int w, int h);
     void _move(int x, int y);
     void _resize(int w, int h);
+
+    void _assign_ws(wf::point_t point);
 
     wf::geometry_t _get_workspace_grid_geometry(wf::output_t *output) const;
 


### PR DESCRIPTION
With this rule, window-rules can move the view to a given workspace.

Example:

```
rule1 = on created if app_id is "terminator" then assign_workspace 1 1
```

Note: the window-rules plugin should come later than the place plugin (if it is enabled), otherwise, there might be a conflict between these two.

Fixes #588
