### PR TITLE
move-drag-interface: add information about all views in done signal

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1276,10 +1276,14 @@ class wayfire_scale : public wf::plugin_interface_t
         auto ev = static_cast<wf::move_drag::drag_done_signal*>(data);
         if ((ev->focused_output == output) && can_handle_drag())
         {
-            if (ev->view->get_output() == ev->focused_output)
+            if (ev->main_view->get_output() == ev->focused_output)
             {
                 // View left on the same output, don't do anything
-                set_tiled_wobbly(ev->view, true);
+                for (auto& v : ev->all_views)
+                {
+                    set_tiled_wobbly(v.view, true);
+                }
+
                 layout_slots(get_views());
                 return;
             }

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -233,13 +233,14 @@ class wayfire_expo : public wf::plugin_interface_t
         auto ev = static_cast<wf::move_drag::drag_done_signal*>(data);
         if ((ev->focused_output == output) && can_handle_drag())
         {
-            bool same_output = ev->view->get_output() == output;
+            bool same_output = ev->main_view->get_output() == output;
 
             auto offset = wf::origin(output->get_layout_geometry());
             auto local  = input_coordinates_to_output_local_coordinates(
                 ev->grab_position + -offset);
 
-            for (auto& v : wf::move_drag::get_target_views(ev->view, ev->join_views))
+            for (auto& v :
+                 wf::move_drag::get_target_views(ev->main_view, ev->join_views))
             {
                 translate_wobbly(v, local - (ev->grab_position - offset));
             }
@@ -250,7 +251,7 @@ class wayfire_expo : public wf::plugin_interface_t
             if (same_output && (move_started_ws != offscreen_point))
             {
                 view_change_viewport_signal data;
-                data.view = ev->view;
+                data.view = ev->main_view;
                 data.from = move_started_ws;
                 data.to   = {target_vx, target_vy};
                 output->emit_signal("view-change-viewport", &data);

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -93,7 +93,7 @@ class wayfire_move : public wf::plugin_interface_t
             if (enable_snap && (slot.slot_id != 0))
             {
                 snap_signal data;
-                data.view = ev->view;
+                data.view = ev->main_view;
                 data.slot = (slot_type)slot.slot_id;
                 output->emit_signal("view-snap", &data);
 
@@ -102,7 +102,7 @@ class wayfire_move : public wf::plugin_interface_t
             }
 
             view_change_viewport_signal data;
-            data.view = ev->view;
+            data.view = ev->main_view;
             data.to   = output->workspace->get_current_workspace();
             data.old_viewport_invalid = false;
             output->emit_signal("view-change-viewport", &data);


### PR DESCRIPTION
This is necessary because for adjusting the end position, we need to know the relative grab locations for all views.

Fixes #1041

cc @damianatorrpm
