### PR TITLE
readme: update install instructions on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ dnf install wayfire
 ```
 
 ###### FreeBSD
-
+Install the latest release and recommended addons with
 ``` sh
-pkg install wayfire
+pkg install wayfire wayfire-plugins-extra wf-shell wcm
 ```
 
 ###### Gentoo


### PR DESCRIPTION
For new users `pkg install wayfire` is not enough as `wayfire` unless configured would just show blank/black screen. Expand the command line to include recommended addons in order to have something usable out of the box.

I'll package if something is recommended but missing.
