### PR TITLE
Rename output.layout field in example config to output.position

### DIFF
--- a/wayfire.ini
+++ b/wayfire.ini
@@ -25,7 +25,7 @@
 #
 # [output:eDP-1]
 # mode = 1920x1080@60000
-# layout = 0,0
+# position = 0,0
 # transform = normal
 # scale = 1.000000
 #


### PR DESCRIPTION
When trying to set wayfire up, I noticed that the placeholder config has a "layout" field (that seemingly does nothing) instead of "position"