### PR TITLE
split surface and output

### DIFF
--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -268,7 +268,7 @@ class wayfire_blur : public wf::plugin_interface_t
                 return false;
             }
 
-            auto view = wf::get_core().get_cursor_focus_view();
+            auto view = wf::get_core().get_cursor_focus().view();
             if (!view)
             {
                 return false;

--- a/plugins/common/wayfire/plugins/common/preview-indication.hpp
+++ b/plugins/common/wayfire/plugins/common/preview-indication.hpp
@@ -108,7 +108,7 @@ class preview_indication_view_t : public wf::color_rect_view_t
     void update_animation()
     {
         wf::geometry_t current = animation;
-        if (current != geometry)
+        if (current != get_wm_geometry())
         {
             set_geometry(current);
         }

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -67,7 +67,7 @@ class simple_decoration_surface : public wf::surface_interface_t,
 
     simple_decoration_surface(wayfire_view view) :
         theme{},
-        layout{theme, [=] (wlr_box box) {this->damage_surface_box(box); }}
+        layout{theme, [=] (wlr_box box) { emit_damage({box}); }}
     {
         this->view = view;
         view->connect_signal("title-changed", &title_set);

--- a/plugins/grid/wayfire/plugins/crossfade.hpp
+++ b/plugins/grid/wayfire/plugins/crossfade.hpp
@@ -37,18 +37,13 @@ class crossfade_t : public wf::view_2D
         OpenGL::render_end();
 
         auto og = view->get_output_geometry();
-        for (auto& surface : view->enumerate_surfaces(wf::origin(og)))
+        for (auto& surface : view->enumerate_surfaces())
         {
-            wf::region_t damage = wf::geometry_t{
-                surface.position.x,
-                surface.position.y,
-                surface.surface->get_size().width,
-                surface.surface->get_size().height
-            };
-
+            auto pos = wf::origin(og) + surface.position;
+            wf::region_t damage =
+                wf::construct_box(pos, surface.surface->output().get_size());
             damage &= original_buffer.geometry;
-            surface.surface->simple_render(original_buffer,
-                surface.position.x, surface.position.y, damage);
+            surface.surface->output().simple_render(original_buffer, pos, damage);
         }
     }
 

--- a/plugins/scale/scale-title-overlay.cpp
+++ b/plugins/scale/scale-title-overlay.cpp
@@ -529,11 +529,11 @@ void scale_show_title_t::update_title_overlay_mouse()
     if (interact)
     {
         /* we can use normal focus tracking */
-        v = wf::get_core().get_cursor_focus_view();
+        v = wf::get_core().get_cursor_focus().view();
     } else
     {
         auto& core = wf::get_core();
-        v = core.get_view_at(core.get_cursor_position());
+        v = core.get_surface_at(core.get_cursor_position()).view();
     }
 
     if (v)

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -485,7 +485,7 @@ class wayfire_scale : public wf::plugin_interface_t
 
         if (state == WLR_BUTTON_PRESSED)
         {
-            auto view = wf::get_core().get_view_at(input_position);
+            auto view = wf::get_core().get_surface_at(input_position).view();
             if (view && should_scale_view(view))
             {
                 // Mark the view as the target of the next input release operation
@@ -503,7 +503,7 @@ class wayfire_scale : public wf::plugin_interface_t
             drag_helper->handle_input_released();
         }
 
-        auto view = wf::get_core().get_view_at(input_position);
+        auto view = wf::get_core().get_surface_at(input_position).view();
         if (!view || (last_selected_view != view))
         {
             last_selected_view = nullptr;

--- a/plugins/single_plugins/alpha.cpp
+++ b/plugins/single_plugins/alpha.cpp
@@ -87,7 +87,7 @@ class wayfire_alpha : public wf::plugin_interface_t
 
         output->deactivate_plugin(grab_interface);
 
-        auto view = wf::get_core().get_cursor_focus_view();
+        auto view = wf::get_core().get_cursor_focus().view();
         if (!view)
         {
             return false;

--- a/plugins/single_plugins/extra-gestures.cpp
+++ b/plugins/single_plugins/extra-gestures.cpp
@@ -58,7 +58,7 @@ class extra_gestures_plugin_t : public plugin_interface_t
             return;
         }
 
-        auto view = core.get_view_at({center.x, center.y});
+        auto view = core.get_surface_at({center.x, center.y}).view();
         if (view && (view->role == VIEW_ROLE_TOPLEVEL))
         {
             action(view);

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -119,7 +119,7 @@ class wayfire_move : public wf::plugin_interface_t
         {
             is_using_touch     = false;
             was_client_request = false;
-            auto view = wf::get_core().get_cursor_focus_view();
+            auto view = wf::get_core().get_cursor_focus().view();
 
             if (view && (view->role != wf::VIEW_ROLE_DESKTOP_ENVIRONMENT))
             {

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -32,7 +32,7 @@ class wayfire_resize : public wf::plugin_interface_t
 
         activate_binding = [=] (auto)
         {
-            auto view = wf::get_core().get_cursor_focus_view();
+            auto view = wf::get_core().get_cursor_focus().view();
             if (view)
             {
                 is_using_touch     = false;

--- a/plugins/single_plugins/wrot.cpp
+++ b/plugins/single_plugins/wrot.cpp
@@ -62,7 +62,7 @@ class wf_wrot : public wf::plugin_interface_t
             return false;
         }
 
-        current_view = wf::get_core().get_cursor_focus_view();
+        current_view = wf::get_core().get_cursor_focus().view();
         if (!current_view || (current_view->role != wf::VIEW_ROLE_TOPLEVEL))
         {
             output->deactivate_plugin(grab_interface);
@@ -190,7 +190,7 @@ class wf_wrot : public wf::plugin_interface_t
                 return false;
             }
 
-            current_view = wf::get_core().get_cursor_focus_view();
+            current_view = wf::get_core().get_cursor_focus().view();
             if (!current_view || (current_view->role != wf::VIEW_ROLE_TOPLEVEL))
             {
                 output->deactivate_plugin(grab_interface);

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -203,9 +203,8 @@ class tile_plugin_t : public wf::plugin_interface_t
     /** Check whether the current pointer focus is tiled view */
     bool has_tiled_focus()
     {
-        auto focus = wf::get_core().get_cursor_focus_view();
-
-        return focus && tile::view_node_t::get_node(focus);
+        auto focus = wf::get_core().get_cursor_focus();
+        return focus && tile::view_node_t::get_node(focus.view());
     }
 
     template<class Controller>

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -60,7 +60,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
         wayfire_view view;
         if (source == wf::activator_source_t::BUTTONBINDING)
         {
-            view = wf::get_core().get_cursor_focus_view();
+            view = wf::get_core().get_cursor_focus().view();
         }
 
         view = output->get_active_view();

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -58,9 +58,51 @@ enum class compositor_state_t
     SHUTDOWN,
 };
 
+/**
+ * Represents a focused view together with its surface which has the input
+ * focus (or can receive it).
+ */
+struct focused_view_t
+{
+    /**
+     * Initialize a focused view with a surface focused.
+     *
+     * Either both parameters are null, or none of them are.
+     */
+    focused_view_t(
+        wayfire_view view = nullptr, wf::surface_interface_t *surface = nullptr);
+
+    /**
+     * Convert to bool, e.g. check whether the view/surface combination is null.
+     */
+    operator bool() const;
+
+    inline wayfire_view view() const
+    {
+        return _view;
+    }
+
+    inline wf::surface_interface_t *surface() const
+    {
+        return _surface;
+    }
+
+  private:
+    wayfire_view _view;
+    wf::surface_interface_t *_surface;
+};
+
+bool operator ==(const focused_view_t& a, const focused_view_t& b);
+bool operator !=(const focused_view_t& a, const focused_view_t& b);
+
 class compositor_core_t : public wf::object_base_t
 {
   public:
+    compositor_core_t(const compositor_core_t&) = delete;
+    compositor_core_t(compositor_core_t&&) = delete;
+    compositor_core_t& operator =(const compositor_core_t&) = delete;
+    compositor_core_t& operator =(compositor_core_t&&) = delete;
+
     /**
      * The current configuration used by Wayfire
      */
@@ -181,26 +223,16 @@ class compositor_core_t : public wf::object_base_t
     /**
      * @return The surface which has the cursor focus, or null if none.
      */
-    virtual wf::surface_interface_t *get_cursor_focus() = 0;
+    virtual focused_view_t get_cursor_focus() = 0;
 
     /**
      * @return The surface which has touch focus, or null if none.
      */
-    virtual wf::surface_interface_t *get_touch_focus() = 0;
-
+    virtual focused_view_t get_touch_focus() = 0;
     /**
      * @return The surface under the given global coordinates, or null if none.
      */
-    virtual wf::surface_interface_t *get_surface_at(wf::pointf_t point) = 0;
-
-    /** @return The view whose surface is cursor focus */
-    wayfire_view get_cursor_focus_view();
-    /** @return The view whose surface is touch focus */
-    wayfire_view get_touch_focus_view();
-    /**
-     * @return The view whose surface is under the given global coordinates,
-     *  or null if none */
-    wayfire_view get_view_at(wf::pointf_t point);
+    virtual focused_view_t get_surface_at(wf::pointf_t point) = 0;
 
     /**
      * @return A list of all currently attached input devices.

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -26,6 +26,8 @@ using geometry_t = wlr_box;
 
 point_t origin(const geometry_t& geometry);
 dimensions_t dimensions(const geometry_t& geometry);
+geometry_t construct_box(
+    const wf::point_t& origin, const wf::dimensions_t& dimensions);
 
 /* Returns the intersection of the two boxes, if the boxes don't intersect,
  * the resulting geometry has undefined (x,y) and width == height == 0 */

--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -200,13 +200,15 @@ class surface_interface_t : public wf::object_base_t
      * @param surface_origin The coordinates of the top-left corner of the
      * surface.
      *
+     * @param mapped_only Whether to include only mapped surfaces in the result.
+     *
      * @return a list of each mapped surface in the surface tree, including the
      * surface itself.
      *
      * The surfaces should be ordered from the topmost to the bottom-most one.
      */
     virtual std::vector<surface_iterator_t> enumerate_surfaces(
-        wf::point_t surface_origin = {0, 0});
+        wf::point_t surface_origin = {0, 0}, bool mapped_only = false);
 
     /**
      * Notify the surface that it is visible or no longer visible on a

--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -144,6 +144,85 @@ class input_surface_t
 };
 
 /**
+ * The output side of a surface.
+ * It is responsible for providing the content of the surface, redrawing,
+ * scaling, etc.
+ */
+class output_surface_t
+{
+  protected:
+    output_surface_t(const output_surface_t&) = delete;
+    output_surface_t(output_surface_t&&) = delete;
+    output_surface_t& operator =(const output_surface_t&) = delete;
+    output_surface_t& operator =(output_surface_t&&) = delete;
+    output_surface_t() = default;
+
+  public:
+    virtual ~output_surface_t() = default;
+
+    /**
+     * Get the position of the surface relative to its parent surface.
+     */
+    virtual wf::point_t get_offset() = 0;
+
+    /**
+     * Get the surface size.
+     */
+    virtual wf::dimensions_t get_size() const = 0;
+
+    /**
+     * The surface can start redrawing for the next frame.
+     * Implementations backed by a wlr_surface typically send a
+     * wl_surface.frame event to the client, most other implementations
+     * likely do not need to do anything here.
+     *
+     * @param frame_end The time when the last frame finished rendering.
+     */
+    virtual void schedule_redraw(const timespec& frame_end) = 0;
+
+    /**
+     * Notify the surface that it is visible or no longer visible on a
+     * specific output. This is hint to the surface, so that it can use
+     * a rendering scale fitting the outputs it is visible on.
+     *
+     * Note that a surface may receive visibility on an output multiple times,
+     * for example if multiple views display it on the same output. In this
+     * case the number of visibility events is counted, and the surface stops
+     * being visible when the counter reaches 0.
+     *
+     * Another consideration is that the outputs that a surface is visible on
+     * are not automatically inherited, so implementations should initially
+     * populate the list of visible outputs manually, if they care about this.
+     *
+     * @param output The output on which the surface is now visible or no
+     *   longer visible.
+     * @param is_visible Whether the view is visible on the output or not.
+     */
+    virtual void set_visible_on_output(wf::output_t *output, bool is_visible) = 0;
+
+    /**
+     * Get the opaque region of the surface, in surface-local coordinates.
+     *
+     * It can be used by renderers for optimization purposes, providing an
+     * empty opaque region is a safe default.
+     */
+    virtual wf::region_t get_opaque_region() = 0;
+
+    /**
+     * Render the surface contents on the provided framebuffer.
+     *
+     * @param fb The target framebuffer.
+     * @param pos The positon of the surface in the same coordinate system as
+     *   the framebuffer's geometry.
+     * @param damage The damaged region of the surface, in the same coordinate
+     *   system as the framebuffer's geometry. Nothing should be drawn outside
+     *   of the damaged region.
+     */
+    virtual void simple_render(const wf::framebuffer_t& fb, wf::point_t pos,
+        const wf::region_t& damage) = 0;
+};
+
+/**
  * surface_interface_t is the base class for everything that can be displayed
  * on the screen. It is the closest thing there is in Wayfire to a Window in X11.
  */
@@ -158,19 +237,9 @@ class surface_interface_t : public wf::object_base_t
     surface_interface_t& operator =(surface_interface_t&&) = delete;
 
     /**
-     * Check whether the surface is mapped. Mapped surfaces are "alive", i.e
-     * they are rendered, can receive input, etc.
+     * Get the immediate parent of this surface.
      *
-     * Note an unmapped surface may be temporarily rendered, for ex. when
-     * using a close animation.
-     *
-     * @return true if the surface is mapped and false otherwise.
-     */
-    virtual bool is_mapped() const = 0;
-
-    /**
-     * Get the parent of the surface in the surface tree, or null if there is
-     * no parent for the surface.
+     * @return The parent or null, if this is the topmost surface in the hierarchy.
      */
     surface_interface_t *get_parent();
 
@@ -208,51 +277,44 @@ class surface_interface_t : public wf::object_base_t
      * The surfaces should be ordered from the topmost to the bottom-most one.
      */
     virtual std::vector<surface_iterator_t> enumerate_surfaces(
-        wf::point_t surface_origin = {0, 0}, bool mapped_only = false);
+        bool mapped_only = false);
 
     /**
-     * Notify the surface that it is visible or no longer visible on a
-     * specific output. This is hint to the surface, so that it can use
-     * a rendering scale fitting the outputs it is visible on.
+     * Get the associated wlr_surface.
+     * By default, a surface does not have an associated wlr_surface.
      *
-     * Note that a surface may receive visibility on an output multiple times,
-     * for example if multiple views display it on the same output. In this
-     * case the number of visibility events is counted, and the surface stops
-     * being visible when the counter reaches 0.
-     *
-     * Another consideration is that the outputs that a surface is visible on
-     * are not automatically inherited, so implementations should initially
-     * populate the list of visible outputs manually, if they care about this.
-     *
-     * @param output The output on which the surface is now visible or no
-     *   longer visible.
-     * @param is_visible Whether the view is visible on the output or not.
+     * @return the wlr_surface this surface was created for, or nullptr, if
+     *   there is no such wlr_surface.
      */
-    virtual void set_visible_on_output(wf::output_t *output, bool is_visible);
-
-    /** @return The offset of this surface relative to its parent surface.  */
-    virtual wf::point_t get_offset() = 0;
-
-    /** @return The surface dimensions */
-    virtual wf::dimensions_t get_size() const = 0;
+    virtual wlr_surface *get_wlr_surface();
 
     /**
-     * Send wl_surface.frame event. Surfaces which aren't backed by a
-     * wlr_surface don't need to do anything here.
+     * Check whether the surface is mapped. Mapped surfaces are "alive", i.e
+     * they are rendered, can receive input, etc.
      *
-     * @param frame_end The time when the frame ended.
+     * Note an unmapped surface may be temporarily rendered, for ex. when
+     * using a close animation.
+     *
+     * @return true if the surface is mapped and false otherwise.
      */
-    virtual void send_frame_done(const timespec& frame_end);
+    virtual bool is_mapped() const = 0;
 
     /**
-     * Get the opaque region of the surface relative to the given point.
-     *
-     * This is just a hint, so surface implementations don't have to implement
-     * this function.
-     *
-     * @param origin The coordinates of the upper-left corner of the surface.
+     * Get the input interface of this surface.
      */
-    virtual wf::region_t get_opaque_region(wf::point_t origin);
+    virtual input_surface_t& input() = 0;
+
+    /**
+     * Get the output interface of this surface.
+     */
+    virtual output_surface_t& output() = 0;
+
+    /**
+     * Private data for surface_interface_t, used for the implementation of
+     * provided functions
+     */
+    class impl;
+    std::unique_ptr<impl> priv;
 
     /**
      * Request that the opaque region is shrunk by a certain amount of pixels
@@ -265,39 +327,6 @@ class surface_interface_t : public wf::object_base_t
      */
     static void set_opaque_shrink_constraint(
         std::string constraint_name, int value);
-
-    /**
-     * @return the wl_client associated with this surface, or null if the
-     *   surface doesn't have a backing wlr_surface.
-     */
-    virtual wl_client *get_client();
-
-    /**
-     * @return the wlr_surface associated with this surface, or null if no
-     *   the surface doesn't have a backing wlr_surface. */
-    virtual wlr_surface *get_wlr_surface();
-
-    /**
-     * Render the surface, without applying any transformations.
-     *
-     * @param fb The target framebuffer.
-     * @param x The x coordinate of the surface in the same coordinate system
-     *   as the framebuffer's geometry.
-     * @param y The y coordinate of the surface the same coordinate system
-     *   as the framebuffer's geometry.
-     * @param damage The damaged region of the surface, in the same coordinate
-     *   system as the framebuffer's geometry. Nothing should be drawn outside
-     *   of the damaged region.
-     */
-    virtual void simple_render(const wf::framebuffer_t& fb, int x, int y,
-        const wf::region_t& damage) = 0;
-
-    virtual input_surface_t& input() = 0;
-
-    /** Private data for surface_interface_t, used for the implementation of
-     * provided functions */
-    class impl;
-    std::unique_ptr<impl> priv;
 
   protected:
     /** Construct a new surface. */

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -98,7 +98,12 @@ class view_interface_t : public surface_interface_t
      * If the new output is different from the previous, the view will be
      * removed from the layer it was on the old output.
      */
-    virtual void set_output(wf::output_t *new_output) override;
+    virtual void set_output(wf::output_t *new_output);
+
+    /**
+     * Get the view's output.
+     */
+    virtual wf::output_t *get_output();
 
     /** Move the view to the given output-local coordinates.  */
     virtual void move(int x, int y) = 0;
@@ -496,21 +501,11 @@ class view_interface_t : public surface_interface_t
      */
     virtual void deinitialize();
 
-    /** get_offset() is not valid for views */
-    virtual wf::point_t get_offset() override
-    {
-        return {0, 0};
-    }
-
-    /** Damage the given box, in surface-local coordinates */
-    virtual void damage_surface_box(const wlr_box& box) override;
-
     /**
      * @return the bounding box of the view before transformers,
      *  in output-local coordinates
      */
     virtual wf::geometry_t get_untransformed_bounding_box();
-
 
     /**
      * Called when the reference count reaches 0.
@@ -544,6 +539,9 @@ class view_interface_t : public surface_interface_t
      * signal is mandatory for all views.
      */
     virtual void emit_view_pre_unmap();
+
+  private:
+    wf::point_t get_offset() final;
 };
 
 wayfire_view wl_surface_to_wayfire_view(wl_resource *surface);

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -539,9 +539,6 @@ class view_interface_t : public surface_interface_t
      * signal is mandatory for all views.
      */
     virtual void emit_view_pre_unmap();
-
-  private:
-    wf::point_t get_offset() final;
 };
 
 wayfire_view wl_surface_to_wayfire_view(wl_resource *surface);

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -73,9 +73,9 @@ class compositor_core_impl_t : public compositor_core_t
     wf::pointf_t get_touch_position(int id) override;
     const wf::touch::gesture_state_t& get_touch_state() override;
 
-    wf::surface_interface_t *get_cursor_focus() override;
-    wf::surface_interface_t *get_touch_focus() override;
-    wf::surface_interface_t *get_surface_at(wf::pointf_t point) override;
+    wf::focused_view_t get_cursor_focus() override;
+    wf::focused_view_t get_touch_focus() override;
+    wf::focused_view_t get_surface_at(wf::pointf_t point) override;
 
     void add_touch_gesture(
         nonstd::observer_ptr<wf::touch::gesture_t> gesture) override;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -424,21 +424,12 @@ const wf::touch::gesture_state_t& wf::compositor_core_impl_t::get_touch_state()
     return seat->touch->get_state();
 }
 
-wf::surface_interface_t*wf::compositor_core_impl_t::get_cursor_focus()
+wf::focused_view_t wf::compositor_core_impl_t::get_cursor_focus()
 {
     return seat->lpointer->get_focus();
 }
 
-wayfire_view wf::compositor_core_t::get_cursor_focus_view()
-{
-    auto focus = get_cursor_focus();
-    auto view  = dynamic_cast<wf::view_interface_t*>(
-        focus ? focus->get_main_surface() : nullptr);
-
-    return view ? view->self() : nullptr;
-}
-
-wf::surface_interface_t*wf::compositor_core_impl_t::get_surface_at(
+wf::focused_view_t wf::compositor_core_impl_t::get_surface_at(
     wf::pointf_t point)
 {
     wf::pointf_t local = {0.0, 0.0};
@@ -446,31 +437,9 @@ wf::surface_interface_t*wf::compositor_core_impl_t::get_surface_at(
     return input->input_surface_at(point, local);
 }
 
-wayfire_view wf::compositor_core_t::get_view_at(wf::pointf_t point)
-{
-    auto surface = get_surface_at(point);
-    if (!surface)
-    {
-        return nullptr;
-    }
-
-    auto view = dynamic_cast<wf::view_interface_t*>(surface->get_main_surface());
-
-    return view ? view->self() : nullptr;
-}
-
-wf::surface_interface_t*wf::compositor_core_impl_t::get_touch_focus()
+wf::focused_view_t wf::compositor_core_impl_t::get_touch_focus()
 {
     return seat->touch->get_focus();
-}
-
-wayfire_view wf::compositor_core_t::get_touch_focus_view()
-{
-    auto focus = get_touch_focus();
-    auto view  = dynamic_cast<wf::view_interface_t*>(
-        focus ? focus->get_main_surface() : nullptr);
-
-    return view ? view->self() : nullptr;
 }
 
 void wf::compositor_core_impl_t::add_touch_gesture(
@@ -917,6 +886,29 @@ wf::compositor_core_t& wf::get_core()
 wf::compositor_core_impl_t& wf::get_core_impl()
 {
     return wf::compositor_core_impl_t::get();
+}
+
+wf::focused_view_t::focused_view_t(
+    wayfire_view view, wf::surface_interface_t *surface)
+{
+    this->_view    = view;
+    this->_surface = surface;
+    assert((view && surface) || (!view && !surface));
+}
+
+bool wf::operator ==(const focused_view_t& a, const focused_view_t& b)
+{
+    return (a.view() == b.view()) && (a.surface() == b.surface());
+}
+
+bool wf::operator !=(const focused_view_t& a, const focused_view_t& b)
+{
+    return !(a == b);
+}
+
+wf::focused_view_t::operator bool() const
+{
+    return _view != nullptr;
 }
 
 // TODO: move this to a better location

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -229,7 +229,9 @@ bool wf::input_manager_t::input_grabbed()
 
 bool wf::input_manager_t::can_focus_surface(wf::focused_view_t surface)
 {
-    if (exclusive_client && (surface.surface()->get_client() != exclusive_client))
+    auto wlr_surf = surface.surface()->get_wlr_surface();
+    auto client   = wlr_surf ? wl_resource_get_client(wlr_surf->resource) : nullptr;
+    if (exclusive_client && (client != exclusive_client))
     {
         /* We have exclusive focus surface, for ex. a lockscreen.
          * The only kind of things we can focus are OSKs and similar */

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -30,6 +30,11 @@ class input_manager_t
     wf::signal_connection_t config_updated;
     wf::signal_connection_t output_added;
 
+    input_manager_t(const input_manager_t&) = delete;
+    input_manager_t(input_manager_t&&) = delete;
+    input_manager_t& operator =(const input_manager_t&) = delete;
+    input_manager_t& operator =(input_manager_t&&) = delete;
+
   public:
     /**
      * Locked mods are stored globally because the keyboard devices might be
@@ -74,11 +79,11 @@ class input_manager_t
      * Check if the given surface is focuseable at the moment.
      * This depends on things like exclusive clients, etc.
      */
-    bool can_focus_surface(wf::surface_interface_t *surface);
+    bool can_focus_surface(wf::focused_view_t surface);
 
     // returns the surface under the given global coordinates
     // if no such surface (return NULL), lx and ly are undefined
-    wf::surface_interface_t *input_surface_at(wf::pointf_t global,
+    wf::focused_view_t input_surface_at(wf::pointf_t global,
         wf::pointf_t& local);
 
     /** @return the bindings for the active output */

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -173,9 +173,10 @@ wf::pointf_t wf::pointer_t::get_absolute_position_from_relative(
     wf::pointf_t relative)
 {
     auto output_geometry = cursor_focus.view()->get_output_geometry();
-    wf::point_t origin   = {output_geometry.x, output_geometry.y};
+    relative.x += output_geometry.x;
+    relative.y += output_geometry.y;
 
-    for (auto& surf : cursor_focus.view()->enumerate_surfaces(origin))
+    for (auto& surf : cursor_focus.view()->enumerate_surfaces())
     {
         if (surf.surface == this->cursor_focus.surface())
         {

--- a/src/core/seat/pointer.hpp
+++ b/src/core/seat/pointer.hpp
@@ -40,7 +40,7 @@ class pointer_t
     void set_enable_focus(bool enabled = true);
 
     /** Get the currenntlly set cursor focus */
-    wf::surface_interface_t *get_focus() const;
+    wf::focused_view_t get_focus() const;
 
     /** Handle events coming from the input devices */
     void handle_pointer_axis(wlr_event_pointer_axis *ev,
@@ -94,7 +94,7 @@ class pointer_t
     wf::signal_connection_t on_views_updated;
 
     /** The surface which currently has cursor focus */
-    wf::surface_interface_t *cursor_focus = nullptr;
+    wf::focused_view_t cursor_focus = {nullptr, nullptr};
     /** Whether focusing is enabled */
     int focus_enabled_count = 1;
     bool focus_enabled() const;
@@ -106,7 +106,7 @@ class pointer_t
      * @param local   The coordinates of the pointer relative to surface.
      *                No meaning if the surface is nullptr
      */
-    void update_cursor_focus(wf::surface_interface_t *surface, wf::pointf_t local);
+    void update_cursor_focus(wf::focused_view_t surface, wf::pointf_t local);
 
     /** Number of currently-pressed mouse buttons */
     int count_pressed_buttons = 0;
@@ -120,11 +120,11 @@ class pointer_t
     void check_implicit_grab();
 
     /** Implicitly grabbed surface when a button is being held */
-    wf::surface_interface_t *grabbed_surface = nullptr;
+    wf::focused_view_t grabbed_surface;
 
     /** Set the currently grabbed surface
      * @param surface The surface to be grabbed, or nullptr to reset grab */
-    void grab_surface(wf::surface_interface_t *surface);
+    void grab_surface(wf::focused_view_t focus);
 
     /** Send a button event to the currently active receiver, i.e to the
      * active input grab(if any), or to the focused surface */

--- a/src/core/seat/seat.hpp
+++ b/src/core/seat/seat.hpp
@@ -23,7 +23,6 @@ struct drag_icon_t : public wlr_child_surface_base_t
 
     /** Called each time the DnD icon position changes. */
     void damage();
-    void damage_surface_box(const wlr_box& rect) override;
 
     /* Force map without receiving a wlroots event */
     void force_map()
@@ -34,6 +33,8 @@ struct drag_icon_t : public wlr_child_surface_base_t
   private:
     /** Last icon box. */
     wf::geometry_t last_box = {0, 0, 0, 0};
+
+    wf::signal_connection_t on_self_damage;
 
     /** Damage surface box in global coordinates. */
     void damage_surface_box_global(const wlr_box& rect);
@@ -102,7 +103,7 @@ class seat_t
      * Make sure that the surface can receive input focus.
      * If it is a xwayland surface, it will be restacked to the top.
      */
-    void ensure_input_surface(wf::surface_interface_t *surface);
+    void ensure_input_surface(wf::focused_view_t surface);
 
   private:
     wf::wl_listener_wrapper request_start_drag, start_drag, end_drag,
@@ -130,7 +131,7 @@ class seat_t
 }
 
 /** Convert the given point to a surface-local point */
-wf::pointf_t get_surface_relative_coords(wf::surface_interface_t *surface,
+wf::pointf_t get_surface_relative_coords(wf::focused_view_t surface,
     const wf::pointf_t& point);
 
 #endif /* end of include guard: SEAT_HPP */

--- a/src/core/seat/tablet.hpp
+++ b/src/core/seat/tablet.hpp
@@ -25,7 +25,7 @@ struct tablet_tool_t
     void update_tool_position();
 
     /** Set the proximity surface */
-    void set_focus(wf::surface_interface_t *surface);
+    void set_focus(wf::focused_view_t surface);
 
     /**
      * Send the axis updates directly.
@@ -54,9 +54,9 @@ struct tablet_tool_t
     wlr_tablet_v2_tablet *tablet_v2;
 
     /** Surface where the tool is in */
-    wf::surface_interface_t *proximity_surface = nullptr;
+    wf::focused_view_t proximity_surface;
     /** Surface where the tool was grabbed */
-    wf::surface_interface_t *grabbed_surface = nullptr;
+    wf::focused_view_t grabbed_surface;
 
     double tilt_x = 0.0;
     double tilt_y = 0.0;

--- a/src/core/seat/touch.hpp
+++ b/src/core/seat/touch.hpp
@@ -14,7 +14,7 @@ namespace wf
 {
 struct plugin_grab_interface_t;
 using input_surface_selector_t =
-    std::function<wf::surface_interface_t*(const wf::pointf_t&, wf::pointf_t&)>;
+    std::function<wf::focused_view_t(const wf::pointf_t&, wf::pointf_t&)>;
 
 /**
  * Responsible for managing touch gestures and forwarding events to clients.
@@ -35,7 +35,7 @@ class touch_interface_t
     const touch::gesture_state_t& get_state() const;
 
     /** Get the focused surface */
-    wf::surface_interface_t *get_focus() const;
+    wf::focused_view_t get_focus() const;
 
     /**
      * Set the active grab interface.
@@ -69,15 +69,15 @@ class touch_interface_t
     void handle_touch_up(int32_t id, uint32_t time,
         input_event_processing_mode_t mode);
 
-    void set_touch_focus(wf::surface_interface_t *surface,
+    void set_touch_focus(wf::focused_view_t surface,
         int32_t id, uint32_t time, wf::pointf_t current);
 
     touch::gesture_state_t finger_state;
 
     /** Pressed a finger on a surface and dragging outside of it now */
-    wf::surface_interface_t *grabbed_surface = nullptr;
-    std::map<int32_t, wf::surface_interface_t*> focus;
-    void start_touch_down_grab(wf::surface_interface_t *surface);
+    wf::focused_view_t grabbed_surface;
+    std::map<int32_t, wf::focused_view_t> focus;
+    void start_touch_down_grab(wf::focused_view_t surface);
     void end_touch_down_grab();
 
     void update_gestures(const wf::touch::gesture_event_t& event);

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -107,7 +107,7 @@ void wayfire_focus::init()
     on_wm_focus_request.set_callback([=] (wf::signal_data_t *data)
     {
         auto ev = static_cast<wm_focus_request*>(data);
-        check_focus_surface(ev->surface);
+        check_focus_surface(ev->focus);
     });
     output->connect_signal("wm-focus-request", &on_wm_focus_request);
 
@@ -155,26 +155,23 @@ void wayfire_focus::init()
     wf::get_core().add_touch_gesture(tap_gesture);
 }
 
-bool wayfire_focus::check_focus_surface(wf::surface_interface_t *focus)
+bool wayfire_focus::check_focus_surface(wf::focused_view_t focus)
 {
     /* Find the main view */
-    auto main_surface = focus ? focus->get_main_surface() : nullptr;
-    auto view = dynamic_cast<wf::view_interface_t*>(main_surface);
-
-    if (!view || !view->is_mapped() ||
+    if (!focus || !focus.view()->is_mapped() ||
         !output->can_activate_plugin(grab_interface->capabilities))
     {
         return false;
     }
 
-    auto target_wo = view->get_output();
+    auto target_wo = focus.view()->get_output();
     auto old_focus = target_wo->get_active_view();
-    if (view->get_keyboard_focus_surface())
+    if (focus.view()->get_keyboard_focus_surface())
     {
-        target_wo->focus_view(view->self(), true);
+        target_wo->focus_view(focus.view(), true);
     } else
     {
-        target_wo->workspace->bring_to_front(view);
+        target_wo->workspace->bring_to_front(focus.view());
     }
 
     return target_wo->get_active_view() != old_focus;

--- a/src/core/wm.hpp
+++ b/src/core/wm.hpp
@@ -9,7 +9,7 @@
 
 struct wm_focus_request : public wf::signal_data_t
 {
-    wf::surface_interface_t *surface;
+    wf::focused_view_t focus;
 };
 
 class wayfire_close : public wf::plugin_interface_t
@@ -29,7 +29,7 @@ class wayfire_focus : public wf::plugin_interface_t
     std::unique_ptr<wf::touch::gesture_t> tap_gesture;
 
     // @return True if the focus has changed
-    bool check_focus_surface(wf::surface_interface_t *surface);
+    bool check_focus_surface(wf::focused_view_t surface);
 
     wf::option_wrapper_t<bool> focus_modifiers{"core/focus_button_with_modifiers"};
     wf::option_wrapper_t<bool> pass_btns{"core/focus_buttons_passthrough"};

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -160,3 +160,11 @@ wf::geometry_t wf::clamp(wf::geometry_t window, wf::geometry_t output)
 
     return window;
 }
+
+wf::geometry_t wf::construct_box(
+    const wf::point_t& origin, const wf::dimensions_t& dimensions)
+{
+    return {
+        origin.x, origin.y, dimensions.width, dimensions.height
+    };
+}

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -1209,8 +1209,6 @@ class wf::render_manager::impl
             return;
         }
 
-        drag_icon->set_output(output);
-
         auto offset = drag_icon->get_offset();
         auto og     = output->get_layout_geometry();
         offset.x -= og.x;
@@ -1219,18 +1217,6 @@ class wf::render_manager::impl
         for (auto& child : drag_icon->enumerate_surfaces(offset))
         {
             schedule_surface(repaint, child.surface, child.position);
-        }
-    }
-
-    /**
-     * Reset the drag icon state for this output
-     */
-    void unschedule_drag_icon()
-    {
-        auto& drag_icon = wf::get_core_impl().seat->drag_icon;
-        if (drag_icon && drag_icon->is_mapped())
-        {
-            drag_icon->set_output(nullptr);
         }
     }
 
@@ -1410,7 +1396,6 @@ class wf::render_manager::impl
 
         render_views(repaint);
 
-        unschedule_drag_icon();
         {
             stream_signal_t data(stream.ws, repaint.ws_damage, repaint.fb);
             output->render->emit_signal("workspace-stream-post", &data);

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -1197,7 +1197,7 @@ class wf::render_manager::impl
             wf::point_t current_output = wf::origin(output->get_layout_geometry());
             auto origin = wf::origin(xw_dnd_icon->get_output_geometry()) +
                 dnd_output + -current_output;
-            for (auto& child : xw_dnd_icon->enumerate_surfaces(origin))
+            for (auto& child : xw_dnd_icon->enumerate_surfaces(origin, true))
             {
                 schedule_surface(repaint, child.surface, child.position);
             }
@@ -1214,7 +1214,7 @@ class wf::render_manager::impl
         offset.x -= og.x;
         offset.y -= og.y;
 
-        for (auto& child : drag_icon->enumerate_surfaces(offset))
+        for (auto& child : drag_icon->enumerate_surfaces(offset, true))
         {
             schedule_surface(repaint, child.surface, child.position);
         }
@@ -1263,7 +1263,8 @@ class wf::render_manager::impl
                     /* Make sure view position is relative to the workspace
                      * being rendered */
                     auto obox = view->get_output_geometry() + view_delta;
-                    for (auto& child : view->enumerate_surfaces({obox.x, obox.y}))
+                    for (auto& child :
+                         view->enumerate_surfaces({obox.x, obox.y}, true))
                     {
                         schedule_surface(repaint, child.surface, child.position);
                     }

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -9,23 +9,18 @@
 
 /* Implementation of mirror_view_t */
 wf::mirror_view_t::mirror_view_t(wayfire_view base_view) :
-    wf::view_interface_t()
+    wf::view_interface_t(), wf::mirror_surface_t(base_view,
+        [=] (wf::region_t reg) { emit_damage(reg); })
 {
     this->base_view = base_view;
 
-    base_view_unmapped.set_callback([=] (wf::signal_data_t*)
+    on_source_view_unmapped.set_callback([=] (wf::signal_data_t*)
     {
+        this->base_view = nullptr;
         close();
     });
 
-    base_view->connect_signal("unmapped", &base_view_unmapped);
-
-    base_view_damaged.set_callback([=] (wf::signal_data_t*)
-    {
-        damage();
-    });
-
-    base_view->connect_signal("region-damaged", &base_view_damaged);
+    base_view->connect_signal("unmapped", &on_source_view_unmapped);
 }
 
 wf::mirror_view_t::~mirror_view_t()
@@ -40,8 +35,7 @@ void wf::mirror_view_t::close()
 
     emit_view_pre_unmap();
 
-    base_view->disconnect_signal(&base_view_unmapped);
-    base_view->disconnect_signal(&base_view_damaged);
+    on_source_view_unmapped.disconnect();
     base_view = nullptr;
 
     emit_map_state_change(this);
@@ -53,44 +47,6 @@ void wf::mirror_view_t::close()
 bool wf::mirror_view_t::is_mapped() const
 {
     return base_view && base_view->is_mapped();
-}
-
-wf::dimensions_t wf::mirror_view_t::get_size() const
-{
-    if (!is_mapped())
-    {
-        return {0, 0};
-    }
-
-    auto box = base_view->get_bounding_box();
-
-    return {box.width, box.height};
-}
-
-void wf::mirror_view_t::simple_render(const wf::framebuffer_t& fb, int x, int y,
-    const wf::region_t& damage)
-{
-    if (!is_mapped())
-    {
-        return;
-    }
-
-    /* Normally we shouldn't copy framebuffers. But in this case we can assume
-     * nothing will break, because the copy will be destroyed immediately */
-    wf::framebuffer_t copy;
-    std::memcpy((void*)&copy, (void*)&fb, sizeof(wf::framebuffer_t));
-
-    /* The base view is in another coordinate system, we need to calculate the
-     * difference between the two, so that it appears at the correct place.
-     *
-     * Note that this simply means we need to change fb's geometry. Damage is
-     * calculated for this mirror view, and needs to stay as it is */
-    auto base_bbox = base_view->get_bounding_box();
-
-    wf::point_t offset = {base_bbox.x - x, base_bbox.y - y};
-    copy.geometry = copy.geometry + offset;
-    base_view->render_transformed(copy, damage + offset);
-    copy.reset();
 }
 
 void wf::mirror_view_t::move(int x, int y)
@@ -139,13 +95,95 @@ bool wf::mirror_view_t::should_be_decorated()
     return false;
 }
 
+wf::input_surface_t& wf::mirror_view_t::input()
+{
+    return *this;
+}
+
+wf::output_surface_t& wf::mirror_view_t::output()
+{
+    return *this;
+}
+
+wf::mirror_surface_t::mirror_surface_t(
+    wayfire_view source, std::function<void(wf::region_t)> damage_callback)
+{
+    this->base_view = source;
+
+    on_source_view_damaged.set_callback([=] (wf::signal_data_t*)
+    {
+        damage_callback(wf::region_t{{0, 0, get_size().width, get_size().height}});
+    });
+
+    base_view->connect_signal("region-damaged", &on_source_view_damaged);
+
+    on_source_view_unmapped.set_callback([=] (wf::signal_data_t*)
+    {
+        this->base_view = nullptr;
+    });
+    base_view->connect_signal("unmapped", &on_source_view_unmapped);
+}
+
+wf::point_t wf::mirror_surface_t::get_offset()
+{
+    return {0, 0};
+}
+
+wf::dimensions_t wf::mirror_surface_t::get_size() const
+{
+    if (!base_view)
+    {
+        return {0, 0};
+    }
+
+    auto box = base_view->get_bounding_box();
+    return {box.width, box.height};
+}
+
+void wf::mirror_surface_t::schedule_redraw(const timespec& frame_end)
+{}
+
+void wf::mirror_surface_t::set_visible_on_output(
+    wf::output_t *output, bool is_visible)
+{
+    /* no-op */ }
+
+wf::region_t wf::mirror_surface_t::get_opaque_region()
+{
+    return {};
+}
+
+void wf::mirror_surface_t::simple_render(
+    const wf::framebuffer_t& fb, wf::point_t pos, const wf::region_t& damage)
+{
+    if (!base_view)
+    {
+        return;
+    }
+
+    /* Normally we shouldn't copy framebuffers. But in this case we can assume
+     * nothing will break, because the copy will be destroyed immediately */
+    wf::framebuffer_t copy;
+    std::memcpy((void*)&copy, (void*)&fb, sizeof(wf::framebuffer_t));
+
+    /* The base view is in another coordinate system, we need to calculate the
+     * difference between the two, so that it appears at the correct place.
+     *
+     * Note that this simply means we need to change fb's geometry. Damage is
+     * calculated for this mirror view, and needs to stay as it is */
+    auto base_bbox = base_view->get_bounding_box();
+
+    wf::point_t offset = wf::origin(base_bbox) - pos;
+    copy.geometry = copy.geometry + offset;
+    base_view->render_transformed(copy, damage + offset);
+    copy.reset();
+}
+
 /* Implementation of color_rect_view_t */
 
-wf::color_rect_view_t::color_rect_view_t() : wf::view_interface_t()
+wf::color_rect_view_t::color_rect_view_t() :
+    wf::view_interface_t(), wf::solid_bordered_surface_t([=] () { damage(); })
 {
-    this->geometry   = {0, 0, 1, 1};
-    this->_color     = {0, 0, 0, 1};
-    this->border     = 0;
     this->_is_mapped = true;
 }
 
@@ -159,35 +197,9 @@ void wf::color_rect_view_t::close()
     unref();
 }
 
-void wf::color_rect_view_t::set_color(wf::color_t color)
-{
-    this->_color = color;
-    damage();
-}
-
-void wf::color_rect_view_t::set_border_color(wf::color_t border)
-{
-    this->_border_color = border;
-    damage();
-}
-
-void wf::color_rect_view_t::set_border(int width)
-{
-    this->border = width;
-    damage();
-}
-
 bool wf::color_rect_view_t::is_mapped() const
 {
     return _is_mapped;
-}
-
-wf::dimensions_t wf::color_rect_view_t::get_size() const
-{
-    return {
-        geometry.width,
-        geometry.height,
-    };
 }
 
 static void render_colored_rect(const wf::framebuffer_t& fb,
@@ -203,46 +215,12 @@ static void render_colored_rect(const wf::framebuffer_t& fb,
         fb.get_orthographic_projection());
 }
 
-void wf::color_rect_view_t::simple_render(const wf::framebuffer_t& fb, int x, int y,
-    const wf::region_t& damage)
-{
-    OpenGL::render_begin(fb);
-    for (const auto& box : damage)
-    {
-        fb.logic_scissor(wlr_box_from_pixman_box(box));
-
-        /* Draw the border, making sure border parts don't overlap, otherwise
-         * we will get wrong corners if border has alpha != 1.0 */
-        // top
-        render_colored_rect(fb, x, y, geometry.width, border,
-            _border_color);
-        // bottom
-        render_colored_rect(fb, x, y + geometry.height - border,
-            geometry.width, border, _border_color);
-        // left
-        render_colored_rect(fb, x, y + border, border,
-            geometry.height - 2 * border, _border_color);
-        // right
-        render_colored_rect(fb, x + geometry.width - border,
-            y + border, border, geometry.height - 2 * border, _border_color);
-
-        /* Draw the inside of the rect */
-        render_colored_rect(fb, x + border, y + border,
-            geometry.width - 2 * border, geometry.height - 2 * border,
-            _color);
-    }
-
-    OpenGL::render_end();
-}
-
 void wf::color_rect_view_t::move(int x, int y)
 {
     damage();
     view_geometry_changed_signal data;
     data.old_geometry = get_wm_geometry();
-
-    this->geometry.x = x;
-    this->geometry.y = y;
+    this->position    = {x, y};
 
     damage();
     emit_signal("geometry-changed", &data);
@@ -250,20 +228,20 @@ void wf::color_rect_view_t::move(int x, int y)
 
 void wf::color_rect_view_t::resize(int w, int h)
 {
-    damage();
     view_geometry_changed_signal data;
     data.old_geometry = get_wm_geometry();
 
-    this->geometry.width  = w;
-    this->geometry.height = h;
+    // This will also apply the damage
+    this->set_size({w, h});
 
-    damage();
     emit_signal("geometry-changed", &data);
 }
 
 wf::geometry_t wf::color_rect_view_t::get_output_geometry()
 {
-    return geometry;
+    return {
+        position.x, position.y, get_size().width, get_size().height
+    };
 }
 
 wlr_surface*wf::color_rect_view_t::get_keyboard_focus_surface()
@@ -325,7 +303,88 @@ wf::input_surface_t& wf::color_rect_view_t::input()
     return *this;
 }
 
-wf::input_surface_t& wf::mirror_view_t::input()
+wf::output_surface_t& wf::color_rect_view_t::output()
 {
     return *this;
+}
+
+void wf::solid_bordered_surface_t::set_border(int width)
+{
+    this->border = width;
+    damage_cb();
+}
+
+void wf::solid_bordered_surface_t::set_border_color(wf::color_t border)
+{
+    this->_border_color = border;
+    damage_cb();
+}
+
+void wf::solid_bordered_surface_t::set_color(wf::color_t color)
+{
+    this->_color = color;
+    damage_cb();
+}
+
+void wf::solid_bordered_surface_t::set_size(wf::dimensions_t new_size)
+{}
+
+wf::solid_bordered_surface_t::solid_bordered_surface_t(
+    std::function<void()> damage_cb)
+{
+    this->damage_cb = damage_cb;
+}
+
+wf::point_t wf::solid_bordered_surface_t::get_offset()
+{
+    return {0, 0};
+}
+
+wf::dimensions_t wf::solid_bordered_surface_t::get_size() const
+{
+    return size;
+}
+
+void wf::solid_bordered_surface_t::schedule_redraw(const timespec& frame_end)
+{}
+
+void wf::solid_bordered_surface_t::set_visible_on_output(
+    wf::output_t *output, bool is_visible)
+{
+    /* no-op */ }
+
+wf::region_t wf::solid_bordered_surface_t::get_opaque_region()
+{
+    return {};
+}
+
+void wf::solid_bordered_surface_t::simple_render(
+    const wf::framebuffer_t& fb, wf::point_t pos, const wf::region_t& damage)
+{
+    OpenGL::render_begin(fb);
+    for (const auto& box : damage)
+    {
+        fb.logic_scissor(wlr_box_from_pixman_box(box));
+
+        /* Draw the border, making sure border parts don't overlap, otherwise
+         * we will get wrong corners if border has alpha != 1.0 */
+        // top
+        render_colored_rect(fb, pos.x, pos.y, size.width, border,
+            _border_color);
+        // bottom
+        render_colored_rect(fb, pos.x, pos.y + size.height - border,
+            size.width, border, _border_color);
+        // left
+        render_colored_rect(fb, pos.x, pos.y + border, border,
+            size.height - 2 * border, _border_color);
+        // right
+        render_colored_rect(fb, pos.x + size.width - border,
+            pos.y + border, border, size.height - 2 * border, _border_color);
+
+        /* Draw the inside of the rect */
+        render_colored_rect(fb, pos.x + border, pos.y + border,
+            size.width - 2 * border, size.height - 2 * border, _color);
+    }
+
+    OpenGL::render_end();
 }

--- a/src/view/subsurface.hpp
+++ b/src/view/subsurface.hpp
@@ -15,7 +15,7 @@ class subsurface_implementation_t : public wlr_child_surface_base_t
 
   public:
     subsurface_implementation_t(wlr_subsurface *s);
-    virtual wf::point_t get_offset() override;
+    wf::point_t get_offset() final;
 };
 }
 

--- a/src/view/surface-impl.hpp
+++ b/src/view/surface-impl.hpp
@@ -1,6 +1,6 @@
-#ifndef SURFACE_IMPL_HPP
-#define SURFACE_IMPL_HPP
+#pragma once
 
+#include <map>
 #include <wayfire/opengl.hpp>
 #include <wayfire/surface.hpp>
 #include <wayfire/util.hpp>
@@ -49,6 +49,8 @@ class wlr_surface_base_t : public input_surface_t
     /* Pointer to this as surface_interface, see requirement above */
     wf::surface_interface_t *_as_si = nullptr;
 
+    std::map<wf::output_t*, int> visibility;
+
   public:
     /* if surface != nullptr, then the surface is mapped */
     wlr_surface *surface = nullptr;
@@ -64,8 +66,7 @@ class wlr_surface_base_t : public input_surface_t
     virtual wf::point_t get_window_offset();
 
     /** Update the surface output */
-    virtual void update_output(wf::output_t *old_output,
-        wf::output_t *new_output);
+    virtual void update_output(wf::output_t *output, bool visible);
 
     /*
      * Functions that need to be implemented/overridden from the
@@ -138,10 +139,9 @@ class wlr_child_surface_base_t :
         _simple_render(fb, x, y, damage);
     }
 
-    virtual void set_output(wf::output_t *output) override
+    void set_visible_on_output(wf::output_t *output, bool is_visible) override
     {
-        update_output(get_output(), output);
-        surface_interface_t::set_output(output);
+        update_output(output, is_visible);
     }
 
     virtual input_surface_t& input() override
@@ -150,5 +150,3 @@ class wlr_child_surface_base_t :
     }
 };
 }
-
-#endif /* end of include guard: SURFACE_IMPL_HPP */

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -281,12 +281,6 @@ void wf::wlr_view_t::set_output(wf::output_t *wo)
     toplevel_update_output(old_output, false);
     view_interface_t::set_output(wo);
     toplevel_update_output(wo, true);
-
-    /* send enter/leave events */
-    if (this->is_mapped())
-    {
-        update_output(old_output, wo);
-    }
 }
 
 void wf::wlr_view_t::commit()

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -224,21 +224,15 @@ class wlr_view_t :
     /* Just pass to the default wlr surface implementation */
     virtual bool is_mapped() const override
     {
-        return _is_mapped();
-    }
-
-    virtual wf::dimensions_t get_size() const override
-    {
-        return _get_size();
-    }
-
-    virtual void simple_render(const wf::framebuffer_t& fb, int x, int y,
-        const wf::region_t& damage) override
-    {
-        _simple_render(fb, x, y, damage);
+        return priv->wsurface;
     }
 
     virtual input_surface_t& input() override
+    {
+        return *this;
+    }
+
+    virtual output_surface_t& output() override
     {
         return *this;
     }

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -83,6 +83,10 @@ class view_interface_t::view_priv_impl
     /* Promoted to the fullscreen layer? For workspace-manager. */
     bool is_promoted = false;
 
+    wf::signal_connection_t on_main_surface_damage;
+
+    wf::output_t *output = nullptr;
+
   private:
     /** Last geometry the view has had in non-tiled and non-fullscreen state.
      * -1 as width/height means that no such geometry has been stored. */

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -385,7 +385,7 @@ wf::surface_interface_t*wf::view_interface_t::map_input_coordinates(
     auto view_relative_coordinates =
         global_to_local_point(cursor, nullptr);
 
-    for (auto& child : enumerate_surfaces({0, 0}))
+    for (auto& child : enumerate_surfaces({0, 0}, true))
     {
         local.x = view_relative_coordinates.x - child.position.x;
         local.y = view_relative_coordinates.y - child.position.y;
@@ -955,7 +955,7 @@ wf::geometry_t wf::view_interface_t::get_untransformed_bounding_box()
     auto bbox = get_output_geometry();
     wf::region_t bounding_region = bbox;
 
-    for (auto& child : enumerate_surfaces({bbox.x, bbox.y}))
+    for (auto& child : enumerate_surfaces({bbox.x, bbox.y}, true))
     {
         auto dim = child.surface->get_size();
         bounding_region |= {child.position.x, child.position.y,
@@ -1034,7 +1034,7 @@ bool wf::view_interface_t::intersects_region(const wlr_box& region)
     }
 
     auto origin = get_output_geometry();
-    for (auto& child : enumerate_surfaces({origin.x, origin.y}))
+    for (auto& child : enumerate_surfaces({origin.x, origin.y}, true))
     {
         wlr_box box = {child.position.x, child.position.y,
             child.surface->get_size().width, child.surface->get_size().height};
@@ -1060,7 +1060,7 @@ wf::region_t wf::view_interface_t::get_transformed_opaque_region()
     auto og   = get_output_geometry();
 
     wf::region_t opaque;
-    for (auto& surf : enumerate_surfaces({og.x, og.y}))
+    for (auto& surf : enumerate_surfaces({og.x, og.y}, true))
     {
         opaque |= surf.surface->get_opaque_region(surf.position);
     }
@@ -1088,7 +1088,8 @@ bool wf::view_interface_t::render_transformed(const wf::framebuffer_t& framebuff
     wf::texture_t previous_texture;
     float texture_scale;
 
-    if (is_mapped() && (enumerate_surfaces().size() == 1) && get_wlr_surface())
+    if (is_mapped() && (enumerate_surfaces({0, 0}, true).size() == 1) &&
+        get_wlr_surface())
     {
         /* Optimized case: there is a single mapped surface.
          * We can directly start with its texture */
@@ -1237,7 +1238,7 @@ const wf::framebuffer_t& wf::view_interface_t::take_snapshot()
     OpenGL::render_end();
 
     auto output_geometry = get_output_geometry();
-    auto children = enumerate_surfaces({output_geometry.x, output_geometry.y});
+    auto children = enumerate_surfaces({output_geometry.x, output_geometry.y}, true);
     for (auto& child : wf::reverse(children))
     {
         wlr_box child_box{

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -928,18 +928,6 @@ class wayfire_dnd_xwayland_view : public wayfire_unmanaged_xwayland_view
         return xwayland_view_type_t::DND;
     }
 
-    void simple_render(const wf::framebuffer_t& fb,
-        int x, int y, const wf::region_t& damage) override
-    {
-        wayfire_unmanaged_xwayland_view::simple_render(fb, x, y, damage);
-
-        timespec repaint_ended;
-        clockid_t presentation_clock =
-            wlr_backend_get_presentation_clock(wf::get_core_impl().backend);
-        clock_gettime(presentation_clock, &repaint_ended);
-        send_frame_done(repaint_ended);
-    }
-
     void destruct() override
     {
         LOGD("Destroying a Xwayland drag icon");

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -956,11 +956,6 @@ class wayfire_dnd_xwayland_view : public wayfire_unmanaged_xwayland_view
         wayfire_unmanaged_xwayland_view::deinitialize();
     }
 
-    void damage_surface_box(const wlr_box&) override
-    {
-        damage();
-    }
-
     wf::geometry_t last_global_bbox = {0, 0, 0, 0};
 
     void damage() override

--- a/test/mock-core.cpp
+++ b/test/mock-core.cpp
@@ -65,20 +65,20 @@ const wf::touch::gesture_state_t& mock_core_t::get_touch_state()
     return ::state;
 }
 
-wf::surface_interface_t*mock_core_t::get_cursor_focus()
+wf::focused_view_t mock_core_t::get_cursor_focus()
 {
-    return nullptr;
+    return {nullptr, nullptr};
 }
 
-wf::surface_interface_t*mock_core_t::get_surface_at(
+wf::focused_view_t mock_core_t::get_surface_at(
     wf::pointf_t point)
 {
-    return nullptr;
+    return {nullptr, nullptr};
 }
 
-wf::surface_interface_t*mock_core_t::get_touch_focus()
+wf::focused_view_t mock_core_t::get_touch_focus()
 {
-    return nullptr;
+    return {nullptr, nullptr};
 }
 
 void mock_core_t::add_touch_gesture(

--- a/test/mock-core.hpp
+++ b/test/mock-core.hpp
@@ -25,9 +25,9 @@ class mock_core_t : public wf::compositor_core_impl_t
     wf::pointf_t get_touch_position(int id) override;
     const wf::touch::gesture_state_t& get_touch_state() override;
 
-    wf::surface_interface_t *get_cursor_focus() override;
-    wf::surface_interface_t *get_touch_focus() override;
-    wf::surface_interface_t *get_surface_at(wf::pointf_t point) override;
+    wf::focused_view_t get_cursor_focus() override;
+    wf::focused_view_t get_touch_focus() override;
+    wf::focused_view_t get_surface_at(wf::pointf_t point) override;
 
     void add_touch_gesture(
         nonstd::observer_ptr<wf::touch::gesture_t> gesture) override;


### PR DESCRIPTION
- api: make provisions for an output on multiple outputs/views
- surface: enumerate all surfaces and optionally filter by mapped state
- api: split output part of surface_interface_t into its own subobject
