### PR TITLE
util: make sure to disconnect if timer is not repeated

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -633,6 +633,9 @@ void wl_timer::execute()
         if (repeat)
         {
             wl_event_source_timer_update(source, this->timeout);
+        } else
+        {
+            disconnect();
         }
     }
 }


### PR DESCRIPTION
When a timer is fired but not repeated, we should destroy the event source, and make sure `is_connected` returns false.
