### PR TITLE
output-layout: do not check for noop's existence when ensuring it exists

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1319,9 +1319,8 @@ class output_layout_t::impl
 
         bool turning_off_all_active =
             !active_outputs.empty() && count_remaining_enabled == 0;
-        bool is_noop_active = noop_output && noop_output->output;
 
-        if (turning_off_all_active && !is_shutting_down() && !is_noop_active)
+        if (turning_off_all_active && !is_shutting_down())
         {
             /* If we aren't shutting down, and we will turn off all the
              * currently enabled outputs, we'll need the noop output, as a


### PR DESCRIPTION
`ensure_noop_output` truly is an "ensure" function, not a "create" one. Among other things, it cancels the `timer_remove_noop`, which always needs to be done.

Otherwise, rapid changes in output configuration (that do happen for me currently with turning my monitor back on after turning it off) cause a situation where the `timer_remove_noop` fires right after removing the last output, causing the noop to be removed too, which results in a crash.