### PR TITLE
cpu micro-optimizations

### DIFF
--- a/src/api/wayfire/opengl.hpp
+++ b/src/api/wayfire/opengl.hpp
@@ -189,7 +189,7 @@ void render_end();
 void clear(wf::color_t color, uint32_t mask = GL_COLOR_BUFFER_BIT);
 
 
-enum texture_rendering_flags_t
+enum rendering_flags_t
 {
     /* Invert the texture's X axis when sampling */
     TEXTURE_TRANSFORM_INVERT_X = (1 << 0),
@@ -197,6 +197,17 @@ enum texture_rendering_flags_t
     TEXTURE_TRANSFORM_INVERT_Y = (1 << 1),
     /* Use a subrectangle of the texture to render */
     TEXTURE_USE_TEX_GEOMETRY   = (1 << 2),
+    /*
+     * Enable an optimized, "cached" mode.
+     *
+     * The user first calls a render_texture variant with this bit set.
+     * The default GL program will be called, uniforms uploaded, etc.
+     * After that, draw_cached() may be used for each damaged rectangle.
+     * In the end, clear_cache() is called.
+     *
+     * This allows re-use of uniform values for different damage rectangles.
+     */
+    RENDER_FLAG_CACHED         = (1 << 3),
 };
 
 /**
@@ -253,6 +264,20 @@ void render_texture(wf::texture_t texture,
     const wf::geometry_t& geometry,
     glm::vec4 color = glm::vec4(1.f),
     uint32_t bits   = 0);
+
+/**
+ * Render the textured rectangle again.
+ *
+ * See RENDER_FLAG_CACHED for detailed explanation.
+ */
+void draw_cached();
+
+/**
+ * Clear the cached state.
+ *
+ * See RENDER_FLAG_CACHED for detailed explanation.
+ */
+void clear_cached();
 
 /* Compiles the given shader source */
 GLuint compile_shader(std::string source, GLuint type);

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -30,10 +30,11 @@ const char *gl_error_string(const GLenum err)
     return "UNKNOWN GL ERROR";
 }
 
+static bool disable_gl_call = false;
 void gl_call(const char *func, uint32_t line, const char *glfunc)
 {
     GLenum err;
-    if ((err = glGetError()) == GL_NO_ERROR)
+    if (disable_gl_call || ((err = glGetError()) == GL_NO_ERROR))
     {
         return;
     }
@@ -137,6 +138,9 @@ void render_transformed_texture(wf::texture_t tex,
     const gl_geometry& g, const gl_geometry& texg,
     glm::mat4 model, glm::vec4 color, uint32_t bits)
 {
+    // We don't expect any errors from us!
+    disable_gl_call = true;
+
     program.use(tex.type);
 
     vertexData = {
@@ -193,6 +197,7 @@ void draw_cached()
 
 void clear_cached()
 {
+    disable_gl_call = false;
     program.deactivate();
 }
 

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -557,7 +557,7 @@ class program_t::impl
     int active_program_idx = 0;
 
     int id[wf::TEXTURE_TYPE_ALL];
-    std::map<std::string, int> uniforms[wf::TEXTURE_TYPE_ALL];
+    std::unordered_map<std::string, int> uniforms[wf::TEXTURE_TYPE_ALL];
 
     /** Find the uniform location for the currently bound program */
     int find_uniform_loc(const std::string& name)

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -161,6 +161,11 @@ wf::seat_t::seat_t()
           case WLR_INPUT_DEVICE_KEYBOARD:
             this->keyboards.emplace_back(std::make_unique<wf::keyboard_t>(
                 ev->device->get_wlr_handle()));
+            if (this->current_keyboard == nullptr)
+            {
+                set_keyboard(keyboards.back().get());
+            }
+
             break;
 
           case WLR_INPUT_DEVICE_TOUCH:

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -131,9 +131,13 @@ bool operator &(const wf::geometry_t& rect, const wf::pointf_t& point)
 
 bool operator &(const wf::geometry_t& r1, const wf::geometry_t& r2)
 {
-    wlr_box result;
+    if ((r1.x + r1.width <= r2.x) || (r2.x + r2.width <= r1.x) ||
+        (r1.y + r1.height <= r2.y) || (r2.y + r2.height <= r1.y))
+    {
+        return false;
+    }
 
-    return wlr_box_intersection(&result, &r1, &r2);
+    return true;
 }
 
 wf::geometry_t wf::geometry_intersection(const wf::geometry_t& r1,

--- a/src/view/surface-impl.hpp
+++ b/src/view/surface-impl.hpp
@@ -13,6 +13,7 @@ class surface_interface_t::impl
     surface_interface_t *parent_surface;
     std::vector<std::unique_ptr<surface_interface_t>> surface_children_above;
     std::vector<std::unique_ptr<surface_interface_t>> surface_children_below;
+    size_t last_cnt_surfaces = 0;
 
     /**
      * Remove all subsurfaces and emit signals for them.

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -71,6 +71,7 @@ std::vector<wf::surface_iterator_t> wf::surface_interface_t::enumerate_surfaces(
     wf::point_t surface_origin)
 {
     std::vector<wf::surface_iterator_t> result;
+    result.reserve(priv->last_cnt_surfaces);
     auto add_surfaces_recursive = [&] (surface_interface_t *child)
     {
         if (!child->is_mapped())
@@ -99,6 +100,7 @@ std::vector<wf::surface_iterator_t> wf::surface_interface_t::enumerate_surfaces(
         add_surfaces_recursive(child.get());
     }
 
+    priv->last_cnt_surfaces = result.size();
     return result;
 }
 

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -420,12 +420,15 @@ void wf::wlr_surface_base_t::_simple_render(const wf::framebuffer_t& fb,
     wf::texture_t texture{surface};
 
     OpenGL::render_begin(fb);
+    OpenGL::render_texture(texture, fb, geometry, glm::vec4(1.f),
+        OpenGL::RENDER_FLAG_CACHED);
     for (const auto& rect : damage)
     {
         fb.logic_scissor(wlr_box_from_pixman_box(rect));
-        OpenGL::render_texture(texture, fb, geometry);
+        OpenGL::draw_cached();
     }
 
+    OpenGL::clear_cached();
     OpenGL::render_end();
 }
 

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -39,6 +39,8 @@ class view_interface_t::view_priv_impl
     /** Reference count to the view */
     int ref_cnt = 0;
 
+    size_t last_view_cnt = 0;
+
     bool keyboard_focus_enabled = true;
 
     /**

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -155,6 +155,7 @@ std::vector<wayfire_view> wf::view_interface_t::enumerate_views(
     }
 
     std::vector<wayfire_view> result;
+    result.reserve(view_impl->last_view_cnt);
     for (auto& v : this->children)
     {
         auto cdr = v->enumerate_views(mapped_only);
@@ -162,6 +163,7 @@ std::vector<wayfire_view> wf::view_interface_t::enumerate_views(
     }
 
     result.push_back(self());
+    view_impl->last_view_cnt = result.size();
 
     return result;
 }


### PR DESCRIPTION
- seat: set current keyboard
- opengl: use unordered_map for accessing uniforms
- opengl: add cached drawing support
- opengl: disable gl_call for internal commands
- view: reserve space for enumerate_views() vector
- surface: reserve space for enumerate_surfaces() vector
- util: optimize geometry intersection
- workspace-impl: add a flat view list

More or less fixes #752

My tests however don't show a big improvement in real-life usages. Maybe we're already as fast as we can be :)
