### PR TITLE
merging get_snapshot() with take_snapshot()

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2021'07'31;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2021'09'09;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -434,14 +434,10 @@ class view_interface_t : public surface_interface_t
     /**
      * A snapshot of the view is a copy of the view's contents into a
      * framebuffer. It is used to get an image of the view while it is mapped,
-     * and continue displaying it afterwards.
+     * and continue displaying it afterwards. Additionally, return the captured
+     * framebuffter
      */
-    virtual void take_snapshot();
-
-    /**
-     * Get current snapshot framebuffer taken by take_snapshot().
-     */
-    const wf::framebuffer_t& get_snapshot();
+    virtual const wf::framebuffer_t& take_snapshot();
 
     /**
      * View lifetime is managed by reference counting. To take a reference,

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -1173,11 +1173,11 @@ wf::view_transform_block_t::~view_transform_block_t()
     OpenGL::render_end();
 }
 
-void wf::view_interface_t::take_snapshot()
+const wf::framebuffer_t& wf::view_interface_t::take_snapshot()
 {
     if (!is_mapped())
     {
-        return;
+        return view_impl->offscreen_buffer;
     }
 
     auto& offscreen_buffer = view_impl->offscreen_buffer;
@@ -1191,7 +1191,7 @@ void wf::view_interface_t::take_snapshot()
     /* Nothing has changed, the last buffer is still valid */
     if (offscreen_buffer.cached_damage.empty())
     {
-        return;
+        return view_impl->offscreen_buffer;
     }
 
     int scaled_width  = buffer_geometry.width * scale;
@@ -1231,10 +1231,7 @@ void wf::view_interface_t::take_snapshot()
     }
 
     offscreen_buffer.cached_damage.clear();
-}
 
-const wf::framebuffer_t& wf::view_interface_t::get_snapshot()
-{
     return view_impl->offscreen_buffer;
 }
 


### PR DESCRIPTION
Code refactoring to merge `void take_snapshot()` with `const wf::framebuffer_t get_snapshot()` int one function: `const wf::framebuffer_t take_snapshot()`. It's basically the `take_snapshot()` function which also returns the captured buffer.