### PR TITLE
surface: Return owned surface on remove_subsurface

### DIFF
--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -73,13 +73,14 @@ class surface_interface_t : public wf::object_base_t
 
     /**
      * Remove the given subsurface from the surface tree.
-     * The subsurface and all of its subsurfaces will be destroyed.
      *
      * No-op if the subsurface does not exist.
      *
      * @param subsurface The subsurface to remove.
+     * @return The subsurface removed or nullptr.
      */
-    void remove_subsurface(nonstd::observer_ptr<surface_interface_t> subsurface);
+    std::unique_ptr<surface_interface_t> remove_subsurface(
+        nonstd::observer_ptr<surface_interface_t> subsurface);
 
     /**
      * @param surface_origin The coordinates of the top-left corner of the

--- a/src/view/subsurface.cpp
+++ b/src/view/subsurface.cpp
@@ -18,7 +18,7 @@ wf::subsurface_implementation_t::subsurface_implementation_t(wlr_subsurface *_su
         on_unmap.disconnect();
         on_destroy.disconnect();
 
-        this->priv->parent_surface->remove_subsurface(this);
+        (void)this->priv->parent_surface->remove_subsurface(this);
     });
 
     on_map.connect(&sub->events.map);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -801,7 +801,7 @@ void wf::view_interface_t::set_decoration(surface_interface_t *frame)
 
         if (view_impl->decoration)
         {
-            this->remove_subsurface(view_impl->decoration);
+            (void)this->remove_subsurface(view_impl->decoration);
         }
 
         view_impl->decoration = nullptr;
@@ -828,7 +828,7 @@ void wf::view_interface_t::set_decoration(surface_interface_t *frame)
     damage();
     if (view_impl->decoration)
     {
-        this->remove_subsurface(view_impl->decoration);
+        (void)this->remove_subsurface(view_impl->decoration);
     }
 
     view_impl->decoration = frame;


### PR DESCRIPTION
As discussed here:
https://github.com/Javyre/swayfire/pull/24#issuecomment-854393828

This isn't too useful yet as the subsurfaces still get dropped on `set_decoration()`. I feel like `set_decoration()` should either not `remove_subsurface` at all or at least return the pointer as well. (although that would be messier since there's less guarantee you're getting back your own surface form the `set_decoration(nullptr)`)