### PR TITLE
core, xwayland: support views which do not accept keyboard focus

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -677,10 +677,18 @@ void wf::compositor_core_impl_t::set_active_view(wayfire_view new_focus)
         new_focus = nullptr;
     }
 
-    if (all_dialogs_modal)
+    if (all_dialogs_modal && new_focus)
     {
-        /* Descend into frontmost child view */
-        new_focus = new_focus ? new_focus->enumerate_views().front() : nullptr;
+        // Choose the frontmost view which has focus enabled.
+        auto all_views = new_focus->enumerate_views();
+        for (auto& view : all_views)
+        {
+            if (view->get_keyboard_focus_surface())
+            {
+                new_focus = view;
+                break;
+            }
+        }
     }
 
     bool refocus = (last_active_view == new_focus);

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -651,6 +651,9 @@ class wayfire_xwayland_view : public wayfire_xwayland_view_base
 
     void map(wlr_surface *surface) override
     {
+        view_impl->keyboard_focus_enabled =
+            wlr_xwayland_or_surface_wants_focus(xw);
+
         if (xw->maximized_horz && xw->maximized_vert)
         {
             if ((xw->width > 0) && (xw->height > 0))


### PR DESCRIPTION
Seems to be a necessary fix for JetBrains IDEs, see https://github.com/swaywm/wlroots/pull/2605
