### PR TITLE
workspace-impl: preserve last-focused order

### DIFF
--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -189,15 +189,15 @@ class output_t : public wf::object_base_t
     bool ensure_visible(wayfire_view view);
 
     /**
-     * Force refocus the topmost view in one of the layers marked in layers
-     * and which isn't skip_view.
+     * Force refocus the most recently focused view in one of the layers marked
+     * in layers and which isn't skip_view.
      *
      * The stacking order is not changed.
      */
     virtual void refocus(wayfire_view skip_view, uint32_t layers) = 0;
 
     /**
-     * Refocus the topmost focuseable view != skip_view, preferring regular
+     * Refocus the most recently focused view != skip_view, preferring regular
      * views. The stacking order is not changed.
      */
     void refocus(wayfire_view skip_view = nullptr);

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -773,12 +773,17 @@ class output_viewport_manager_t
             }
         }
 
-        // Update the last-focused order to be the same as the stacking order.
-        // This ensures we don't run into problems where a view on the old
-        // workspace is below a view on the current workspace, but gets focus
-        // because it has a newer timestamp from the old workspace.
+        // Refresh the last-focused order. This ensures we don't run into
+        // problems where a view on the old workspace is still visible on the
+        // current workspace, and gets focus because it has a newer timestamp
+        // from the old workspace.
         auto views = get_views_on_workspace(get_current_workspace(), wf::WM_LAYERS);
-        for (auto v : wf::reverse(views))
+        std::sort(views.begin(), views.end(),
+            [] (const auto& x, const auto& y)
+        {
+            return x->last_focus_timestamp < y->last_focus_timestamp;
+        });
+        for (auto v : views)
         {
             auto children = v->enumerate_views();
             std::sort(children.begin(), children.end(),


### PR DESCRIPTION
Preserve last-focused order on workspace changed.

This solved the following bug that I described on IRC:
1. open view # 1 and view # 2
2. click on view # 2 to bring it to the front
3. move mouse over view # 1 to give it keyboard focus (with follow-focus plugin and raise view option false)
4. use viewport switcher or expo to go to another workspace
5. switch back to the original workspace and the view # 2 on top is given keyboard focus instead of view # 1