### PR TITLE
Make transforms relative to the WM geometry

### DIFF
--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -102,7 +102,7 @@ class FireTransformer : public wf::view_transformer_t
         p.base_radius = p.radius = random(size * 0.8, size * 1.2);
     }
 
-    void render_box(wf::texture_t src_tex, wlr_box src_box,
+    void render_box(wf::texture_t src_tex, wlr_box src_box, wlr_box wm_geom,
         wlr_box scissor_box, const wf::framebuffer_t& target_fb) override
     {
         OpenGL::render_begin(target_fb);

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -67,7 +67,7 @@ class wf_blur_transformer : public wf::view_transformer_t
         OpenGL::render_end();
     }
 
-    void render_with_damage(wf::texture_t src_tex, wlr_box src_box,
+    void render_with_damage(wf::texture_t src_tex, wlr_box src_box, wlr_box wm_geom,
         const wf::region_t& damage, const wf::framebuffer_t& target_fb) override
     {
         wf::region_t clip_damage = damage & src_box;
@@ -99,15 +99,15 @@ class wf_blur_transformer : public wf::view_transformer_t
         wf::region_t blurred_region = clip_damage ^ opaque_region;
 
         provider()->pre_render(src_tex, src_box, blurred_region, target_fb);
-        wf::view_transformer_t::render_with_damage(src_tex, src_box, blurred_region,
-            target_fb);
+        wf::view_transformer_t::render_with_damage(src_tex, src_box, wm_geom,
+            blurred_region, target_fb);
 
         /* Opaque non-blurred regions can be rendered directly without blending */
         direct_render(src_tex, src_box, opaque_region & clip_damage, target_fb);
     }
 
-    void render_box(wf::texture_t src_tex, wlr_box src_box, wlr_box scissor_box,
-        const wf::framebuffer_t& target_fb) override
+    void render_box(wf::texture_t src_tex, wlr_box src_box, wlr_box wm_geom,
+        wlr_box scissor_box, const wf::framebuffer_t& target_fb) override
     {
         provider()->render(src_tex, src_box, scissor_box, target_fb);
     }

--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -198,18 +198,18 @@ class scale_around_grab_t : public wf::view_transformer_t
     wf::geometry_t get_bounding_box(wf::geometry_t view,
         wf::geometry_t region) override
     {
-        int w = std::floor(view.width / scale_factor);
-        int h = std::floor(view.height / scale_factor);
+        int w = std::floor(region.width / scale_factor);
+        int h = std::floor(region.height / scale_factor);
 
         auto bb = find_geometry_around({w, h}, grab_position, relative_grab);
         return bb;
     }
 
-    void render_with_damage(wf::texture_t src_tex, wlr_box src_box,
+    void render_with_damage(wf::texture_t src_tex, wlr_box src_box, wlr_box wm_geom,
         const wf::region_t& damage, const wf::framebuffer_t& target_fb) override
     {
         // Get target size
-        auto bbox = get_bounding_box(src_box, src_box);
+        auto bbox = get_bounding_box(wm_geom, src_box);
 
         OpenGL::render_begin(target_fb);
         for (auto& rect : damage)

--- a/plugins/scale/scale-title-overlay.cpp
+++ b/plugins/scale/scale-title-overlay.cpp
@@ -99,8 +99,7 @@ class view_title_overlay_t : public wf::scale_transformer_t::overlay_t
      */
     wlr_box get_transformed_wm_geometry(wf::scale_transformer_t& tr)
     {
-        wlr_box box = tr.get_transformed_view()->get_wm_geometry();
-        return tr.trasform_box_without_padding(box);
+        return tr.transform_wm_geom_without_padding();
     }
 
     wlr_box get_transformed_wm_geometry()

--- a/plugins/scale/wayfire/plugins/scale-transform.hpp
+++ b/plugins/scale/wayfire/plugins/scale-transform.hpp
@@ -108,11 +108,12 @@ class scale_transformer_t : public wf::view_2D
     };
 
     /* render the transformed view and then add all overlays */
-    void render_with_damage(wf::texture_t src_tex, wlr_box src_box,
+    void render_with_damage(wf::texture_t src_tex, wlr_box src_box, wlr_box wm_geom,
         const wf::region_t& damage, const wf::framebuffer_t& target_fb) override
     {
         /* render the transformed view first */
-        view_transformer_t::render_with_damage(src_tex, src_box, damage, target_fb);
+        view_transformer_t::render_with_damage(src_tex, src_box, wm_geom, damage,
+            target_fb);
 
         /* call all overlays */
         for (auto& p : overlays)
@@ -199,10 +200,11 @@ class scale_transformer_t : public wf::view_2D
      * Transform the view's bounding box, including the current transform, but not
      * the padding.
      */
-    wlr_box transform_bounding_box_without_padding()
+    wlr_box transform_wm_geom_without_padding()
     {
-        auto box = view->get_bounding_box(this);
-        return view_transformer_t::get_bounding_box(box, box);
+        auto wm_geom = view->get_wm_geometry();
+        wm_geom = view->transform_region(wm_geom, this);
+        return view_transformer_t::get_bounding_box(wm_geom, wm_geom);
     }
 
     /**

--- a/plugins/single_plugins/grid.cpp
+++ b/plugins/single_plugins/grid.cpp
@@ -58,16 +58,16 @@ class grid_crossfade_transformer : public wf::view_2D
     }
 
     void render_box(wf::texture_t src_tex, wlr_box src_box,
-        wlr_box scissor_box, const wf::framebuffer_t& fb) override
+        wlr_box scissor_box, wlr_box wm_geom, const wf::framebuffer_t& fb) override
     {
         // See the current target geometry
-        auto bbox = view->get_wm_geometry();
+        auto bbox = wm_geom;
         bbox = this->get_bounding_box(bbox, bbox);
 
         double saved = this->alpha;
         this->alpha = 1.0;
         // Now render the real view
-        view_2D::render_box(src_tex, src_box, scissor_box, fb);
+        view_2D::render_box(src_tex, src_box, wm_geom, scissor_box, fb);
         this->alpha = saved;
 
         double ra;

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -695,7 +695,7 @@ class wf_wobbly : public wf::view_transformer_t
         }
     }
 
-    void render_box(wf::texture_t src_tex, wlr_box src_box,
+    void render_box(wf::texture_t src_tex, wlr_box src_box, wlr_box wm_geom,
         wlr_box scissor_box, const wf::framebuffer_t& target_fb) override
     {
         OpenGL::render_begin(target_fb);

--- a/src/api/wayfire/view-transform.hpp
+++ b/src/api/wayfire/view-transform.hpp
@@ -37,7 +37,8 @@ class view_transformer_t
      * It must be guaranteed that the pixels part of the returned region are
      * opaque. The default implementation simply returns an empty region.
      *
-     * @param box The bounding box of the view up to this transformer.
+     * @param box The bounding box of the WM geometry of the view up to this
+     *   transformer.
      * @param region The opaque region to transform.
      *
      * @return The transformed opaque region.
@@ -48,8 +49,8 @@ class view_transformer_t
     /**
      * Transform a single point.
      *
-     * @param view The bounding box of the view, in output-local
-     *   coordinates.
+     * @param view The bounding box of the WM geometry of the view up to this
+     *   transformer, in output-local coordinates.
      * @param point The point to transform, in output-local coordinates.
      *
      * @return The point after transforming it, in output-local coordinates.
@@ -60,8 +61,8 @@ class view_transformer_t
     /**
      * Reverse the transformation of the point.
      *
-     * @param view The bounding box of the view, in output-local
-     *   coordinates.
+     * @param view The bounding box of the WM geometry of the view up to this
+     *   transformer, in output-local coordinates.
      * @param point The point to untransform, in output-local coordinates.
      *
      * @return The point before after transforming it, in output-local
@@ -74,8 +75,8 @@ class view_transformer_t
     /**
      * Compute the bounding box of the given region after transforming it.
      *
-     * @param view The bounding box of the view, in output-local
-     *   coordinates.
+     * @param view The bounding box of the WM geometry of the view up to this
+     *   transformer, in output-local coordinates.
      * @param region The region whose bounding box should be computed, in
      *   output-local coordinates.
      *
@@ -89,6 +90,8 @@ class view_transformer_t
      *
      * @param src_tex The texture of the view.
      * @param src_box The bounding box of the view in output-local coordinates.
+     * @param wm_geom The bounding box of the WM geometry of the view up to this
+     *   transformer, in output-local coordinates.
      * @param damage The region to repaint, clipped to the view's bounds.
      *   It is in output-local coordinates.
      * @param target_fb The framebuffer to draw the view to. It's geometry
@@ -100,11 +103,12 @@ class view_transformer_t
      * either of the functions.
      */
     virtual void render_with_damage(wf::texture_t src_tex, wlr_box src_box,
-        const wf::region_t& damage, const wf::framebuffer_t& target_fb);
+        wlr_box wm_geom, const wf::region_t& damage,
+        const wf::framebuffer_t& target_fb);
 
     /** Same as render_with_damage(), but for a single rectangle of damage */
     virtual void render_box(wf::texture_t src_tex, wlr_box src_box,
-        wlr_box scissor_box, const wf::framebuffer_t& target_fb)
+        wlr_box wm_geom, wlr_box scissor_box, const wf::framebuffer_t& target_fb)
     {}
 
     virtual ~view_transformer_t()
@@ -137,10 +141,12 @@ class view_2D : public view_transformer_t
     wf::pointf_t untransform_point(
         wf::geometry_t view, wf::pointf_t point) override;
     void render_box(wf::texture_t src_tex, wlr_box src_box,
-        wlr_box scissor_box, const wf::framebuffer_t& target_fb) override;
+        wlr_box wm_geom, wlr_box scissor_box,
+        const wf::framebuffer_t& target_fb) override;
 };
 
-/* Those are centered relative to the view's bounding box */
+/* Those are centered relative to the view's WM geometry (i.e. the view's main
+ * surface). */
 class view_3D : public view_transformer_t
 {
   protected:
@@ -165,7 +171,8 @@ class view_3D : public view_transformer_t
     wf::pointf_t untransform_point(
         wf::geometry_t view, wf::pointf_t point) override;
     void render_box(wf::texture_t src_tex, wlr_box src_box,
-        wlr_box scissor_box, const wf::framebuffer_t& target_fb) override;
+        wlr_box wm_geom, wlr_box scissor_box,
+        const wf::framebuffer_t& target_fb) override;
 
     static const float fov; // PI / 8
     static glm::mat4 default_view_matrix();


### PR DESCRIPTION
Depends on #1050 

Transforms receive the view's bounding box to be able to work in a local coordinate system. In my opinion, this is not ideal, since the bounding box will change in "unimportant" ways, e.g. if a tooltip is added that goes outside of the main surface's bounds.

The view_2D transform works this around by using the WM geometry instead, but this only works if it is the first transformer (which is not the case e.g. for scale).

This PR changes the logic so that transforms always receive the (partially transformed) WM geometry to work with. Also, this makes the view_2D transformer use the passed in geometry.

This fixes my issue with 3D rotation and interactive scale.

Note: without the change to use WM geometry everywhere, changing view_2D to use the passed-in geometry resulted in weird artifacts.

Possible alternatives:
 - Pass both the partially transformed WM geometry and the full bounding box (so that a transformer always knows the full bounds -- currently, the bounding box is only passed to the rendering function).
 - Pass the partially transformed coordinates of the view's center (this is what transformers seem to care about anyway).
 - Change the interface so that transformers always work in a coordinate system where the view's center is in the origin; transform all coordinates to this in view.cpp, transformers don't need to receive any extra geometry parameter.
