### PR TITLE
core: Implement new_pointer_event suggested_output

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -263,7 +263,8 @@ void wf::compositor_core_impl_t::init()
         input->handle_new_input(&ptr->input_device);
         if (event->suggested_output)
         {
-            wlr_cursor_map_input_to_output(seat->cursor->cursor, &ptr->input_device, event->suggested_output);
+            wlr_cursor_map_input_to_output(seat->cursor->cursor, &ptr->input_device,
+                event->suggested_output);
         }
     });
     vptr_created.connect(&protocols.vptr_manager->events.new_virtual_pointer);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -261,6 +261,10 @@ void wf::compositor_core_impl_t::init()
         auto event = (wlr_virtual_pointer_v1_new_pointer_event*)data;
         auto ptr   = event->new_pointer;
         input->handle_new_input(&ptr->input_device);
+        if (event->suggested_output)
+        {
+            wlr_cursor_map_input_to_output(seat->cursor->cursor, &ptr->input_device, event->suggested_output);
+        }
     });
     vptr_created.connect(&protocols.vptr_manager->events.new_virtual_pointer);
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -261,6 +261,9 @@ void wf::compositor_core_impl_t::init()
         auto event = (wlr_virtual_pointer_v1_new_pointer_event*)data;
         auto ptr   = event->new_pointer;
         input->handle_new_input(&ptr->input_device);
+        /* TODO: Implement checking for suggested_seat, if/when multi-seat is
+         * implemented, or at least verify it's either NULL or equivalent to
+         * `seat` allocated above */
         if (event->suggested_output)
         {
             wlr_cursor_map_input_to_output(seat->cursor->cursor, &ptr->input_device,


### PR DESCRIPTION
    This is a partial implementation, which is enough to get wayvnc
    cursor working on sessions with multiple outputs. It does not
    implement suggested_seat, but Wayfire does not appear to use
    that yet, anyway. Perhaps a simple check could be added to at
    least make sure that suggested_seat is either NULL or the one
    seat that Wayfire creates.

    Partial fix for #1283 , enough to get it basically working, but
    not exactly a full implementation of this functionality.