### PR TITLE
fix 960

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'05'2;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'12;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -197,6 +197,9 @@ class surface_interface_t : public wf::object_base_t
     /** Damage the given region, in surface-local coordinates */
     virtual void damage_surface_region(const wf::region_t& region);
 
+    /** Remove all subsurfaces that we have. Should to be called after unmapping! */
+    virtual void clear_subsurfaces();
+
     /* Allow wlr surface implementation to access surface internals */
     friend class wlr_surface_base_t;
 };

--- a/src/view/subsurface.cpp
+++ b/src/view/subsurface.cpp
@@ -1,4 +1,6 @@
 #include "subsurface.hpp"
+#include "view/view-impl.hpp"
+#include "wayfire/signal-definitions.hpp"
 #include <cassert>
 
 wf::subsurface_implementation_t::subsurface_implementation_t(wlr_subsurface *_sub) :
@@ -22,6 +24,19 @@ wf::subsurface_implementation_t::subsurface_implementation_t(wlr_subsurface *_su
     on_map.connect(&sub->events.map);
     on_unmap.connect(&sub->events.unmap);
     on_destroy.connect(&sub->events.destroy);
+
+    on_removed.set_callback([=] (auto data)
+    {
+        auto ev = static_cast<wf::subsurface_removed_signal*>(data);
+        if ((ev->subsurface.get() == this) && this->is_mapped())
+        {
+            unmap();
+        }
+    });
+
+    // At this point, priv->parent_surface is not set!
+    auto parent = wf_surface_from_void(sub->parent->data);
+    parent->connect_signal("subsurface-removed", &on_removed);
 }
 
 wf::point_t wf::subsurface_implementation_t::get_offset()

--- a/src/view/subsurface.hpp
+++ b/src/view/subsurface.hpp
@@ -11,6 +11,8 @@ class subsurface_implementation_t : public wlr_child_surface_base_t
     wl_listener_wrapper on_map, on_unmap, on_destroy;
     wlr_subsurface *sub;
 
+    wf::signal_connection_t on_removed;
+
   public:
     subsurface_implementation_t(wlr_subsurface *s);
     virtual wf::point_t get_offset() override;

--- a/src/view/surface-impl.hpp
+++ b/src/view/surface-impl.hpp
@@ -14,6 +14,11 @@ class surface_interface_t::impl
     std::vector<std::unique_ptr<surface_interface_t>> surface_children_above;
     std::vector<std::unique_ptr<surface_interface_t>> surface_children_below;
 
+    /**
+     * Remove all subsurfaces and emit signals for them.
+     */
+    void clear_subsurfaces(surface_interface_t *self);
+
     wf::output_t *output = nullptr;
     static int active_shrink_constraint;
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1258,22 +1258,7 @@ void wf::view_interface_t::deinitialize()
 
     set_decoration(nullptr);
 
-    subsurface_removed_signal ev;
-    ev.main_surface = this;
-    const auto& finish_subsurfaces = [&] (auto& container)
-    {
-        for (auto& surface : container)
-        {
-            ev.subsurface = {surface};
-            this->emit_signal("subsurface-removed", &ev);
-        }
-
-        container.clear();
-    };
-
-    finish_subsurfaces(priv->surface_children_above);
-    finish_subsurfaces(priv->surface_children_below);
-
+    this->clear_subsurfaces();
     this->view_impl->transforms.clear();
     this->_clear_data();
 


### PR DESCRIPTION
When unmapping a surface, we expect that its subsurfaces will be unmapped too. Unfortunately, this is not the case in the current wlroots version, and it is not guaranteed for compositor subsurfaces. To mitigate this, we need to remove all subsurfaces after unmapping a surface.

This is necessary because otherwise it can happen that the main surface is destroyed before the subsurfaces have had a chance to unmap. In that case, they would actually be destroyed without being unmapped, causing a crash.

Fixes #960
Fixes #1017
