### PR TITLE
use GL_NEAREST for integer scale

### DIFF
--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -438,6 +438,14 @@ void wf::wlr_surface_base_t::_simple_render(const wf::framebuffer_t& fb,
     OpenGL::render_begin(fb);
     OpenGL::render_texture(texture, fb, geometry, glm::vec4(1.f),
         OpenGL::RENDER_FLAG_CACHED);
+    // use GL_NEAREST for integer scale.
+    // GL_NEAREST makes scaled text blocky instead of blurry, which looks better
+    // but only for integer scale.
+    if (fb.scale - floor(fb.scale) < 0.001)
+    {
+        GL_CALL(glTexParameteri(texture.target, GL_TEXTURE_MAG_FILTER, GL_NEAREST));
+    }
+
     for (const auto& rect : damage)
     {
         fb.logic_scissor(wlr_box_from_pixman_box(rect));


### PR DESCRIPTION
Currently wayfire scales windows with default GL_LINEAR method. When scaling up this method gives blurry edges. For integral scales GL_NEAREST will give shape lines and blocky text instead, which looks much nicer. See files attached in [this comment](https://github.com/swaywm/wlroots/issues/1770#issuecomment-515404622).

Sway has [already supported this](https://github.com/swaywm/sway/pull/4727). It defaults to GL_NEAREST and has an option to change.

This patch makes wayfire to use GL_NEAREST when scale is an integer but I don't know how to make it an option.

I have [a better solution for xwayland windows on HiDPI monitors](https://gitlab.freedesktop.org/lilydjwg/wlroots/-/tree/hidpi) but it depends on [an xwayland patch which has stalled for some days](https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/733). Anyway I made this before that so here's a pull request.