### PR TITLE
wlr/types/wlr_types.h -> wlr/utils/box.h

### DIFF
--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -50,7 +50,7 @@ extern "C"
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_output.h>
-#include <wlr/types/wlr_box.h>
+#include <wlr/util/box.h>
 #include <wlr/util/edges.h>
 #include <wayland-server.h>
 


### PR DESCRIPTION
Change wlr/types/wlr_types.h to wlr/utils/box.h fix the build warnings.