### PR TITLE
core API: Add get_snapshot

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2020'01'30;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2021'04'15;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -440,6 +440,11 @@ class view_interface_t : public surface_interface_t
     virtual void take_snapshot();
 
     /**
+     * Get current snapshot framebuffer taken by take_snapshot().
+     */
+    const wf::framebuffer_t& get_snapshot();
+
+    /**
      * View lifetime is managed by reference counting. To take a reference,
      * use take_ref(). Note that one reference is automatically made when the
      * view is created.

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1239,6 +1239,11 @@ void wf::view_interface_t::take_snapshot()
     offscreen_buffer.cached_damage.clear();
 }
 
+const wf::framebuffer_t& wf::view_interface_t::get_snapshot()
+{
+    return view_impl->offscreen_buffer;
+}
+
 wf::view_interface_t::view_interface_t()
 {
     this->view_impl = std::make_unique<wf::view_interface_t::view_priv_impl>();


### PR DESCRIPTION
Allow plugins to get the framebuffer containing the snapshot of the view.