### PR TITLE
build: Add -fno-gnu-unique compiler option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -87,13 +87,20 @@ else
   conf_data.set('DEFAULT_CONFIG_BACKEND', get_option('default_config_backend'))
 endif
 
+cpp = meson.get_compiler('cpp')
+
 # needed to dlopen() plugins
 # -E is for RTTI/dynamic_cast across plugins
-add_project_arguments(['-DWLR_USE_UNSTABLE'], language: ['cpp', 'c'])
 add_project_link_arguments(['-rdynamic', '-Wl,-E'], language: 'cpp')
 
+project_args = ['-DWLR_USE_UNSTABLE']
+# Needed for dlclose to actually free plugin memory
+if cpp.has_argument('-fno-gnu-unique')
+  project_args += '-fno-gnu-unique'
+endif
+add_project_arguments(project_args, language: ['cpp', 'c'])
+
 # Needed on some older compilers
-  cpp = meson.get_compiler('cpp')
 if cpp.has_link_argument('-lc++fs')
   add_project_link_arguments(['-lc++fs'], language: 'cpp')
 elif cpp.has_link_argument('-lc++experimental')


### PR DESCRIPTION
dlclose POSIX docs say "Although a dlclose() operation is not required
to remove structures from an address space, neither is an implementation
prohibited from doing so."[1]. The fno-gnu-unique option makes it so the
plugin is unloaded when dlclose is called[2]. This makes wayfire use less
resident memory when unloading plugins. It also allows developers to make
changes to wayfire plugins without restarting wayfire.

1. The Open Group Base Specifications Issue 6.
http://pubs.opengroup.org/onlinepubs/007904975/functions/dlclose.html
2. GCC Code Gen Options.
https://gcc.gnu.org/onlinedocs/gcc/Code-Gen-Options.html