### PR TITLE
default-config-backend: read exactly one inotify event at a time

### DIFF
--- a/src/default-config-backend.cpp
+++ b/src/default-config-backend.cpp
@@ -1,3 +1,4 @@
+#include <string.h>
 #include <vector>
 #include "wayfire/debug.hpp"
 #include <string>
@@ -26,6 +27,48 @@ static void reload_config(int fd)
     readd_watch(fd);
 }
 
+/**
+ * Read exactly @amount bytes from @fd into @buffer.
+ * @buffer must be big enough.
+ */
+static bool read_exact(int fd, char *buffer, size_t amount)
+{
+    while (amount > 0)
+    {
+        ssize_t chunk = read(fd, buffer, amount);
+        if (chunk < 0)
+        {
+            return false;
+        }
+
+        amount -= chunk;
+        buffer += chunk;
+    }
+
+    return true;
+}
+
+/**
+ * Read a SINGLE inotify event from @fd into @buffer.
+ * @buffer must be big enough for the event.
+ *
+ * @return True if the event was read successfully
+ */
+static bool read_event(int fd, char *buffer)
+{
+    // First, read base event
+    if (read_exact(fd, buffer, sizeof(inotify_event)))
+    {
+        auto ev = reinterpret_cast<inotify_event*>(buffer);
+
+        // Read remaining bytes from the file name
+        return read_exact(fd, buffer + sizeof(inotify_event), ev->len);
+    }
+
+    return false;
+}
+
+static wl_event_source *wl_source;
 static int handle_config_updated(int fd, uint32_t mask, void *data)
 {
     if ((mask & WL_EVENT_READABLE) == 0)
@@ -34,37 +77,26 @@ static int handle_config_updated(int fd, uint32_t mask, void *data)
     }
 
     LOGD("Reloading configuration file");
-
     char buf[INOT_BUF_SIZE] __attribute__((aligned(alignof(inotify_event))));
 
     bool should_reload = false;
-    inotify_event *event;
-
-    while (true)
+    if (read_event(fd, buf))
     {
-        auto len = read(fd, buf, INOT_BUF_SIZE);
-        if (len < 0)
+        auto event = reinterpret_cast<inotify_event*>(buf);
+        if (event->len == 0)
         {
-            break;
-        }
-
-        for (char *ptr = buf; ptr < (buf + len);
-             ptr += sizeof(inotify_event) + event->len)
+            // is file, probably the config file itself
+            should_reload = true;
+        } else if (!strncmp(config_file.c_str(), event->name, event->len))
         {
-            event = reinterpret_cast<inotify_event*>(ptr);
-
-            if (event->len == 0)
-            {
-                // is file, probably the config file itself
-                should_reload = true;
-                continue;
-            }
-
-            if (config_file == event->name)
-            {
-                should_reload = true;
-            }
+            should_reload = true;
         }
+    } else
+    {
+        LOGE("Error reading from inotify, stopping dynamic reload!");
+        wl_event_source_remove(wl_source);
+        close(fd);
+        return 0;
     }
 
     if (should_reload)
@@ -101,7 +133,7 @@ class dynamic_ini_config_t : public wf::config_backend_t
         int inotify_fd = inotify_init1(IN_CLOEXEC);
         reload_config(inotify_fd);
 
-        wl_event_loop_add_fd(wl_display_get_event_loop(display),
+        wl_source = wl_event_loop_add_fd(wl_display_get_event_loop(display),
             inotify_fd, WL_EVENT_READABLE, handle_config_updated, NULL);
     }
 


### PR DESCRIPTION
Second attempt at fixing #1107
