### PR TITLE
WM-Actions Send to back functionality

### DIFF
--- a/metadata/wm-actions.xml
+++ b/metadata/wm-actions.xml
@@ -34,5 +34,10 @@
 			<_long>Show the desktop.</_long>
 			<default>disabled</default>
 		</option>
+		<option name="send_to_back" type="activator">
+			<_short>Send to back</_short>
+			<_long>Send the active view to behind all other views.</_long>
+			<default>disabled</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -318,6 +318,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
         output->rem_binding(&on_toggle_maximize);
         output->rem_binding(&on_toggle_above);
         output->rem_binding(&on_toggle_fullscreen);
+        output->rem_binding(&on_toggle_sticky);
     }
 };
 


### PR DESCRIPTION
For feature request #1269 

I also noticed a missing binding removal in fini(), so I added it in a separate commit.