### PR TITLE
Add settings to fire effects

### DIFF
--- a/metadata/animate.xml
+++ b/metadata/animate.xml
@@ -106,5 +106,15 @@
 			<_long>Sets the size of the fire particles in pixels.</_long>
 			<default>16.0</default>
 		</option>
+		<option name="random_fire_color" type="bool">
+			<_short>Random fire colors</_short>
+			<_long>Sets wether to use one solid color or select a random color for each particle</_long>
+			<default>false</default>
+		</option>
+		<option name="fire_color" type="color">
+			<_short>Color of the fire</_short>
+			<_long>Sets the color of the fire effects, alpha is ignored</_long>
+			<default>#b22303ff</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -116,17 +116,6 @@ class FireTransformer : public wf::view_transformer_t
             g = random(0, 1);
             b = random(0, 1);
 
-            // Squrae the values several times to make them less of a blinding light and more of a spray of colors
-            // for (int i = 0; i < 4; i++) {
-            //     r *= r;
-            //     g *= g;
-            //     b *= b;
-            // }
-
-            // r *= 2;
-            // g *= 2;
-            // b *= 2;
-
             r = 2 * pow(r, 16);
             g = 2 * pow(g, 16);
             b = 2 * pow(b, 16);

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -91,27 +91,29 @@ class FireTransformer : public wf::view_transformer_t
         p.fade = random(0.1, 0.6);
 
         wf::color_t color_setting = fire_color;
-        
+
         float r;
         float g;
         float b;
 
-        if (!random_fire_color) {
+        if (!random_fire_color)
+        {
             // The calculation here makes the variation lower at darker values
             float randomize_amount_r = (color_setting.r * 0.857) / 2;
             float randomize_amount_g = (color_setting.g * 0.857) / 2;
             float randomize_amount_b = (color_setting.b * 0.857) / 2;
 
-            r = random(color_setting.r - randomize_amount_r, 
-                       std::min(color_setting.r + randomize_amount_r, 
-                       1.0));
-            g = random(color_setting.g - randomize_amount_g, 
-                       std::min(color_setting.g + randomize_amount_g, 
-                       1.0));
-            b = random(color_setting.b - randomize_amount_b, 
-                       std::min(color_setting.b + randomize_amount_b, 
-                       1.0));
-        } else {
+            r = random(color_setting.r - randomize_amount_r,
+                std::min(color_setting.r + randomize_amount_r,
+                    1.0));
+            g = random(color_setting.g - randomize_amount_g,
+                std::min(color_setting.g + randomize_amount_g,
+                    1.0));
+            b = random(color_setting.b - randomize_amount_b,
+                std::min(color_setting.b + randomize_amount_b,
+                    1.0));
+        } else
+        {
             r = random(0, 1);
             g = random(0, 1);
             b = random(0, 1);

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -98,7 +98,7 @@ class FireTransformer : public wf::view_transformer_t
         float b;
 
         if (!random_colors) {
-            // The calculation here makes the variation lower 
+            // The calculation here makes the variation lower at darker values
             float randomize_amount_r = (color_setting.r * 0.857) / 2;
             float randomize_amount_g = (color_setting.g * 0.857) / 2;
             float randomize_amount_b = (color_setting.b * 0.857) / 2;

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -91,13 +91,12 @@ class FireTransformer : public wf::view_transformer_t
         p.fade = random(0.1, 0.6);
 
         wf::color_t color_setting = fire_color;
-        bool random_colors = random_fire_color;
         
         float r;
         float g;
         float b;
 
-        if (!random_colors) {
+        if (!random_fire_color) {
             // The calculation here makes the variation lower at darker values
             float randomize_amount_r = (color_setting.r * 0.857) / 2;
             float randomize_amount_g = (color_setting.g * 0.857) / 2;
@@ -118,15 +117,19 @@ class FireTransformer : public wf::view_transformer_t
             b = random(0, 1);
 
             // Squrae the values several times to make them less of a blinding light and more of a spray of colors
-            for (int i = 0; i < 4; i++) {
-                r *= r;
-                g *= g;
-                b *= b;
-            }
+            // for (int i = 0; i < 4; i++) {
+            //     r *= r;
+            //     g *= g;
+            //     b *= b;
+            // }
 
-            r *= 2;
-            g *= 2;
-            b *= 2;
+            // r *= 2;
+            // g *= 2;
+            // b *= 2;
+
+            r = 2 * pow(r, 16);
+            g = 2 * pow(g, 16);
+            b = 2 * pow(b, 16);
         }
 
         p.color = {r, g, b, 1};

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -8,6 +8,8 @@
 
 static wf::option_wrapper_t<int> fire_particles{"animate/fire_particles"};
 static wf::option_wrapper_t<double> fire_particle_size{"animate/fire_particle_size"};
+static wf::option_wrapper_t<bool> random_fire_color{"animate/random_fire_color"};
+static wf::option_wrapper_t<wf::color_t> fire_color{"animate/fire_color"};
 
 // generate a random float between s and e
 static float random(float s, float e)
@@ -88,7 +90,46 @@ class FireTransformer : public wf::view_transformer_t
         p.life = 1;
         p.fade = random(0.1, 0.6);
 
-        p.color = {random(0.4, 1), random(0.08, 0.2), random(0.008, 0.018), 1};
+        wf::color_t color_setting = fire_color;
+        bool random_colors = random_fire_color;
+        
+        float r;
+        float g;
+        float b;
+
+        if (!random_colors) {
+            // The calculation here makes the variation lower 
+            float randomize_amount_r = (color_setting.r * 0.857) / 2;
+            float randomize_amount_g = (color_setting.g * 0.857) / 2;
+            float randomize_amount_b = (color_setting.b * 0.857) / 2;
+
+            r = random(color_setting.r - randomize_amount_r, 
+                       std::min(color_setting.r + randomize_amount_r, 
+                       1.0));
+            g = random(color_setting.g - randomize_amount_g, 
+                       std::min(color_setting.g + randomize_amount_g, 
+                       1.0));
+            b = random(color_setting.b - randomize_amount_b, 
+                       std::min(color_setting.b + randomize_amount_b, 
+                       1.0));
+        } else {
+            r = random(0, 1);
+            g = random(0, 1);
+            b = random(0, 1);
+
+            // Squrae the values several times to make them less of a blinding light and more of a spray of colors
+            for (int i = 0; i < 4; i++) {
+                r *= r;
+                g *= g;
+                b *= b;
+            }
+
+            r *= 2;
+            g *= 2;
+            b *= 2;
+        }
+
+        p.color = {r, g, b, 1};
 
         p.pos = {random(0, last_boundingbox.width),
             random(last_boundingbox.height * progress_line - 10,


### PR DESCRIPTION
This PR adds 2 settings, `fire_color` (color) and `random_fire_color` (boolean).

If `random_fire_color` is false, the fire will be colored according to `fire_color`. If it is true then the color of each particle will be randomized.