### PR TITLE
Prevent multiple events being fired by hotspot area

### DIFF
--- a/src/core/seat/hotspot-manager.cpp
+++ b/src/core/seat/hotspot-manager.cpp
@@ -5,11 +5,13 @@ void wf::hotspot_instance_t::process_input_motion(wf::point_t gc)
     if (!(hotspot_geometry[0] & gc) && !(hotspot_geometry[1] & gc))
     {
         timer.disconnect();
+        this->armed = true;
         return;
     }
 
-    if (!timer.is_connected())
+    if (!timer.is_connected() && this->armed)
     {
+        this->armed = false;
         timer.set_timeout(timeout_ms, [=] ()
         {
             callback(this->edges);

--- a/src/core/seat/hotspot-manager.hpp
+++ b/src/core/seat/hotspot-manager.hpp
@@ -49,6 +49,12 @@ class hotspot_instance_t : public noncopyable_t
     /** Timer for hotspot activation */
     wf::wl_timer timer;
 
+    /**
+     * Only one event should be triggered once the cursor enters the hotspot area.
+     * This prevents another event being fired until the cursor has left the area.
+     */
+    bool armed = true;
+
     /** Timeout to activate hotspot */
     uint32_t timeout_ms;
 


### PR DESCRIPTION
Fixes #1141 

Using a boolean flag to determine whether or not an event has already been fired by the cursor entering the hotspot area. Cursor must leave the area before another event can be fired.

