### PR TITLE
Add middle_emulation for middle click emulation

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -60,7 +60,7 @@
 		<!-- libinput configuration -->
 		<option name="middle_emulation" type="bool">
 			<_short>Middle-click emulation</_short>
-			<_long>Sets the middle button emulation property by hitting the left and right buttons simultaneously.</_long>
+			<_long>Enables middle button emulation by hitting the left and right buttons simultaneously.</_long>
 			<default>false</default>
 		</option>
 		<option name="mouse_accel_profile" type="string">

--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -58,6 +58,11 @@
 			<default></default>
 		</option>
 		<!-- libinput configuration -->
+		<option name="middle_emulation" type="bool">
+			<_short>Middle-click emulation</_short>
+			<_long>Sets the middle button emulation property by hitting the left and right buttons simultaneously.</_long>
+			<default>false</default>
+		</option>
 		<option name="mouse_accel_profile" type="string">
 			<_short>Mouse acceleration profile</_short>
 			<_long>Sets the pointer acceleration profile.</_long>

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -9,6 +9,8 @@ wf::pointing_device_t::pointing_device_t(wlr_input_device *dev) :
 wf::pointing_device_t::config_t wf::pointing_device_t::config;
 void wf::pointing_device_t::config_t::load()
 {
+    middle_emulation.load_option("input/middle_emulation");
+
     mouse_scroll_speed.load_option("input/mouse_scroll_speed");
     mouse_cursor_speed.load_option("input/mouse_cursor_speed");
     touchpad_cursor_speed.load_option("input/touchpad_cursor_speed");
@@ -57,6 +59,11 @@ void wf::pointing_device_t::update_options()
 
     auto dev = wlr_libinput_get_device_handle(get_wlr_handle());
     assert(dev);
+
+    libinput_device_config_middle_emulation_set_enabled(dev,
+        config.middle_emulation ?
+        LIBINPUT_CONFIG_MIDDLE_EMULATION_ENABLED :
+        LIBINPUT_CONFIG_MIDDLE_EMULATION_DISABLED);
 
     /* we are configuring a touchpad */
     if (libinput_device_config_tap_get_finger_count(dev) > 0)

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -14,6 +14,7 @@ struct pointing_device_t : public input_device_impl_t
 
     static struct config_t
     {
+        wf::option_wrapper_t<bool> middle_emulation;
         wf::option_wrapper_t<double> mouse_cursor_speed;
         wf::option_wrapper_t<double> mouse_scroll_speed;
         wf::option_wrapper_t<double> touchpad_cursor_speed;


### PR DESCRIPTION
This pull request adds [middle click emulation](https://wayland.freedesktop.org/libinput/doc/1.11.3/middle_button_emulation.html) support into the config like so:

```ini
[input]
 middle_emulation = true
```