### PR TITLE
unit test infrastructure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,11 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev eudev-dev libxml2-dev libexecinfo-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev eudev-dev libxml2-dev libexecinfo-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest-dev
     - uses: actions/checkout@v1
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
     - run: meson build
     - run: ninja -v -Cbuild
+    - run: ninja -v -Cbuild test
   test_glibc_llvm:
     name: "Test with clang/glibc/libc++/lld on Arch Linux"
     runs-on: ubuntu-latest

--- a/meson.build
+++ b/meson.build
@@ -28,6 +28,7 @@ libinput       = dependency('libinput', version: '>=1.7.0')
 pixman         = dependency('pixman-1')
 threads        = dependency('threads')
 xkbcommon      = dependency('xkbcommon')
+libdl          = meson.get_compiler('cpp').find_library('dl')
 wlroots        = dependency('wlroots', version: ['>=0.14.0', '<0.15.0'], required: get_option('use_system_wlroots'))
 wfconfig       = dependency('wf-config', version: ['>=0.7.0', '<0.8.0'], required: get_option('use_system_wfconfig'))
 
@@ -164,6 +165,12 @@ subdir('src')
 subdir('metadata')
 subdir('plugins')
 
+# Unit tests
+doctest = dependency('doctest', required: get_option('tests'))
+if doctest.found()
+    subdir('test')
+endif
+
 summary = [
 	'',
 	'----------------',
@@ -176,6 +183,7 @@ summary = [
     '        imageio: @0@'.format(conf_data.get('BUILD_WITH_IMAGEIO')),
     '         gles32: @0@'.format(conf_data.get('USE_GLES32')),
     '    print trace: @0@'.format(print_trace),
+    '     unit tests: @0@'.format(doctest.found()),
     '----------------',
     ''
 ]

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,3 +4,4 @@ option('use_system_wlroots', type: 'feature', value: 'auto', description: 'Use t
 option('xwayland', type: 'feature', value: 'auto', description: 'Build with xwayland support. Requires wlroots also built with xwayland support')
 option('default_config_backend', type: 'string', value: 'default', description: 'Default configuration backend to use')
 option('print_trace', type: 'boolean', value: true, description: 'Print stack trace in debug logs (disables coredump)')
+option('tests', type: 'feature', value: 'auto', description: 'Enable unit tests')

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -31,7 +31,9 @@ dimensions_t dimensions(const geometry_t& geometry);
  * the resulting geometry has undefined (x,y) and width == height == 0 */
 geometry_t geometry_intersection(const geometry_t& r1,
     const geometry_t& r2);
-}
+
+std::ostream& operator <<(std::ostream& stream, const wf::point_t& point);
+std::ostream& operator <<(std::ostream& stream, const wf::pointf_t& pointf);
 
 bool operator ==(const wf::dimensions_t& a, const wf::dimensions_t& b);
 bool operator !=(const wf::dimensions_t& a, const wf::dimensions_t& b);
@@ -39,14 +41,17 @@ bool operator !=(const wf::dimensions_t& a, const wf::dimensions_t& b);
 bool operator ==(const wf::point_t& a, const wf::point_t& b);
 bool operator !=(const wf::point_t& a, const wf::point_t& b);
 
+wf::point_t operator +(const wf::point_t& a, const wf::point_t& b);
+wf::point_t operator -(const wf::point_t& a, const wf::point_t& b);
+
+wf::point_t operator -(const wf::point_t& a);
+}
+
 bool operator ==(const wf::geometry_t& a, const wf::geometry_t& b);
 bool operator !=(const wf::geometry_t& a, const wf::geometry_t& b);
 
-wf::point_t operator +(const wf::point_t& a, const wf::point_t& b);
-wf::point_t operator -(const wf::point_t& a, const wf::point_t& b);
 wf::point_t operator +(const wf::point_t& a, const wf::geometry_t& b);
 wf::geometry_t operator +(const wf::geometry_t & a, const wf::point_t& b);
-wf::point_t operator -(const wf::point_t& a);
 
 /** Scale the box */
 wf::geometry_t operator *(const wf::geometry_t& box, double scale);
@@ -63,7 +68,5 @@ bool operator &(const wf::geometry_t& r1, const wf::geometry_t& r2);
 
 /* Make geometry and point printable */
 std::ostream& operator <<(std::ostream& stream, const wf::geometry_t& geometry);
-std::ostream& operator <<(std::ostream& stream, const wf::point_t& point);
-std::ostream& operator <<(std::ostream& stream, const wf::pointf_t& pointf);
 
 #endif /* end of include guard: WF_GEOMETRY_HPP */

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2021'06'07;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2021'06'15;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -27,6 +27,7 @@
 #include "../output/wayfire-shell.hpp"
 #include "../output/output-impl.hpp"
 #include "../output/gtk-shell.hpp"
+#include "main.hpp"
 
 #include "core-impl.hpp"
 
@@ -907,4 +908,21 @@ wf::compositor_core_t& wf::get_core()
 wf::compositor_core_impl_t& wf::get_core_impl()
 {
     return wf::compositor_core_impl_t::get();
+}
+
+// TODO: move this to a better location
+wf_runtime_config runtime_config;
+
+// TODO: move this to a better location
+namespace wf
+{
+namespace _safe_list_detail
+{
+wl_event_loop *event_loop;
+void idle_cleanup_func(void *data)
+{
+    auto priv = reinterpret_cast<std::function<void()>*>(data);
+    (*priv)();
+}
+}
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,9 +17,6 @@
 #include "core/core-impl.hpp"
 #include "wayfire/output.hpp"
 
-wf_runtime_config runtime_config;
-
-
 static void print_version()
 {
     std::cout << WAYFIRE_VERSION << std::endl;
@@ -42,19 +39,6 @@ static void print_help()
     std::cout << " -R,  --damage-rerender   rerender damaged regions" << std::endl;
     std::cout << " -v,  --version           print version and exit" << std::endl;
     exit(0);
-}
-
-namespace wf
-{
-namespace _safe_list_detail
-{
-wl_event_loop *event_loop;
-void idle_cleanup_func(void *data)
-{
-    auto priv = reinterpret_cast<std::function<void()>*>(data);
-    (*priv)();
-}
-}
 }
 
 static bool drop_permissions(void)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,4 @@
-wayfire_sources = ['main.cpp',
-                   'util.cpp',
+wayfire_sources = ['util.cpp',
 
                    'core/output-layout.cpp',
                    'core/matcher.cpp',
@@ -43,7 +42,7 @@ wayfire_sources = ['main.cpp',
                    'output/gtk-shell.cpp']
 
 wayfire_dependencies = [wayland_server, wlroots, xkbcommon, libinput,
-                       pixman, drm, egl, glesv2, glm, wf_protos,
+                       pixman, drm, egl, glesv2, glm, wf_protos, libdl,
                        wfconfig, libinotify, backtrace, wfutils, xcb, wftouch]
 
 if conf_data.get('BUILD_WITH_IMAGEIO')
@@ -71,12 +70,25 @@ if print_trace
   debug_arguments += ['-DPRINT_TRACE']
 endif
 
-executable('wayfire', wayfire_sources,
+# First build a static library of all sources, so that it can be reused
+# in tests
+libwayfire_sta = static_library('libwayfire', wayfire_sources,
     dependencies: wayfire_dependencies,
     include_directories: [wayfire_conf_inc, wayfire_api_inc],
     cpp_args: debug_arguments,
-    link_args: '-ldl',
-    install: true)
+    install: false)
+
+libwayfire = declare_dependency(link_with: libwayfire_sta,
+    include_directories: [wayfire_conf_inc, wayfire_api_inc],
+    dependencies: wayfire_dependencies)
+
+tests_include_dirs = include_directories('.')
+
+# Generate main executable
+executable('wayfire', ['main.cpp'],
+    dependencies: libwayfire,
+    install: true,
+    cpp_args: debug_arguments)
 
 shared_module('default-config-backend', 'default-config-backend.cpp',
     dependencies: wayfire_dependencies,
@@ -84,7 +96,6 @@ shared_module('default-config-backend', 'default-config-backend.cpp',
     cpp_args: debug_arguments,
     install_dir: conf_data.get('PLUGIN_PATH'),
     install: true)
-
 
 install_subdir('api/wayfire',
     install_dir: get_option('includedir'))

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -16,21 +16,6 @@ std::ostream& operator <<(std::ostream& stream, const wf::geometry_t& geometry)
     return stream;
 }
 
-std::ostream& operator <<(std::ostream& stream, const wf::point_t& point)
-{
-    stream << '(' << point.x << ',' << point.y << ')';
-
-    return stream;
-}
-
-std::ostream& operator <<(std::ostream& stream, const wf::pointf_t& pointf)
-{
-    stream << std::fixed << std::setprecision(4) <<
-        '(' << pointf.x << ',' << pointf.y << ')';
-
-    return stream;
-}
-
 wf::point_t wf::origin(const geometry_t& geometry)
 {
     return {geometry.x, geometry.y};
@@ -41,22 +26,22 @@ wf::dimensions_t wf::dimensions(const geometry_t& geometry)
     return {geometry.width, geometry.height};
 }
 
-bool operator ==(const wf::dimensions_t& a, const wf::dimensions_t& b)
+bool wf::operator ==(const wf::dimensions_t& a, const wf::dimensions_t& b)
 {
     return a.width == b.width && a.height == b.height;
 }
 
-bool operator !=(const wf::dimensions_t& a, const wf::dimensions_t& b)
+bool wf::operator !=(const wf::dimensions_t& a, const wf::dimensions_t& b)
 {
     return !(a == b);
 }
 
-bool operator ==(const wf::point_t& a, const wf::point_t& b)
+bool wf::operator ==(const wf::point_t& a, const wf::point_t& b)
 {
     return a.x == b.x && a.y == b.y;
 }
 
-bool operator !=(const wf::point_t& a, const wf::point_t& b)
+bool wf::operator !=(const wf::point_t& a, const wf::point_t& b)
 {
     return !(a == b);
 }
@@ -71,12 +56,12 @@ bool operator !=(const wf::geometry_t& a, const wf::geometry_t& b)
     return !(a == b);
 }
 
-wf::point_t operator +(const wf::point_t& a, const wf::point_t& b)
+wf::point_t wf::operator +(const wf::point_t& a, const wf::point_t& b)
 {
     return {a.x + b.x, a.y + b.y};
 }
 
-wf::point_t operator -(const wf::point_t& a, const wf::point_t& b)
+wf::point_t wf::operator -(const wf::point_t& a, const wf::point_t& b)
 {
     return {a.x - b.x, a.y - b.y};
 }
@@ -96,7 +81,7 @@ wf::geometry_t operator +(const wf::geometry_t & a, const wf::point_t& b)
     };
 }
 
-wf::point_t operator -(const wf::point_t& a)
+wf::point_t wf::operator -(const wf::point_t& a)
 {
     return {-a.x, -a.y};
 }
@@ -479,6 +464,21 @@ static int handle_timeout(void *data)
 
 namespace wf
 {
+std::ostream& operator <<(std::ostream& stream, const wf::point_t& point)
+{
+    stream << '(' << point.x << ',' << point.y << ')';
+
+    return stream;
+}
+
+std::ostream& operator <<(std::ostream& stream, const wf::pointf_t& pointf)
+{
+    stream << std::fixed << std::setprecision(4) <<
+        '(' << pointf.x << ',' << pointf.y << ')';
+
+    return stream;
+}
+
 wl_listener_wrapper::wl_listener_wrapper()
 {
     _wrap.self = this;

--- a/test/geometry/geometry_test.cpp
+++ b/test/geometry/geometry_test.cpp
@@ -1,0 +1,13 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/geometry.hpp>
+
+TEST_CASE("Point addition")
+{
+    wf::point_t a = {1, 2};
+    wf::point_t b = {3, 4};
+
+    using namespace wf;
+    REQUIRE_EQ(a + b, wf::point_t{4, 6});
+}

--- a/test/geometry/meson.build
+++ b/test/geometry/meson.build
@@ -1,0 +1,6 @@
+geometry_test = executable(
+    'geometry_test',
+    'geometry_test.cpp',
+    dependencies: [wfconfig, doctest, libwayfire],
+    install: false)
+test('Geometry test', geometry_test)

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,1 @@
+subdir('geometry')


### PR DESCRIPTION
This PR adds basic infrastructure for unit tests with doctest.

Since Wayfire's design does not rely too heavily on interfaces, we can hardly isolate different parts of the code from each other.
As a result, most of Wayfire's code needs to be compiled into a static library, which is then compiled with `main.cpp` to produce the executable.
The same static library is also linked to the tests.

Currently, there is only a single very simple test case, it is more a proof-of-concept.
The upcoming transactions will be the first part of Wayfire itself which should be properly unit-tested, as should ideally be
any new big change in core.
