### PR TITLE
Add keyboard shortcuts for moving and resizing views

### DIFF
--- a/metadata/move.xml
+++ b/metadata/move.xml
@@ -47,5 +47,25 @@
       <default>-1</default>
       <min>-1</min>
     </option>
+		<option name="up" type="activator">
+			<_short>Move window up</_short>
+			<_long>Move window up</_long>
+			<default>&lt;super&gt; KEY_W</default>
+		</option>
+		<option name="down" type="activator">
+			<_short>Move window down</_short>
+			<_long>Move window down</_long>
+			<default>&lt;super&gt; KEY_S</default>
+		</option>
+		<option name="left" type="activator">
+			<_short>Move window left</_short>
+			<_long>Move window left</_long>
+			<default>&lt;super&gt; KEY_A</default>
+		</option>
+		<option name="right" type="activator">
+			<_short>Move window right</_short>
+			<_long>Move window right</_long>
+			<default>&lt;super&gt; KEY_D</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/resize.xml
+++ b/metadata/resize.xml
@@ -9,5 +9,25 @@
 			<_long>When the specified button is held down, you can drag windows to resize them.</_long>
 			<default>&lt;super&gt; BTN_RIGHT</default>
 		</option>
+		<option name="up" type="activator">
+			<_short>Shrink window vertically</_short>
+			<_long>Shrink window vertically by its bottom edge.</_long>
+			<default>&lt;alt&gt; &lt;shift&gt; KEY_K</default>
+		</option>
+		<option name="down" type="activator">
+			<_short>Grow window vertically</_short>
+			<_long>Grow window vertically by its bottom edge.</_long>
+			<default>&lt;alt&gt; &lt;shift&gt; KEY_J</default>
+		</option>
+		<option name="left" type="activator">
+			<_short>Shrink window horizontally</_short>
+			<_long>Shrink window horizontally by its right edge.</_long>
+			<default>&lt;alt&gt; &lt;shift&gt; KEY_H</default>
+		</option>
+		<option name="right" type="activator">
+			<_short>Grow window horizontally</_short>
+			<_long>Grow window horizontally by its right edge.</_long>
+			<default>&lt;alt&gt; &lt;shift&gt; KEY_L</default>
+		</option>
 	</plugin>
 </wayfire>


### PR DESCRIPTION
For https://github.com/WayfireWM/wayfire/issues/944 and https://github.com/WayfireWM/wayfire/issues/918

I have just hard-coded the amount to 80 but I could add another options for it.