### PR TITLE
layer-shell: ignore unmapped layer-shell view commits without output

### DIFF
--- a/src/view/layer-shell.cpp
+++ b/src/view/layer-shell.cpp
@@ -373,6 +373,16 @@ void wayfire_layer_shell_view::initialize()
 
     on_commit_unmapped.set_callback([&] (void*)
     {
+        if (!this->get_output())
+        {
+            // This case can happen in the following scenario:
+            // 1. Create output X
+            // 2. Client opens a layer-shell surface Y on X
+            // 3. X is destroyed, Y's output is now NULL
+            // 4. Y commits
+            return;
+        }
+
         wf_layer_shell_manager::get_instance().arrange_unmapped_view(this);
     });
 


### PR DESCRIPTION
Fixes #908

This can happen if an output is plugged in and unplugged immediately (possibly on the noop output): the compositor will close the (unmapped) layer-surface, it may commit before receiving the close request, but its output is set to `nullptr` by output-layout (since the output was destroyed).
