### PR TITLE
api: add support for dynamically changing the number of workspaces

### DIFF
--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -152,18 +152,6 @@ class wayfire_cube : public wf::plugin_interface_t
             deactivate();
         };
 
-        auto wsize = output->workspace->get_workspace_grid_size();
-        animation.side_angle = 2 * M_PI / float(wsize.width);
-        identity_z_offset    = 0.5 / std::tan(animation.side_angle / 2);
-        if (wsize.width == 1)
-        {
-            // tan(M_PI) is 0, so identity_z_offset is invalid
-            identity_z_offset = 0.0f;
-        }
-
-        animation.cube_animation.offset_z.set(identity_z_offset + Z_OFFSET_NEAR,
-            identity_z_offset + Z_OFFSET_NEAR);
-
         renderer = [=] (const wf::framebuffer_t& dest) {render(dest);};
 
         OpenGL::render_begin(output->render->get_target_framebuffer());
@@ -275,6 +263,18 @@ class wayfire_cube : public wf::plugin_interface_t
         output->render->schedule_redraw();
         wf::get_core().hide_cursor();
         grab_interface->grab();
+
+        auto wsize = output->workspace->get_workspace_grid_size();
+        animation.side_angle = 2 * M_PI / float(wsize.width);
+        identity_z_offset    = 0.5 / std::tan(animation.side_angle / 2);
+        if (wsize.width == 1)
+        {
+            // tan(M_PI) is 0, so identity_z_offset is invalid
+            identity_z_offset = 0.0f;
+        }
+
+        animation.cube_animation.offset_z.set(identity_z_offset + Z_OFFSET_NEAR,
+            identity_z_offset + Z_OFFSET_NEAR);
 
         return true;
     }

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'24;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'30;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -297,6 +297,20 @@ struct workspace_change_request_signal : public workspace_changed_signal
 };
 
 /**
+ * name: workspace-grid-changed
+ * on: output
+ * when: Whenever the workspace grid size changes.
+ */
+struct workspace_grid_changed_signal : public wf::signal_data_t
+{
+    /** The grid size before the change. */
+    wf::dimensions_t old_grid_size;
+
+    /** The grid size after the change. */
+    wf::dimensions_t new_grid_size;
+};
+
+/**
  * name: workarea-changed
  * on: output
  * when: Whenever the available workarea changes.

--- a/src/api/wayfire/workspace-manager.hpp
+++ b/src/api/wayfire/workspace-manager.hpp
@@ -113,14 +113,23 @@ class workspace_manager
   public:
     /**
      * Calculate a list of workspaces the view is visible on.
+     *
      * @param threshold How much of the view's area needs to overlap a workspace to
-     * be counted as visible on it.
-     *    1.0 for 100% visible, 0.1 for 10%.
+     *   be counted as visible on it. 1.0 for 100% visible, 0.1 for 10%.
      *
      * @return a vector of all the workspaces
      */
     std::vector<wf::point_t> get_view_workspaces(wayfire_view view,
         double threshold);
+
+    /**
+     * Get the main workspace for a view.
+     * The main workspace is the one which contains the view's center.
+     *
+     * If the center is on an invalid workspace, the closest workspace will
+     * be returned.
+     */
+    wf::point_t get_view_main_workspace(wayfire_view view);
 
     /**
      * Check if the given view is visible on the given workspace
@@ -319,6 +328,14 @@ class workspace_manager
      * @return The number of workspace columns and rows
      */
     wf::dimensions_t get_workspace_grid_size();
+
+    /**
+     * Set the workspace grid size for this output.
+     *
+     * Once a plugin calls this, the number of workspaces will no longer be
+     * updated according to the config file.
+     */
+    void set_workspace_grid_size(wf::dimensions_t grid_size);
 
     /**
      * @return Whether the given workspace is valid


### PR DESCRIPTION
This PR adds support for changing the number of workspaces on-the-fly. The user can now simply edit `wayfire.ini` and set `vwidth/vheight`, and the changes will be applied immediately. If the change reduces the number of workspaces, core will make sure that the views on the now-removed workspaces are moved to the remaining workspaces.

For people wishing to write their own plugins, this PR also adds support for changing the number of workspaces from a plugin on a per-output basis. A proof-of-concept can be found here: https://github.com/ammen99/wayfire-plugins/blob/dyn-ws/src/dynamic-workspace-switch.cpp
This is a new plugin which works the following way: initially, Wayfire has only one workspace 1x1 (hardcoded in the plugin). The plugin also provides hardcoded bindings `<super>KEY_J` and `<super>KEY_K` to move up and down in the workspaces list (vertical-only for this plugin). If you go down after the last workspace, a new workspace will be created there. If you go up from the last workspace, it will be erased if it is empty.

Fixes #89 
