### PR TITLE
output: preserve last-focused order (take 2)

### DIFF
--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -189,15 +189,15 @@ class output_t : public wf::object_base_t
     bool ensure_visible(wayfire_view view);
 
     /**
-     * Force refocus the topmost view in one of the layers marked in layers
-     * and which isn't skip_view.
+     * Force refocus the most recently focused view in one of the layers marked
+     * in layers and which isn't skip_view.
      *
      * The stacking order is not changed.
      */
     virtual void refocus(wayfire_view skip_view, uint32_t layers) = 0;
 
     /**
-     * Refocus the topmost focuseable view != skip_view, preferring regular
+     * Refocus the most recently focused view != skip_view, preferring regular
      * views. The stacking order is not changed.
      */
     void refocus(wayfire_view skip_view = nullptr);

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -23,6 +23,8 @@ class output_impl_t : public output_t
         FOCUS_VIEW_RAISE        = (1 << 0),
         /* Close popups of non-focused views */
         FOCUS_VIEW_CLOSE_POPUPS = (1 << 1),
+        /* Inhibit updating the focus timestamp of the view */
+        FOCUS_VIEW_NOBUMP       = (1 << 2),
     };
 
     /**

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -101,7 +101,7 @@ void wf::output_impl_t::refocus(wayfire_view skip_view, uint32_t layers)
         focus_view(nullptr, 0u);
     } else
     {
-        focus_view(*it, 0u);
+        focus_view(*it, (uint32_t)FOCUS_VIEW_NOBUMP);
     }
 }
 
@@ -343,7 +343,11 @@ void wf::output_impl_t::focus_view(wayfire_view v, uint32_t flags)
     if (v->get_keyboard_focus_surface() || interactive_view_from_view(v.get()))
     {
         make_view_visible(v);
-        update_focus_timestamp(v);
+        if (!(flags & FOCUS_VIEW_NOBUMP))
+        {
+            update_focus_timestamp(v);
+        }
+
         update_active_view(v, flags);
         data.view = v;
         emit_signal("view-focused", &data);

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -773,25 +773,6 @@ class output_viewport_manager_t
             }
         }
 
-        // Update the last-focused order to be the same as the stacking order.
-        // This ensures we don't run into problems where a view on the old
-        // workspace is below a view on the current workspace, but gets focus
-        // because it has a newer timestamp from the old workspace.
-        auto views = get_views_on_workspace(get_current_workspace(), wf::WM_LAYERS);
-        for (auto v : wf::reverse(views))
-        {
-            auto children = v->enumerate_views();
-            std::sort(children.begin(), children.end(),
-                [] (const auto& x, const auto& y)
-            {
-                return x->last_focus_timestamp < y->last_focus_timestamp;
-            });
-            for (auto& child : children)
-            {
-                update_focus_timestamp(child);
-            }
-        }
-
         for (auto& v : fixed_views)
         {
             output->focus_view(v, true);


### PR DESCRIPTION
Preserve last-focused order on workspace changed.

This is an alternative, simpler solution for the issue described in #1237. The solution is to simply not meddle with the focus timestamps on `set_workspace()`.

This should also cover the cases described in the previous attempt where if a view is sticky or spans multiple workspaces it could lead to unintuitive behaviour.