### PR TITLE
Option to show minimized views in scale

### DIFF
--- a/metadata/scale.xml
+++ b/metadata/scale.xml
@@ -32,6 +32,11 @@
 				<_long>Use the middle mouse button to close views in the scale state. Only applies if interactive mode is not enabled.</_long>
 				<default>false</default>
 			</option>
+			<option name="include_minimized" type="bool">
+				<_short>Include minimized views</_short>
+				<_long>Whether to show views that are minimized when starting scale.</_long>
+				<default>false</default>
+			</option>
 		</group>
 		<group>
 			<_short>Appearance</_short>
@@ -45,6 +50,14 @@
 				<_short>Inactive Opacity</_short>
 				<_long>Set the opacity value of the inactive windows.</_long>
 				<default>0.75</default>
+				<precision>0.05</precision>
+				<min>0.0</min>
+				<max>1.0</max>
+			</option>
+			<option name="minimized_alpha" type="double">
+				<_short>Minimized View Opacity</_short>
+				<_long>Set the opacity value of minimized views that are shown in scale.</_long>
+				<default>0.45</default>
 				<precision>0.05</precision>
 				<min>0.0</min>
 				<max>1.0</max>


### PR DESCRIPTION
This can be helpful if scale is used as a primary method to switch between views. Of course, this is probably highly opinion-based, so I made this into a config option. Depends on #1906 

Issues / questions:
 - [x] Test the case when a view is minimized while scale is running ~~(should work, but not easy to test, I don't find the interactive scale option anymore)~~ simple test case [here](https://github.com/dkondor/wayfire/blob/scale_test/minimize_window.py)
 - [x] Should this be a global option? Yes
 - ~~[ ] Option for an other plugin starting scale to specify whether to include minimized views (e.g. the dbus plugin [here](https://github.com/damianatorrpm/wayfire-plugin_dbus_interface/blob/c705bf1e9dbe54b7ecc3608869db7c53e82bb38d/dbus_interface_backend.cpp#L1095))~~
 - [x] Should minimized view be differentiated in some way? E.g. more faded, different title overlay, etc.
 - [ ] Any view that is focused during scale is unminimzed. This is an issue when using the arrow keys which focuses the views under selection. I see that a related issue came up in #1698 
 - ~~[ ] This currently works by setting the state of the view unminimized for the duration of scale; this is the easiest option to make it show up without extra hacks. Still, it could be an issue whether it is "logically" minimized or not (e.g. if a taskbar is displaying minimized views separately). Also, setting the minimized state automatically adjusts focus ([here](https://github.com/WayfireWM/wayfire/blob/84ec9fce347c330ad04c30036d22d3367e915802/src/view/view.cpp#L397)), which is not really needed here.~~

