### PR TITLE
scale: allow small mouse movement between click and release

### DIFF
--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -480,13 +480,7 @@ class core_drag_t : public signal_provider_t
     {
         if (view_held_in_place)
         {
-            auto current_offset = to - grab_origin;
-            const int dst_sq    = current_offset.x * current_offset.x +
-                current_offset.y * current_offset.y;
-            const int thresh_sq =
-                params.snap_off_threshold * params.snap_off_threshold;
-
-            if (dst_sq >= thresh_sq)
+            if (distance_to_grab_origin(to) >= (double)params.snap_off_threshold)
             {
                 view_held_in_place = false;
                 for (auto& v : all_views)
@@ -513,6 +507,13 @@ class core_drag_t : public signal_provider_t
         }
 
         update_current_output(to);
+    }
+
+    double distance_to_grab_origin(wf::point_t to) const
+    {
+        auto offset = to - grab_origin;
+        const int dst_sq = offset.x * offset.x + offset.y * offset.y;
+        return std::sqrt(dst_sq);
     }
 
     void handle_input_released()

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -107,6 +107,7 @@ class wayfire_scale : public wf::plugin_interface_t
     bool all_workspaces;
     std::unique_ptr<wf::vswitch::control_bindings_t> workspace_bindings;
 
+    wf::point_t drag_origin;
     wf::shared_data::ref_ptr_t<wf::move_drag::core_drag_t> drag_helper;
 
   public:
@@ -556,9 +557,17 @@ class wayfire_scale : public wf::plugin_interface_t
             opts.snap_off_threshold = 200;
 
             drag_helper->start_drag(last_selected_view, to, opts);
+            drag_origin = to;
         } else if (drag_helper->view)
         {
             drag_helper->handle_motion(to);
+            if (last_selected_view)
+            {
+                wf::point_t drag = to - drag_origin;
+                const int threshold = 20;
+                if (drag.x * drag.x + drag.y * drag.y > threshold * threshold)
+                    last_selected_view = nullptr;
+            }
         }
     }
 

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -148,6 +148,7 @@ class wayfire_scale : public wf::plugin_interface_t
 
         drag_helper->connect_signal("focus-output", &on_drag_output_focus);
         drag_helper->connect_signal("done", &on_drag_done);
+        drag_helper->connect_signal("snap-off", &on_drag_snap_off);
 
         show_title.init(output);
     }
@@ -547,7 +548,7 @@ class wayfire_scale : public wf::plugin_interface_t
 
     void process_motion(wf::point_t to)
     {
-        if (last_selected_view)
+        if (!drag_helper->view && last_selected_view)
         {
             wf::move_drag::drag_options_t opts;
             opts.join_views = true;
@@ -555,7 +556,6 @@ class wayfire_scale : public wf::plugin_interface_t
             opts.snap_off_threshold = 200;
 
             drag_helper->start_drag(last_selected_view, to, opts);
-            last_selected_view = nullptr;
         } else if (drag_helper->view)
         {
             drag_helper->handle_motion(to);
@@ -1317,6 +1317,11 @@ class wayfire_scale : public wf::plugin_interface_t
 
             wf::move_drag::adjust_view_on_output(ev);
         }
+    };
+
+    wf::signal_connection_t on_drag_snap_off = [=] (auto data)
+    {
+        last_selected_view = nullptr;
     };
 
     /* Activate and start scale animation */

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -107,7 +107,6 @@ class wayfire_scale : public wf::plugin_interface_t
     bool all_workspaces;
     std::unique_ptr<wf::vswitch::control_bindings_t> workspace_bindings;
 
-    wf::point_t drag_origin;
     wf::shared_data::ref_ptr_t<wf::move_drag::core_drag_t> drag_helper;
 
   public:
@@ -557,16 +556,16 @@ class wayfire_scale : public wf::plugin_interface_t
             opts.snap_off_threshold = 200;
 
             drag_helper->start_drag(last_selected_view, to, opts);
-            drag_origin = to;
         } else if (drag_helper->view)
         {
             drag_helper->handle_motion(to);
             if (last_selected_view)
             {
-                wf::point_t drag = to - drag_origin;
-                const int threshold = 20;
-                if (drag.x * drag.x + drag.y * drag.y > threshold * threshold)
+                const double threshold = 20.0;
+                if (drag_helper->distance_to_grab_origin(to) > threshold)
+                {
                     last_selected_view = nullptr;
+                }
             }
         }
     }


### PR DESCRIPTION
Before, any movement between click and release would reset 
last_selected_view, resulting in BTN_LEFT not ending scale.
Now this only happens after the drag snap-off is triggered, making it
less likely to happen accidentally.