### PR TITLE
Scale: ensure transformed views fit in their slot

### DIFF
--- a/plugins/animate/basic_animations.hpp
+++ b/plugins/animate/basic_animations.hpp
@@ -28,7 +28,8 @@ class fade_animation : public animation_base
         }
 
         name = "animation-fade-" + std::to_string(type);
-        view->add_transformer(std::make_unique<wf::view_2D>(view), name);
+        view->add_transformer(
+            std::make_unique<wf::view_2D>(view, wf::TRANSFORMER_HIGHLEVEL), name);
     }
 
     bool step() override
@@ -114,7 +115,7 @@ class zoom_animation : public animation_base
         }
 
         name = "animation-zoom-" + std::to_string(type);
-        our_transform = new wf::view_2D(view);
+        our_transform = new wf::view_2D(view, wf::TRANSFORMER_HIGHLEVEL);
         view->add_transformer(std::unique_ptr<wf::view_2D>(our_transform), name);
     }
 

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'14;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'24;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/view-transform.hpp
+++ b/src/api/wayfire/view-transform.hpp
@@ -117,6 +117,7 @@ class view_2D : public view_transformer_t
 {
   protected:
     wayfire_view view;
+    const uint32_t z_order;
 
   public:
     float angle = 0.0f;
@@ -125,11 +126,11 @@ class view_2D : public view_transformer_t
     float alpha = 1.0f;
 
   public:
-    view_2D(wayfire_view view);
+    view_2D(wayfire_view view, uint32_t z_order_ = TRANSFORMER_2D);
 
     virtual uint32_t get_z_order() override
     {
-        return TRANSFORMER_2D;
+        return z_order;
     }
 
     wf::pointf_t transform_point(
@@ -145,6 +146,7 @@ class view_3D : public view_transformer_t
 {
   protected:
     wayfire_view view;
+    const uint32_t z_order;
 
   public:
     glm::mat4 view_proj{1.0}, translation{1.0}, rotation{1.0}, scaling{1.0};
@@ -153,11 +155,11 @@ class view_3D : public view_transformer_t
     glm::mat4 calculate_total_transform();
 
   public:
-    view_3D(wayfire_view view);
+    view_3D(wayfire_view view, uint32_t z_order_ = TRANSFORMER_3D);
 
     virtual uint32_t get_z_order() override
     {
-        return TRANSFORMER_3D;
+        return z_order;
     }
 
     wf::pointf_t transform_point(

--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -99,7 +99,7 @@ static transformable_quad center_geometry(wf::geometry_t output_geometry,
     return quad;
 }
 
-wf::view_2D::view_2D(wayfire_view view)
+wf::view_2D::view_2D(wayfire_view view, uint32_t z_order_) : z_order(z_order_)
 {
     this->view = view;
 }
@@ -189,7 +189,7 @@ glm::mat4 wf::view_3D::default_proj_matrix()
     return glm::perspective(fov, 1.0f, .1f, 100.f);
 }
 
-wf::view_3D::view_3D(wayfire_view view)
+wf::view_3D::view_3D(wayfire_view view, uint32_t z_order_) : z_order(z_order_)
 {
     this->view = view;
     view_proj  = default_proj_matrix() * default_view_matrix();


### PR DESCRIPTION
Fixes #1046 

Depends on #1050 and ~~#1051~~ #1056 -- otherwise the results can look strange.

Note: this is not a perfect solution, since the bounding box of the view's WM geometry can grow excessively with multiple transforms (e.g. two 45 degree rotations will result in the bounding box growing twice as wide). A better way could be to transform each of the corner points (but that only works for transforms that preserve straight lines -- so far all transforms do that).
