### PR TITLE
Invert 3d transformer

### DIFF
--- a/metadata/wrot.xml
+++ b/metadata/wrot.xml
@@ -5,15 +5,40 @@
 		<_long>A plugin to rotate windows with the mouse.</_long>
 		<category>Effects</category>
 		<option name="activate" type="button">
-			<_short>Activate</_short>
-			<_long>Rotates the window with the specified button.</_long>
+			<_short>Rotate 2D</_short>
+			<_long>Rotates the window around its z-axis.</_long>
 			<default>&lt;super&gt; &lt;ctrl&gt; BTN_RIGHT</default>
+		</option>
+		<option name="activate-3d" type="button">
+			<_short>Rotate 3D</_short>
+			<_long>Rotates the window around its x and y axes..</_long>
+			<default>&lt;super&gt; &lt;shift&gt; BTN_RIGHT</default>
 		</option>
 		<option name="reset_radius" type="double">
 			<_short>Reset Radius</_short>
-			<_long>The radius of the reset area. The reset area is located at the center of the view and resets the rotation.</_long>
+			<_long>The radius of the reset area for 2D rotations. The reset area is located at the center of the view and resets the rotation.</_long>
 			<default>25.0</default>
 			<min>1.0</min>
+		</option>
+		<option name="reset-one" type="key">
+			<_short>Reset Current</_short>
+			<_long>Remove rotation from the currently focused view.</_long>
+			<default>&lt;super&gt; KEY_R</default>
+		</option>
+		<option name="reset" type="key">
+			<_short>Reset All</_short>
+			<_long>Remove rotation from all views.</_long>
+			<default>&lt;super&gt; &lt;ctrl&gt; KEY_R</default>
+		</option>
+		<option name="sensitivity" type="int">
+			<_short>Sensitivity (3D)</_short>
+			<_long>How quickly 3D rotations happen with mouse movements (in arminutes per pixel).</_long>
+			<default>24</default>
+		</option>
+		<option name="invert" type="bool">
+			<_short>Invert 3D rotation directions</_short>
+			<_long>Invert the direction of movement for 3D rotations.</_long>
+			<default>false</default>
 		</option>
 	</plugin>
 </wayfire>

--- a/plugins/single_plugins/wrot.cpp
+++ b/plugins/single_plugins/wrot.cpp
@@ -3,7 +3,13 @@
 #include "wayfire/view-transform.hpp"
 #include "wayfire/output.hpp"
 #include "wayfire/core.hpp"
+#include <wayfire/workspace-manager.hpp>
 #include <linux/input.h>
+
+#include <glm/gtc/matrix_transform.hpp>
+
+static const char *transformer_3d = "wrot-3d";
+static const char *transformer_2d = "wrot-2d";
 
 static double cross(double x1, double y1, double x2, double y2) // cross product
 {
@@ -15,13 +21,144 @@ static double vlen(double x1, double y1) // length of vector centered at the ori
     return std::sqrt(x1 * x1 + y1 * y1);
 }
 
+enum class mode
+{
+    NONE,
+    ROT_2D,
+    ROT_3D,
+};
+
 class wf_wrot : public wf::plugin_interface_t
 {
     wf::button_callback call;
     wf::option_wrapper_t<double> reset_radius{"wrot/reset_radius"};
+    wf::option_wrapper_t<int> sensitivity{"wrot/sensitivity"};
+    wf::option_wrapper_t<bool> invert{"wrot/invert"};
 
     wf::pointf_t last_position;
-    wayfire_view current_view;
+    wayfire_view current_view = nullptr;
+
+    mode current_mode = mode::NONE;
+
+    void reset_all()
+    {
+        for (auto v : output->workspace->get_views_in_layer(wf::LAYER_WORKSPACE))
+        {
+            v->pop_transformer(transformer_3d);
+            v->pop_transformer(transformer_2d);
+        }
+    }
+
+    wf::button_callback call_3d = [this] (auto)
+    {
+        if (current_mode != mode::NONE)
+        {
+            return false;
+        }
+
+        if (!output->activate_plugin(grab_interface))
+        {
+            return false;
+        }
+
+        current_view = wf::get_core().get_cursor_focus_view();
+        if (!current_view || (current_view->role != wf::VIEW_ROLE_TOPLEVEL))
+        {
+            output->deactivate_plugin(grab_interface);
+
+            return false;
+        }
+
+        output->focus_view(current_view, true);
+        grab_interface->grab();
+
+        last_position = output->get_cursor_position();
+        current_mode  = mode::ROT_3D;
+        return true;
+    };
+
+    wf::key_callback reset = [this] (auto)
+    {
+        reset_all();
+        return true;
+    };
+
+    wf::key_callback reset_one = [this] (auto)
+    {
+        auto view = output->get_active_view();
+        if (view)
+        {
+            view->pop_transformer(transformer_3d);
+            view->pop_transformer(transformer_2d);
+        }
+
+        return true;
+    };
+
+    void motion_2d(int x, int y)
+    {
+        if (!current_view->get_transformer(transformer_2d))
+        {
+            current_view->add_transformer(std::make_unique<wf::view_2D>(
+                current_view), transformer_2d);
+        }
+
+        auto tr = dynamic_cast<wf::view_2D*>(current_view->get_transformer(
+            transformer_2d).get());
+        assert(tr);
+
+        current_view->damage();
+
+        auto g = current_view->get_wm_geometry();
+
+        double cx = g.x + g.width / 2.0;
+        double cy = g.y + g.height / 2.0;
+
+        double x1 = last_position.x - cx, y1 = last_position.y - cy;
+        double x2 = x - cx, y2 = y - cy;
+
+        if (vlen(x2, y2) <= reset_radius)
+        {
+            return current_view->pop_transformer(transformer_2d);
+        }
+
+        /* cross(a, b) = |a| * |b| * sin(a, b) */
+        tr->angle -= std::asin(cross(x1, y1, x2, y2) / vlen(x1, y1) / vlen(x2,
+            y2));
+
+        current_view->damage();
+
+        last_position = {1.0 * x, 1.0 * y};
+    }
+
+    void motion_3d(int x, int y)
+    {
+        if ((x == last_position.x) && (y == last_position.y))
+        {
+            return;
+        }
+
+        if (!current_view->get_transformer(transformer_3d))
+        {
+            current_view->add_transformer(std::make_unique<wf::view_3D>(
+                current_view), transformer_3d);
+        }
+
+        auto tr = dynamic_cast<wf::view_3D*>(current_view->get_transformer(
+            transformer_3d).get());
+        assert(tr);
+
+        current_view->damage();
+        float dx     = x - last_position.x;
+        float dy     = y - last_position.y;
+        float ascale = glm::radians(sensitivity / 60.0f);
+        float dir    = invert ? -1.f : 1.f;
+        tr->rotation = glm::rotate<float>(tr->rotation, vlen(dx, dy) * ascale,
+            {dir *dy, dir * dx, 0});
+        current_view->damage();
+
+        last_position = {(double)x, (double)y};
+    }
 
   public:
     void init() override
@@ -31,6 +168,11 @@ class wf_wrot : public wf::plugin_interface_t
 
         call = [=] (auto)
         {
+            if (current_mode != mode::NONE)
+            {
+                return false;
+            }
+
             if (!output->activate_plugin(grab_interface))
             {
                 return false;
@@ -48,46 +190,28 @@ class wf_wrot : public wf::plugin_interface_t
             grab_interface->grab();
 
             last_position = output->get_cursor_position();
+            current_mode  = mode::ROT_2D;
             return true;
         };
 
         output->add_button(
             wf::option_wrapper_t<wf::buttonbinding_t>("wrot/activate"), &call);
+        output->add_button(
+            wf::option_wrapper_t<wf::buttonbinding_t>("wrot/activate-3d"), &call_3d);
+        output->add_key(wf::option_wrapper_t<wf::keybinding_t>{"wrot/reset"},
+            &reset);
+        output->add_key(wf::option_wrapper_t<wf::keybinding_t>{"wrot/reset-one"},
+            &reset_one);
 
         grab_interface->callbacks.pointer.motion = [=] (int x, int y)
         {
-            if (!current_view->get_transformer("wrot"))
+            if (current_mode == mode::ROT_2D)
             {
-                current_view->add_transformer(std::make_unique<wf::view_2D>(
-                    current_view), "wrot");
-            }
-
-            auto tr = dynamic_cast<wf::view_2D*>(current_view->get_transformer(
-                "wrot").get());
-            assert(tr);
-
-            current_view->damage();
-
-            auto g = current_view->get_wm_geometry();
-
-            double cx = g.x + g.width / 2.0;
-            double cy = g.y + g.height / 2.0;
-
-            double x1 = last_position.x - cx, y1 = last_position.y - cy;
-            double x2 = x - cx, y2 = y - cy;
-
-            if (vlen(x2, y2) <= reset_radius)
+                motion_2d(x, y);
+            } else if (current_mode == mode::ROT_3D)
             {
-                return current_view->pop_transformer("wrot");
+                motion_3d(x, y);
             }
-
-            /* cross(a, b) = |a| * |b| * sin(a, b) */
-            tr->angle -= std::asin(cross(x1, y1, x2, y2) / vlen(x1, y1) / vlen(x2,
-                y2));
-
-            current_view->damage();
-
-            last_position = {1.0 * x, 1.0 * y};
         };
 
         grab_interface->callbacks.pointer.button = [=] (uint32_t, uint32_t s)
@@ -111,6 +235,29 @@ class wf_wrot : public wf::plugin_interface_t
     {
         grab_interface->ungrab();
         output->deactivate_plugin(grab_interface);
+        if ((current_mode == mode::ROT_3D) && current_view)
+        {
+            auto tr = dynamic_cast<wf::view_3D*>(current_view->get_transformer(
+                transformer_3d).get());
+            if (tr)
+            {
+                /* check if the view was rotated to perpendicular to the screen
+                 * and move it a bit more, so it will not get "stuck" that way */
+                glm::vec4 n{0, 0, 1.f, 0};
+                glm::vec4 x = tr->rotation * n;
+                auto dot    = glm::dot(n, x);
+                if (std::abs(dot) < 0.05)
+                {
+                    /* rotate 2.5 degrees around an axis perpendicular to x */
+                    current_view->damage();
+                    tr->rotation = glm::rotate<float>(tr->rotation, glm::radians(
+                        dot < 0 ? -2.5f : 2.5f), {x.y, -x.x, 0});
+                    current_view->damage();
+                }
+            }
+        }
+
+        current_mode = mode::NONE;
     }
 
     void fini() override
@@ -120,7 +267,12 @@ class wf_wrot : public wf::plugin_interface_t
             input_released();
         }
 
+        reset_all();
+
         output->rem_binding(&call);
+        output->rem_binding(&call_3d);
+        output->rem_binding(&reset);
+        output->rem_binding(&reset_one);
     }
 };
 


### PR DESCRIPTION
While working on #996 I've noticed [this TODO](https://github.com/WayfireWM/wayfire/blob/faab309a9122b758f5edd164a7bc2748ce3e4f52/src/view/view-3d.cpp#L229) and realized that I can provide a solution. This is possible since the "3D" transform in this case is actually mapping a 2D object to a 2D canvas, so it is not losing information (except in the case when the view is turned perpendicular to the screen).

The first commit is actually the inverse of the transform, the second commit adds a simple plugin to demonstrate that it is working -- I'm actually not sure if this plugin should go in the main plugin collection (maybe it could be merged with the 2D "wrot" plugin?).
