### PR TITLE
vswitch: add support for motion to absolute workspace pos

### DIFF
--- a/metadata/vswitch.xml
+++ b/metadata/vswitch.xml
@@ -24,26 +24,74 @@
 			<_long>Switches to workspace down with the specified activator.</_long>
 			<default>&lt;super&gt; &lt;alt&gt; KEY_DOWN</default>
 		</option>
-		<option name="binding_win_left" type="activator">
+		<option name="with_win_left" type="activator">
 			<_short>Left with window</_short>
 			<_long>Switches to workspace left with the focused window with the specified activator.</_long>
 			<default>&lt;super&gt; &lt;alt&gt; &lt;shift&gt; KEY_LEFT</default>
 		</option>
-		<option name="binding_win_right" type="activator">
+		<option name="with_win_right" type="activator">
 			<_short>Right with window</_short>
 			<_long>Switches to workspace right with the focused window with the specified activator.</_long>
 			<default>&lt;super&gt; &lt;alt&gt; &lt;shift&gt; KEY_RIGHT</default>
 		</option>
-		<option name="binding_win_up" type="activator">
+		<option name="with_win_up" type="activator">
 			<_short>Up with window</_short>
 			<_long>Switches to workspace up with the focused window with the specified activator.</_long>
 			<default>&lt;super&gt; &lt;alt&gt; &lt;shift&gt; KEY_UP</default>
 		</option>
-		<option name="binding_win_down" type="activator">
+		<option name="with_win_down" type="activator">
 			<_short>Down with window</_short>
 			<_long>Switches to workspace down with the focused window with the specified activator.</_long>
-			<default>&lt;super&gt; &lt;alt&gt; &lt;shift&gt; KEY_DOWN</default>
+			<default></default>
 		</option>
+		<option name="send_win_left" type="activator">
+			<_short>Send window to the left</_short>
+			<_long>Send the focused window to the workspace on the left.</_long>
+			<default></default>
+		</option>
+		<option name="send_win_right" type="activator">
+			<_short>Send window to the right</_short>
+			<_long>Send the focused window to the workspace on the right.</_long>
+			<default></default>
+		</option>
+		<option name="send_win_up" type="activator">
+			<_short>Send window above</_short>
+			<_long>Send the focused window to the workspace above.</_long>
+			<default></default>
+		</option>
+		<option name="send_win_down" type="activator">
+			<_short>Send window below</_short>
+			<_long>Send the focused window to the workspace below.</_long>
+			<default></default>
+		</option>
+
+		<option name="workspace_bindings" type="dynamic-list">
+			<_short>Go-To-Workspace bindings</_short>
+			<_long>Go-To-Workspace bindings</_long>
+			<entry prefix="binding_" type="activator">
+				<_short>Binding for workspace N</_short>
+				<_long>Sets the binding to go to workspace N.</_long>
+			</entry>
+		</option>
+
+		<option name="workspace_bindings_win" type="dynamic-list">
+			<_short>Go-To-Workspace with window bindings</_short>
+			<_long>Go-To-Workspace with window bindings</_long>
+			<entry prefix="with_win_" type="activator">
+				<_short>Binding for workspace N</_short>
+				<_long>Sets the binding to go to workspace N with currently focused window.</_long>
+			</entry>
+		</option>
+
+		<option name="bindings_win" type="dynamic-list">
+			<_short>Go-To-Workspace with window bindings</_short>
+			<_long>Go-To-Workspace with window bindings</_long>
+			<entry prefix="send_win_" type="activator">
+				<_short>Move window to workspace N</_short>
+				<_long>Sets the binding to move focused window to workspace N.</_long>
+			</entry>
+		</option>
+
 		<option name="duration" type="int">
 			<_short>Duration</_short>
 			<_long>Sets the duration of the workspace switching animation in milliseconds.</_long>

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -156,7 +156,8 @@ class wayfire_scale : public wf::plugin_interface_t
     {
         workspace_bindings =
             std::make_unique<wf::vswitch::control_bindings_t>(output);
-        workspace_bindings->setup([&] (wf::point_t delta, wayfire_view view)
+        workspace_bindings->setup([&] (wf::point_t delta,
+                                       wayfire_view view, bool only_view)
         {
             if (!output->is_plugin_active(grab_interface->name))
             {
@@ -167,6 +168,12 @@ class wayfire_scale : public wf::plugin_interface_t
             {
                 // Consume input event
                 return true;
+            }
+
+            if (only_view)
+            {
+                // For now, scale does not let you move views between workspaces
+                return false;
             }
 
             auto ws = output->workspace->get_current_workspace() + delta;

--- a/plugins/vswitch/wayfire/plugins/vswitch.hpp
+++ b/plugins/vswitch/wayfire/plugins/vswitch.hpp
@@ -4,10 +4,12 @@
 #include <wayfire/plugins/common/geometry-animation.hpp>
 #include <wayfire/plugins/common/workspace-wall.hpp>
 #include <wayfire/util/duration.hpp>
+#include <wayfire/config/compound-option.hpp>
 #include <wayfire/view.hpp>
 #include <wayfire/view-transform.hpp>
 #include <wayfire/nonstd/reverse.hpp>
 #include <cmath>
+#include <list>
 
 namespace wf
 {
@@ -256,7 +258,7 @@ class workspace_switch_t
 /**
  * A simple class to register the vswitch bindings and get a custom callback called.
  */
-class control_bindings_t
+class control_bindings_t : public noncopyable_t
 {
   public:
     /**
@@ -267,6 +269,10 @@ class control_bindings_t
     control_bindings_t(wf::output_t *output)
     {
         this->output = output;
+
+        workspace_bindings.set_callback(on_cfg_reload);
+        workspace_bindings_win.set_callback(on_cfg_reload);
+        bindings_win.set_callback(on_cfg_reload);
     }
 
     virtual ~control_bindings_t() = default;
@@ -276,9 +282,11 @@ class control_bindings_t
      *
      * @param delta The difference between current and target workspace.
      * @param view The view to be moved together with the switch, or nullptr.
+     * @param window_only Move only the view to the given workspace. It is
+     *   guaranteed that @view will not be nullptr if this is true.
      */
-    using binding_callback_t =
-        std::function<bool (wf::point_t delta, wayfire_view view)>;
+    using binding_callback_t = std::function<bool (
+        wf::point_t delta, wayfire_view view, bool window_only)>;
 
     /**
      * Connect bindings on the output.
@@ -287,67 +295,92 @@ class control_bindings_t
      */
     void setup(binding_callback_t callback)
     {
-        callback_left = [=] (const wf::activator_data_t&)
+        tear_down();
+        this->user_cb = callback;
+
+        // Setup a new binding on the output.
+        //
+        // @param name The binding name
+        // @param dx, dy The delta from the current workspace
+        // @param only Whether to grab the current view
+        // @param only Whether to move the view without changing workspaces
+        /* *INDENT-OFF* */ // Uncrustify has problems with this macro
+#define SETUP(name, dx, dy, view, only) \
+        wf::option_wrapper_t<wf::activatorbinding_t> binding_##name { \
+            "vswitch/"#name}; \
+        activator_cbs.push_back(std::make_unique<activator_callback>()); \
+        *activator_cbs.back() = [=] (const wf::activator_data_t&) \
+        {\
+            return handle_dir({dx, dy}, view, only, callback); \
+        };\
+        output->add_activator(binding_##name, activator_cbs.back().get());
+
+        // Setup bindings for the 4 directions (left/right/up/down)
+#define SETUP4(prefix, view, only) \
+        SETUP(prefix ## _left, -1, 0, view, only) \
+        SETUP(prefix ## _right, 1, 0, view, only) \
+        SETUP(prefix ## _up, 0, -1, view, only) \
+        SETUP(prefix ## _down, 0, 1, view, only)
+
+        SETUP4(binding, nullptr, false);
+        SETUP4(with_win, get_target_view(), false);
+        SETUP4(send_win, get_target_view(), true);
+
+#undef SETUP4
+#undef SETUP
+        /* *INDENT-ON* */
+
+        // Setup a binding for going directly to a workspace identified by a name
+        const auto& setup_direct_binding = [=] (wf::activatorbinding_t binding,
+                                                std::string workspace_name,
+                                                bool grab_view, bool only_view)
         {
-            return handle_dir({-1, 0}, nullptr, callback);
-        };
-        callback_right = [=] (const wf::activator_data_t&)
-        {
-            return handle_dir({1, 0}, nullptr, callback);
-        };
-        callback_up = [=] (const wf::activator_data_t&)
-        {
-            return handle_dir({0, -1}, nullptr, callback);
-        };
-        callback_down = [=] (const wf::activator_data_t&)
-        {
-            return handle_dir({0, 1}, nullptr, callback);
+            auto ws_nr = wf::option_type::from_string<int>(workspace_name);
+            if (!ws_nr)
+            {
+                LOGE("Invalid vswitch binding, no such workspace ", workspace_name);
+                return;
+            }
+
+            int nr = ws_nr.value();
+            --nr;
+
+            activator_cbs.push_back(std::make_unique<activator_callback>());
+            *activator_cbs.back() = [=] (const wf::activator_data_t&)
+            {
+                auto [wsize, hsize] = output->workspace->get_workspace_grid_size();
+
+                // Calculate target x,y each time.
+                // Workspace grid size might change at runtime, so we cannot
+                // compute them at initialization time
+                wf::point_t target{
+                    nr % wsize,
+                    nr / wsize,
+                };
+                wf::point_t current = output->workspace->get_current_workspace();
+
+                auto view = (grab_view ? get_target_view() : nullptr);
+                return handle_dir(target - current, view, only_view, callback);
+            };
+
+            output->add_activator(wf::create_option(binding),
+                activator_cbs.back().get());
         };
 
-        callback_win_left = [=] (const wf::activator_data_t&)
+        for (auto& [name, act] : workspace_bindings.value())
         {
-            return handle_dir({-1, 0}, get_target_view(), callback);
-        };
-        callback_win_right = [=] (const wf::activator_data_t&)
+            setup_direct_binding(act, name, false, false);
+        }
+
+        for (auto& [name, act] : workspace_bindings_win.value())
         {
-            return handle_dir({1, 0}, get_target_view(), callback);
-        };
-        callback_win_up = [=] (const wf::activator_data_t&)
+            setup_direct_binding(act, name, true, false);
+        }
+
+        for (auto& [name, act] : bindings_win.value())
         {
-            return handle_dir({0, -1}, get_target_view(), callback);
-        };
-        callback_win_down = [=] (const wf::activator_data_t&)
-        {
-            return handle_dir({0, 1}, get_target_view(), callback);
-        };
-
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_left{
-            "vswitch/binding_left"};
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_right{
-            "vswitch/binding_right"};
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_up{
-            "vswitch/binding_up"};
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_down{
-            "vswitch/binding_down"};
-
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_win_left{
-            "vswitch/binding_win_left"};
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_win_right{
-            "vswitch/binding_win_right"};
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_win_up{
-            "vswitch/binding_win_up"};
-        wf::option_wrapper_t<wf::activatorbinding_t> binding_win_down{
-            "vswitch/binding_win_down"};
-
-        output->add_activator(binding_left, &callback_left);
-        output->add_activator(binding_right, &callback_right);
-        output->add_activator(binding_up, &callback_up);
-        output->add_activator(binding_down, &callback_down);
-
-        output->add_activator(binding_win_left, &callback_win_left);
-        output->add_activator(binding_win_right, &callback_win_right);
-        output->add_activator(binding_win_up, &callback_win_up);
-        output->add_activator(binding_win_down, &callback_win_down);
+            setup_direct_binding(act, name, true, true);
+        }
     }
 
     /**
@@ -355,21 +388,39 @@ class control_bindings_t
      */
     void tear_down()
     {
-        output->rem_binding(&callback_left);
-        output->rem_binding(&callback_right);
-        output->rem_binding(&callback_up);
-        output->rem_binding(&callback_down);
+        for (auto& cb : activator_cbs)
+        {
+            output->rem_binding(cb.get());
+        }
 
-        output->rem_binding(&callback_win_left);
-        output->rem_binding(&callback_win_right);
-        output->rem_binding(&callback_win_up);
-        output->rem_binding(&callback_win_down);
+        activator_cbs.clear();
     }
 
   protected:
-    wf::activator_callback callback_left, callback_right, callback_up, callback_down;
-    wf::activator_callback callback_win_left, callback_win_right, callback_win_up,
-        callback_win_down;
+    binding_callback_t user_cb;
+    std::vector<std::unique_ptr<wf::activator_callback>> activator_cbs;
+
+    wf::wl_idle_call idle_reload;
+    wf::config::option_base_t::updated_callback_t on_cfg_reload = [=] ()
+    {
+        // Aggregate multiple updates together
+        idle_reload.run_once([=] ()
+        {
+            // Reload only if the plugin has already setup bindings once,
+            // otherwise, we do not have any callbacks to register.
+            if (user_cb)
+            {
+                setup(user_cb);
+            }
+        });
+    };
+
+    wf::option_wrapper_t<wf::config::compound_list_t<wf::activatorbinding_t>>
+    workspace_bindings{"vswitch/workspace_bindings"};
+    wf::option_wrapper_t<wf::config::compound_list_t<wf::activatorbinding_t>>
+    workspace_bindings_win{"vswitch/workspace_bindings_win"};
+    wf::option_wrapper_t<wf::config::compound_list_t<wf::activatorbinding_t>>
+    bindings_win{"vswitch/bindings_win"};
 
     wf::option_wrapper_t<bool> wraparound{"vswitch/wraparound"};
 
@@ -379,6 +430,11 @@ class control_bindings_t
     virtual wayfire_view get_target_view()
     {
         auto view = output->get_active_view();
+        while (view->parent)
+        {
+            view = view->parent;
+        }
+
         if (!view || (view->role != wf::VIEW_ROLE_TOPLEVEL))
         {
             return nullptr;
@@ -392,9 +448,15 @@ class control_bindings_t
      * determined by the current workspace, target direction and wraparound
      * mode.
      */
-    virtual bool handle_dir(wf::point_t dir, wayfire_view view,
+    virtual bool handle_dir(wf::point_t dir, wayfire_view view, bool window_only,
         binding_callback_t callback)
     {
+        if (!view && window_only)
+        {
+            // Maybe there is no view, in any case, no need to do anything
+            return false;
+        }
+
         auto ws = output->workspace->get_current_workspace();
         auto target_ws = ws + dir;
         if (!output->workspace->is_workspace_valid(target_ws))
@@ -410,7 +472,7 @@ class control_bindings_t
             }
         }
 
-        return callback(target_ws - ws, view);
+        return callback(target_ws - ws, view, window_only);
     }
 };
 }


### PR DESCRIPTION
There is also support for directly moving a view to a workspace.

Vswitch now supports the following options:

`binding_{N, dir}` -> Move to workspace N or in the given direction
`with_win_{N, dir}` -> Move to workspace N or in the given direction together with focused window.
`send_win_{N, dir}` -> Move focused window to workspace N or in the given direction.

`N` is the workspace number, workspaces are numbered from left to right, top to bottom.
`dir` can be `left`, `right`, `up` or `down`.

Important: this contains a breaking change for vswitch. `binding_win_left/etc` were renamed to `with_win_left/etc`, to avoid conflicts between option lists, otherwise `binding_win_1` could be interpreted either as 'move with window to workspace 1' or 'move to workspace `win_1`'