### PR TITLE
Focus the main dragged view when a drag ends

### DIFF
--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -660,6 +660,9 @@ inline void adjust_view_on_output(drag_done_signal *ev)
     target_ws.x = wf::clamp(target_ws.x, 0, gsize.width - 1);
     target_ws.y = wf::clamp(target_ws.y, 0, gsize.height - 1);
 
+    // view to focus at the end of drag
+    auto focus_view = ev->main_view;
+
     for (auto& v : ev->all_views)
     {
         if (!v.view->is_mapped())
@@ -684,6 +687,12 @@ inline void adjust_view_on_output(drag_done_signal *ev)
         {
             v.view->tile_request(v.view->tiled_edges, target_ws);
         }
+
+        // check focus timestamp and select the last focused view to (re)focus
+        if (v.view->last_focus_timestamp > focus_view->last_focus_timestamp)
+        {
+            focus_view = v.view;
+        }
     }
 
     // Ensure that every view is visible on parent's main workspace
@@ -692,7 +701,7 @@ inline void adjust_view_on_output(drag_done_signal *ev)
         ev->focused_output->workspace->move_to_workspace(v, target_ws);
     }
 
-    ev->focused_output->focus_view(parent, true);
+    ev->focused_output->focus_view(focus_view, true);
 }
 
 /**

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -276,6 +276,7 @@ class wayfire_move : public wf::plugin_interface_t
 
     bool initiate(wayfire_view view)
     {
+        wayfire_view grabbed_view = view;
         view = get_target_view(view);
         if (!can_move_view(view))
         {
@@ -292,6 +293,12 @@ class wayfire_move : public wf::plugin_interface_t
             (view->fullscreen || view->tiled_edges);
         opts.snap_off_threshold = move_snap_off_threshold;
         opts.join_views = join_views;
+
+        if (join_views)
+        {
+            // ensure that the originally grabbed view will be focused
+            output->focus_view(grabbed_view);
+        }
 
         drag_helper->start_drag(view, get_global_input_coords(), opts);
         slot.slot_id = 0;


### PR DESCRIPTION
Fixes #1186 (only the case with the move plugin)

Tested with regular move, drag with expo active and setting `workarounds/all_dialogs_modal` both on and off. Did not test with multiple outputs. Does not work if `move/join_views = true`, in that case, it seems that the clicked view is "forgotten" when the drag starts.