### PR TITLE
build: make stacktrace configureable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -146,6 +146,12 @@ else
   conf_data.set('WF_HAS_XWAYLAND', 0)
 endif
 
+if get_option('print_trace')
+  print_trace = true
+else
+  print_trace = false
+endif
+
 add_project_arguments(['-DWF_USE_CONFIG_H'], language: ['cpp', 'c'])
 configure_file(input: 'config.h.in',
                output: 'config.h',
@@ -169,6 +175,7 @@ summary = [
     '    x11-backend: @0@'.format(have_x11_backend),
     '        imageio: @0@'.format(conf_data.get('BUILD_WITH_IMAGEIO')),
     '         gles32: @0@'.format(conf_data.get('USE_GLES32')),
+    '    print trace: @0@'.format(print_trace),
     '----------------',
     ''
 ]

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,3 +3,4 @@ option('use_system_wfconfig', type: 'feature', value: 'auto', description: 'Use 
 option('use_system_wlroots', type: 'feature', value: 'auto', description: 'Use the system-wide installation of wlroots')
 option('xwayland', type: 'feature', value: 'auto', description: 'Build with xwayland support. Requires wlroots also built with xwayland support')
 option('default_config_backend', type: 'string', value: 'default', description: 'Default configuration backend to use')
+option('print_trace', type: 'boolean', value: true, description: 'Print stack trace in debug logs (disables coredump)')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ static void wlr_log_handler(wlr_log_importance level,
     wf::log::log_plain(wlevel, buffer);
 }
 
-#ifndef ASAN_ENABLED
+#ifndef ASAN_ENABLED || COREDUMP_ENABLED
 static void signal_handler(int signal)
 {
     std::string error;
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
     wlr_log_init(wlr_log_level, wlr_log_handler);
     wf::log::initialize_logging(std::cout, log_level, detect_color_mode());
 
-#ifndef ASAN_ENABLED
+#ifndef ASAN_ENABLED || COREDUMP_ENABLED
     /* In case of crash, print the stacktrace for debugging.
      * However, if ASAN is enabled, we'll get better stacktrace from there. */
     signal(SIGSEGV, signal_handler);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ static void wlr_log_handler(wlr_log_importance level,
     wf::log::log_plain(wlevel, buffer);
 }
 
-#ifndef ASAN_ENABLED || COREDUMP_ENABLED
+#ifdef PRINT_TRACE
 static void signal_handler(int signal)
 {
     std::string error;
@@ -238,7 +238,7 @@ int main(int argc, char *argv[])
     wlr_log_init(wlr_log_level, wlr_log_handler);
     wf::log::initialize_logging(std::cout, log_level, detect_color_mode());
 
-#ifndef ASAN_ENABLED || COREDUMP_ENABLED
+#ifdef PRINT_TRACE
     /* In case of crash, print the stacktrace for debugging.
      * However, if ASAN is enabled, we'll get better stacktrace from there. */
     signal(SIGSEGV, signal_handler);

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,6 +52,10 @@ endif
 
 debug_arguments = []
 
+if not get_option('print_trace')
+   debug_arguments += ['-DCOREDUMP_ENABLED']
+endif
+
 addr2line = find_program('addr2line', required: false)
 if addr2line.found()
   debug_arguments += ['-DHAS_ADDR2LINE=1']

--- a/src/meson.build
+++ b/src/meson.build
@@ -52,10 +52,6 @@ endif
 
 debug_arguments = []
 
-if not get_option('print_trace')
-   debug_arguments += ['-DCOREDUMP_ENABLED']
-endif
-
 addr2line = find_program('addr2line', required: false)
 if addr2line.found()
   debug_arguments += ['-DHAS_ADDR2LINE=1']
@@ -66,8 +62,13 @@ endif
 
 cxx_flags_asan = run_command('/bin/sh', '-c', 'echo $CXXFLAGS $CPPFLAGS | grep fsanitize')
 if get_option('b_sanitize').contains('address') or cxx_flags_asan.returncode() == 0
+  print_trace = false
   message('Address sanitizer enabled, disabling internal backtrace')
-  debug_arguments += ['-DASAN_ENABLED']
+  message('Overriding print_trace build option!')
+endif
+
+if get_option('print_trace')
+  debug_arguments += ['-DPRINT_TRACE']
 endif
 
 executable('wayfire', wayfire_sources,


### PR DESCRIPTION
This should help users that want coredump generation to work correctly.

Systemd-coredump should work when this option is disabled, but I haven't
tested systemd-coredump specifically.