### PR TITLE
multi-output fixes

### DIFF
--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -339,6 +339,10 @@ void wf::wlr_view_t::unmap()
 
     destroy_toplevel();
 
+    // Unset decoration when unmapping, since the policy is to always remove
+    // all subsurfaces when a view is unmapped.
+    set_decoration(nullptr);
+
     wlr_surface_base_t::unmap();
     emit_view_unmap();
 }


### PR DESCRIPTION
- view: reset decoration on unmap
- preserve-output: store the output's workspace too
- output-layout: fix shutdown handling
- preserve-output: fix reference counting by using shared_data helpers
