### PR TITLE
plugin-loader: clarify dlclose() behaviour

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,7 @@ cpp = meson.get_compiler('cpp')
 add_project_link_arguments(['-rdynamic', '-Wl,-E'], language: 'cpp')
 
 project_args = ['-DWLR_USE_UNSTABLE']
-# Needed for dlclose to actually free plugin memory
+# Needed for dlclose to actually free plugin memory on gcc+glibc
 if cpp.has_argument('-fno-gnu-unique')
   project_args += '-fno-gnu-unique'
 endif

--- a/src/output/plugin-loader.cpp
+++ b/src/output/plugin-loader.cpp
@@ -74,7 +74,19 @@ void plugin_manager::destroy_plugin(wayfire_plugin& p)
      * as many times as we opened it.
      *
      * We also need to close the handle after deallocating the plugin, otherwise
-     * we unload its destructor before calling it. */
+     * we unload its destructor before calling it.
+     *
+     * Note however, that dlclose() is merely a "statement of intent" as per
+     * POSIX[1]:
+     * - On glibc[2], this decreases the reference count and potentially unloads
+     *   the binary.
+     * - On musl-libc[3] this is a noop.
+     *
+     * [1]: https://pubs.opengroup.org/onlinepubs/9699919799/functions/dlclose.html
+     * [2]: https://man7.org/linux/man-pages/man3/dlclose.3.html
+     * [3]:
+     * https://wiki.musl-libc.org/functional-differences-from-glibc.html#Unloading-libraries
+     * */
     if (handle)
     {
         dlclose(handle);


### PR DESCRIPTION
This came up twice in conversation on IRC and it's quite verbose to
track it down from scratch every time.

I think it would be useful to have this in the code to easily find and
point at.