### PR TITLE
WIP: deco: Separate decoration surface from frame.

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2021'04'15;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2021'06'07;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -6,6 +6,7 @@
 
 #include "wayfire/surface.hpp"
 #include "wayfire/geometry.hpp"
+#include "wayfire/decorator.hpp"
 #include <wayfire/nonstd/wlroots.hpp>
 
 namespace wf
@@ -317,20 +318,18 @@ class view_interface_t : public surface_interface_t
     /**
      * Set the decoration surface for the view.
      *
-     * @param frame The surface to be set as a decoration. It must be subclass
-     * of both surface_interface_t and of wf::decorator_frame_t_t, and its parent
-     * surface must be this view.
+     * @param frame The surface to be set as a decoration.
      *
-     * The life-time of the decoration is managed by the view itself, so after
+     * The life-time of the decoration frame is managed by the view itself, so after
      * calling this function you probably want to drop any references that you
      * hold (excluding the default one)
      */
-    virtual void set_decoration(surface_interface_t *frame);
+    virtual void set_decoration(std::unique_ptr<decorator_frame_t_t> frame);
 
     /**
-     * Get the decoration surface for a view. May be nullptr.
+     * Get the decoration frame for a view. May be nullptr.
      */
-    virtual nonstd::observer_ptr<surface_interface_t> get_decoration();
+    virtual nonstd::observer_ptr<decorator_frame_t_t> get_decoration();
 
     /*
      *                        View transforms

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -339,8 +339,6 @@ void wf::wlr_view_t::unmap()
 
     destroy_toplevel();
 
-    // Unset decoration when unmapping, since the policy is to always remove
-    // all subsurfaces when a view is unmapped.
     set_decoration(nullptr);
 
     wlr_surface_base_t::unmap();

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -54,10 +54,7 @@ class view_interface_t::view_priv_impl
      */
     void update_windowed_geometry(wayfire_view self, wf::geometry_t geometry);
 
-    /* those two point to the same object. Two fields are used to avoid
-     * constant casting to and from types */
-    surface_interface_t *decoration = NULL;
-    wf::decorator_frame_t_t *frame  = NULL;
+    std::unique_ptr<wf::decorator_frame_t_t> frame = nullptr;
 
     uint32_t edges = 0;
     int in_continuous_move   = 0;


### PR DESCRIPTION
This doesn't work yet as I'm still working on it.

I'm not sure how you want to split the deco plugin's `simple_decoration_surface`. Do you want to store the surface state in the surface itself or in the decoration frame? The new `simple_decoration_frame` could also just be empty and forward all the events to the surface.. I'm not sure how you want to approach this.