### PR TITLE
resize: support for keeping ratio

### DIFF
--- a/metadata/resize.xml
+++ b/metadata/resize.xml
@@ -9,5 +9,11 @@
 			<_long>When the specified button is held down, you can drag windows to resize them.</_long>
 			<default>&lt;super&gt; BTN_RIGHT</default>
 		</option>
+
+		<option name="activate_preserve_aspect" type="button">
+			<_short>Activate resize while preserving aspect</_short>
+			<_long>When the specified button is held down, you can drag windows to resize them while perserving its orignal aspect.</_long>
+			<default>disabled</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/metadata/resize.xml
+++ b/metadata/resize.xml
@@ -6,13 +6,13 @@
 		<category>Window Management</category>
 		<option name="activate" type="button">
 			<_short>Activate</_short>
-			<_long>When the specified button is held down, you can drag windows to resize them.</_long>
+			<_long>When the specified button is held down, you can drag a window to resize it.</_long>
 			<default>&lt;super&gt; BTN_RIGHT</default>
 		</option>
 
 		<option name="activate_preserve_aspect" type="button">
 			<_short>Activate resize while preserving aspect</_short>
-			<_long>When the specified button is held down, you can drag windows to resize them while perserving its orignal aspect.</_long>
+			<_long>When the specified button is held down, you can drag a window to resize it while perserving its orignal aspect.</_long>
 			<default>disabled</default>
 		</option>
 	</plugin>

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -36,7 +36,7 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
         }
 
         was_client_request = true;
-        preserve_aspect = false;
+        preserve_aspect    = false;
         initiate(request->view, request->edges);
     };
 

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -50,15 +50,19 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
     };
 
     wf::button_callback activate_binding;
+    wf::button_callback activate_binding_preserve_aspect;
 
     wayfire_toplevel_view view;
 
     bool was_client_request, is_using_touch;
+    bool preserve_aspect = false;
     wf::point_t grab_start;
     wf::geometry_t grabbed_geometry;
 
     uint32_t edges;
     wf::option_wrapper_t<wf::buttonbinding_t> button{"resize/activate"};
+    wf::option_wrapper_t<wf::buttonbinding_t> button_preserve_aspect{
+        "resize/activate_preserve_aspect"};
     std::unique_ptr<wf::input_grab_t> input_grab;
     wf::plugin_activation_data_t grab_interface = {
         .name = "resize",
@@ -72,18 +76,16 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
 
         activate_binding = [=] (auto)
         {
-            auto view = toplevel_cast(wf::get_core().get_cursor_focus_view());
-            if (view)
-            {
-                is_using_touch     = false;
-                was_client_request = false;
-                initiate(view);
-            }
+            return activate(false);
+        };
 
-            return false;
+        activate_binding_preserve_aspect = [=] (auto)
+        {
+            return activate(true);
         };
 
         output->add_button(button, &activate_binding);
+        output->add_button(button_preserve_aspect, &activate_binding_preserve_aspect);
         grab_interface.cancel = [=] ()
         {
             input_pressed(WLR_BUTTON_RELEASED);
@@ -93,6 +95,20 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
         output->connect(&on_view_disappeared);
     }
 
+    bool activate(bool should_preserve_aspect)
+    {
+        auto view = toplevel_cast(wf::get_core().get_cursor_focus_view());
+        if (view)
+        {
+            is_using_touch     = false;
+            was_client_request = false;
+            preserve_aspect    = should_preserve_aspect;
+            initiate(view);
+        }
+
+        return false;
+    }
+
     void handle_pointer_button(const wlr_pointer_button_event& event) override
     {
         if ((event.state == WLR_BUTTON_RELEASED) && was_client_request && (event.button == BTN_LEFT))
@@ -100,7 +116,8 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
             return input_pressed(event.state);
         }
 
-        if (event.button != wf::buttonbinding_t(button).get_button())
+        if ((event.button != wf::buttonbinding_t(button).get_button()) &&
+            (event.button != wf::buttonbinding_t(button_preserve_aspect).get_button()))
         {
             return;
         }
@@ -287,6 +304,12 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
         int dy     = input.y - grab_start.y;
 
         wf::geometry_t desired = grabbed_geometry;
+        double ratio;
+        if (preserve_aspect)
+        {
+            ratio = (double)desired.width / desired.height;
+        }
+
         if (edges & WLR_EDGE_LEFT)
         {
             desired.x     += dx;
@@ -305,8 +328,24 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
             desired.height += dy;
         }
 
-        desired.width  = std::max(desired.width, 1);
-        desired.height = std::max(desired.height, 1);
+        if (preserve_aspect)
+        {
+            auto bbox = desired;
+            desired.width  = std::min(std::max(bbox.width, 1), (int)(bbox.height * ratio));
+            desired.height = std::min(std::max(bbox.height, 1), (int)(bbox.width / ratio));
+            if (edges & WLR_EDGE_LEFT)
+            {
+                desired.x += bbox.width - desired.width;
+            }
+            if (edges & WLR_EDGE_TOP)
+            {
+                desired.y += bbox.height - desired.height;
+            }
+        } else
+        {
+            desired.width  = std::max(desired.width, 1);
+            desired.height = std::max(desired.height, 1);
+        }
 
         view->toplevel()->pending().gravity  = calculate_gravity();
         view->toplevel()->pending().geometry = desired;
@@ -321,6 +360,7 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
         }
 
         output->rem_binding(&activate_binding);
+        output->rem_binding(&activate_binding_preserve_aspect);
     }
 };
 

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -36,6 +36,7 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
         }
 
         was_client_request = true;
+        preserve_aspect = false;
         initiate(request->view, request->edges);
     };
 
@@ -337,6 +338,7 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
             {
                 desired.x += bbox.width - desired.width;
             }
+
             if (edges & WLR_EDGE_TOP)
             {
                 desired.y += bbox.height - desired.height;


### PR DESCRIPTION
In some cases it's desirable to keep the width / height ratio even when the application doesn't require it, e.g. resizing scrcpy out of ratio will leave unpleasant black space.

The patch adds another key binding to resize to keep ratio.