### PR TITLE
wayfire_xdg_popup: calculate position during initialization

### DIFF
--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -65,6 +65,8 @@ void wayfire_xdg_popup::initialize()
         &this->parent_app_id_changed);
     popup_parent->connect_signal("title-changed",
         &this->parent_title_changed);
+
+    unconstrain();
 }
 
 void wayfire_xdg_popup::map(wlr_surface *surface)
@@ -82,7 +84,6 @@ void wayfire_xdg_popup::map(wlr_surface *surface)
 
     wlr_view_t::map(surface);
     update_position();
-    unconstrain();
 }
 
 void wayfire_xdg_popup::commit()


### PR DESCRIPTION
Fixes #1125 

It seems that for xdg_popups, wlroots will immediately send a configure event in response to a commit request (see [here](https://github.com/swaywm/wlroots/blob/c740fccc9dd0913908c0632c10f8c6d10b2b1ca4/types/xdg_shell/wlr_xdg_surface.c#L372) and [here](https://github.com/swaywm/wlroots/blob/c740fccc9dd0913908c0632c10f8c6d10b2b1ca4/types/xdg_shell/wlr_xdg_positioner.c#L154)), so there is no chance to update the position then (the configure event might be sent with the wrong position).

This can be avoided by adjusting the position while creating the popup. This is what [sway is doing](https://github.com/swaywm/sway/blob/152a559e30244e64d4d61b9c87db442dfa04ee52/sway/desktop/xdg_shell.c#L107) if I understand correctly. Since the client is required to supply the requested size in the xdg_positioner object when creating the popup, this should be OK to do.

