### PR TITLE
core-impl: Fix ODR violation warnings with b_lto

### DIFF
--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -8,7 +8,6 @@
 #include <set>
 #include <unordered_map>
 
-class input_method_relay;
 struct wayfire_shell;
 struct wf_gtk_shell;
 
@@ -16,6 +15,7 @@ namespace wf
 {
 class seat_t;
 class input_manager_t;
+class input_method_relay;
 class compositor_core_impl_t : public compositor_core_t
 {
   public:


### PR DESCRIPTION
compiling with link-time optimizations turned on generated One
Definition Rule violation warnings due to input_method_relay being
referred to in the global namespace and being defined in wf::

This line was probably placed outside of wf:: by mistake.