### PR TITLE
output-layout: add workarounds/use_external_output_config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,8 @@ jobs:
 
       # Build seatd from AUR
     - run: git clone https://aur.archlinux.org/seatd.git
+    - run: useradd makepkgtest
+    - run: (cd seatd && chown makepkgtest:root . && su makepkgtest -c "makepkg --printsrcinfo" > .SRCINFO)
     - uses: edlanglois/pkgbuild-action@v1
       id: makepkg
       with:

--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -31,5 +31,12 @@
       <_long>If true, allows Wayfire to dynamically recalculate its max_render_time, i.e allow render time higher than max_render_time.</_long>
       <default>false</default>
     </option>
+    <option name="use_external_output_configuration" type="bool">
+      <_short>Use external output configuration instead of Wayfire's own.</_short>
+      <_long>If true, Wayfire will not handle any configuration options for outputs in the config file once an
+      external daemon like https://github.com/emersion/kanshi sets the output configuration via the wlr-output-management protocol.
+      Exceptions are made for options not available via wlr-output-management, like output mirroring and custom modelines.</_long>
+      <default>false</default>
+    </option>
 	</plugin>
 </wayfire>

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1061,7 +1061,8 @@ class output_layout_t::impl
 
     void add_output(wlr_output *output)
     {
-        LOGI("new output: ", output->name);
+        LOGI("new output: ", output->name,
+            " (\"", output->make, " ", output->model, " ", output->serial, "\")");
 
         auto lo = new output_layout_output_t(output);
         outputs[output] = std::unique_ptr<output_layout_output_t>(lo);


### PR DESCRIPTION
Currently, if an external application like kanshi sets the output configuration, Wayfire will reset it to the values in the config file whenever the config file is reloaded.

To fix this, the new `workarounds/use_external_output_config` option modifies Wayfire's handling of output configuration: when this option is true, Wayfire will ignore any values in the config file (except mirroring) and use the values given by kanshi (or any similar program).
