### PR TITLE
Expo: add keyboard interaction

### DIFF
--- a/metadata/expo.xml
+++ b/metadata/expo.xml
@@ -29,6 +29,19 @@
 			<_long>Allow the use of arrow keys to select a workspace, ESC to cancel and ENTER to accept.</_long>
 			<default>true</default>
 		</option>
+		<option name="inactive_brightness" type="double">
+			<_short>Brightness of inactive workspaces</_short>
+			<_long>Decrease the brightness of all workspaces except the currently selected one to this value.</_long>
+			<default>0.7</default>
+			<min>0.0</min>
+			<max>1.0</max>
+			<precision>0.01</precision>
+		</option>
+		<option name="transition_len" type="int">
+			<_short>Brightness transition duration</_short>
+			<_long>Duration of the transition of brightness when a new workspace is selected in milliseconds.</_long>
+			<default>200</default>
+		</option>
 		<option name="workspace_bindings" type="dynamic-list">
 			<_short>Select workspace</_short>
 			<_long>When the binding is triggered while expo is active, the corresponding workspace will be focused and Expo will exit.</_long>

--- a/metadata/expo.xml
+++ b/metadata/expo.xml
@@ -24,6 +24,11 @@
 			<_long>Sets the delimiter offset (in pixels) between workspaces.</_long>
 			<default>10</default>
 		</option>
+		<option name="keyboard_interaction" type="bool">
+			<_short>Keyboard interaction</_short>
+			<_long>Allow the use of arrow keys to select a workspace, ESC to cancel and ENTER to accept.</_long>
+			<default>true</default>
+		</option>
 		<option name="workspace_bindings" type="dynamic-list">
 			<_short>Select workspace</_short>
 			<_long>When the binding is triggered while expo is active, the corresponding workspace will be focused and Expo will exit.</_long>

--- a/metadata/expo.xml
+++ b/metadata/expo.xml
@@ -37,7 +37,7 @@
 			<max>1.0</max>
 			<precision>0.01</precision>
 		</option>
-		<option name="transition_len" type="int">
+		<option name="transition_length" type="int">
 			<_short>Brightness transition duration</_short>
 			<_long>Duration of the transition of brightness when a new workspace is selected in milliseconds.</_long>
 			<default>200</default>

--- a/plugins/common/wayfire/plugins/common/key-repeat.hpp
+++ b/plugins/common/wayfire/plugins/common/key-repeat.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <wayfire/option-wrapper.hpp>
+#include <wayfire/util.hpp>
+
+namespace wf
+{
+struct key_repeat_t
+{
+    wf::option_wrapper_t<int> delay{"input/kb_repeat_delay"};
+    wf::option_wrapper_t<int> rate{"input/kb_repeat_rate"};
+
+    wf::wl_timer timer_delay;
+    wf::wl_timer timer_rate;
+
+    using callback_t = std::function<bool (uint32_t)>;
+
+    key_repeat_t()
+    {}
+    key_repeat_t(uint32_t key, callback_t handler)
+    {
+        set_callback(key, handler);
+    }
+
+    void set_callback(uint32_t key, callback_t handler)
+    {
+        disconnect();
+        timer_delay.set_timeout(delay, [=] ()
+        {
+            timer_rate.set_timeout(1000 / rate, [=] ()
+            {
+                // handle can determine if key should be repeated
+                return handler(key);
+            });
+
+            return false; // no more repeat
+        });
+    }
+
+    void disconnect()
+    {
+        timer_delay.disconnect();
+        timer_rate.disconnect();
+    }
+};
+}

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -541,7 +541,6 @@ class wayfire_expo : public wf::plugin_interface_t
 
         shade_workspace(x, y, true);
         shade_workspace(target_vx, target_vy, false);
-        // output->render->schedule_redraw();
     }
 
     /**
@@ -696,8 +695,6 @@ class wayfire_expo : public wf::plugin_interface_t
             target_vy = tmpy;
             shade_workspace(target_vx, target_vy, false);
         }
-
-        // output->render->schedule_redraw();
     }
 
     wf::signal_connection_t on_frame = {[=] (wf::signal_data_t*)
@@ -752,6 +749,18 @@ class wayfire_expo : public wf::plugin_interface_t
     wf::signal_connection_t on_workspace_grid_changed = [=] (auto)
     {
         resize_ws_fade();
+
+        // check that the target and initial workspaces are still in the grid
+        auto size = this->output->workspace->get_workspace_grid_size();
+        initial_vx = std::min(initial_vx, size.width - 1);
+        initial_vy = std::min(initial_vy, size.height - 1);
+
+        if ((target_vx >= size.width) || (target_vy >= size.height))
+        {
+            target_vx = std::min(target_vx, size.width - 1);
+            target_vy = std::min(target_vy, size.height - 1);
+            highlight_active_workspace();
+        }
     };
 
     void finalize_and_exit()


### PR DESCRIPTION
Fixes #1142

Arrows keys can be used to select a target workspace, enter to change, esc to cancel.

Also added shading to unselected workspaces.

TODO:

- [x] Make this optional (add a bool option)
- [x] Option for the shading of unselected workspaces instead of fixed value of 70%
- [x] Animation when the selected workspace changes
- [x] Handle key repeat (when a key is held down)
- [ ] Make keys configurable? Postponed for later
- [x] Decide what should happen if multiple keys are pressed / keys are pressed while dragging a view? Only the last pressed key is used, keys are disabled while dragging a view.
- [x] Test for regressions in other places where `workspace-wall` is used
- [x] Test the case when the grid size changes while expo is running

