### PR TITLE
Scale focus bug

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1442,6 +1442,10 @@ class wayfire_scale : public wf::plugin_interface_t
         workspace_changed.disconnect();
         view_geometry_changed.disconnect();
         output->deactivate_plugin(grab_interface);
+
+        wf::stack_order_changed_signal data;
+        data.output = output;
+        wf::get_core().emit_signal("output-stack-order-changed", &data);
     }
 
     /* Utility hook setter */

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -255,6 +255,10 @@ class WayfireSwitcher : public wf::plugin_interface_t
         }
 
         views.clear();
+
+        wf::stack_order_changed_signal data;
+        data.output = output;
+        wf::get_core().emit_signal("output-stack-order-changed", &data);
     }
 
     /* offset from the left or from the right */


### PR DESCRIPTION
Both the Scale and Switcher plugins have a bug that can leave the wrong view focused by the pointer after using them. This means that scrolling the mouse wheel after selecting a view with these plugins can scroll the wrong view.

This fixes emits an `output-stack-order-changed` signal at the end of both of these plugins' animation when closing them, to cause `update_cursor_focus` in `src/core/seat/pointer.cpp` to recalculate which view should have focus.

Fixes #1280