### PR TITLE
api: remove compositor_view_t

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1243,7 +1243,7 @@ class wayfire_scale : public wf::plugin_interface_t
         for (auto v : views)
         {
             if (v->is_mapped() &&
-                v->get_keyboard_focus_surface())
+                v->get_keyboard_focus().accepts_focus())
             {
                 next_focus = v;
                 break;

--- a/src/api/wayfire/compositor-view.hpp
+++ b/src/api/wayfire/compositor-view.hpp
@@ -6,23 +6,6 @@
 namespace wf
 {
 /**
- * Base class for compositor views that need to interact with the keyboard
- */
-class compositor_interactive_view_t
-{
-  public:
-    void handle_keyboard_enter()
-    {}
-    void handle_keyboard_leave()
-    {}
-    void handle_key(uint32_t key, uint32_t state)
-    {}
-};
-
-compositor_interactive_view_t *interactive_view_from_view(
-    wf::view_interface_t *view);
-
-/**
  * Input surface implementation which denies all input.
  */
 class no_input_surface_t : public wf::input_surface_t
@@ -43,6 +26,17 @@ class no_input_surface_t : public wf::input_surface_t
     void handle_touch_down(uint32_t time_ms, int32_t id, wf::pointf_t at) final;
     void handle_touch_up(uint32_t time_ms, int32_t id, bool finger_lifted) final;
     void handle_touch_motion(uint32_t time_ms, int32_t id, wf::pointf_t at) final;
+};
+
+class no_input_view_t : public wf::keyboard_focus_view_t
+{
+  public:
+    no_input_view_t() = default;
+
+    bool accepts_focus() const final;
+    void handle_keyboard_enter() final;
+    void handle_keyboard_leave() final;
+    void handle_keyboard_key(wlr_event_keyboard_key event) final;
 };
 
 /**
@@ -85,7 +79,8 @@ class mirror_surface_t : public wf::output_surface_t
  * view becomes unmapped, until it is destroyed.
  */
 class mirror_view_t : public wf::view_interface_t,
-    public wf::no_input_surface_t, public wf::mirror_surface_t
+    public wf::no_input_surface_t, public wf::no_input_view_t,
+    public wf::mirror_surface_t
 {
   protected:
     wf::signal_connection_t on_source_view_unmapped;
@@ -124,7 +119,7 @@ class mirror_view_t : public wf::view_interface_t,
     virtual void move(int x, int y) override;
     virtual wf::geometry_t get_output_geometry() override;
 
-    virtual wlr_surface *get_keyboard_focus_surface() override;
+    virtual keyboard_focus_view_t& get_keyboard_focus() override;
     virtual bool is_focuseable() const override;
     virtual bool should_be_decorated() override;
 
@@ -178,7 +173,8 @@ class solid_bordered_surface_t : public wf::output_surface_t
  * view which is simply a colored rectangle with a border.
  */
 class color_rect_view_t : public wf::view_interface_t,
-    public wf::no_input_surface_t, public wf::solid_bordered_surface_t
+    public wf::no_input_surface_t, public wf::solid_bordered_surface_t,
+    public wf::no_input_view_t
 {
     wf::point_t position = {0, 0};
     bool _is_mapped = true;
@@ -206,7 +202,7 @@ class color_rect_view_t : public wf::view_interface_t,
     virtual void resize(int w, int h) override;
     virtual wf::geometry_t get_output_geometry() override;
 
-    virtual wlr_surface *get_keyboard_focus_surface() override;
+    virtual keyboard_focus_view_t& get_keyboard_focus() override;
     virtual bool is_focuseable() const override;
     virtual bool should_be_decorated() override;
 };

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -46,6 +46,50 @@ constexpr uint32_t TILED_EDGES_ALL =
     WLR_EDGE_TOP | WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT;
 
 /**
+ * An interface for views to interact with keyboard input.
+ */
+class keyboard_focus_view_t
+{
+  public:
+    keyboard_focus_view_t(const keyboard_focus_view_t&) = delete;
+    keyboard_focus_view_t(keyboard_focus_view_t&&) = delete;
+    keyboard_focus_view_t& operator =(const keyboard_focus_view_t&) = delete;
+    keyboard_focus_view_t& operator =(keyboard_focus_view_t&&) = delete;
+
+    /**
+     * Check whether the view wants to accept focus at all.
+     *
+     * The returned value does not have to remain constant for the whole
+     * lifetime of the view.
+     */
+    virtual bool accepts_focus() const = 0;
+
+    /**
+     * Handle a keyboard enter event.
+     * This means that the view is now focused.
+     */
+    virtual void handle_keyboard_enter() = 0;
+
+    /**
+     * Handle a keyboard leave event.
+     * The view is no longer focused.
+     */
+    virtual void handle_keyboard_leave() = 0;
+
+    /**
+     * Handle a keyboard key event.
+     *
+     * These are received only after the view has received keyboard focus and
+     * before it loses it.
+     */
+    virtual void handle_keyboard_key(wlr_event_keyboard_key event) = 0;
+
+  protected:
+    keyboard_focus_view_t() = default;
+    virtual ~keyboard_focus_view_t() = default;
+};
+
+/**
  * view_interface_t is the base class for all "toplevel windows", i.e surfaces
  * which have no parent.
  */
@@ -199,14 +243,9 @@ class view_interface_t : public surface_interface_t
         surface_interface_t *surface);
 
     /**
-     * @return the wlr_surface which should receive focus when focusing this
-     * view. Views which aren't backed by a wlr_surface should implement the
-     * compositor_view interface.
-     *
-     * In case no focus surface is available, or the view should not be focused,
-     * nullptr should be returned.
+     * Get the keyboard focus interface of this view.
      */
-    virtual wlr_surface *get_keyboard_focus_surface() = 0;
+    virtual keyboard_focus_view_t& get_keyboard_focus() = 0;
 
     /**
      * Check whether the surface is focuseable. Note the actual ability to give

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -653,7 +653,7 @@ void wf::compositor_core_impl_t::set_active_view(wayfire_view new_focus)
         auto all_views = new_focus->enumerate_views();
         for (auto& view : all_views)
         {
-            if (view->get_keyboard_focus_surface())
+            if (view->get_keyboard_focus().accepts_focus())
             {
                 new_focus = view;
                 break;

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -32,8 +32,15 @@ void wf::keyboard_t::setup_listeners()
         if (!handle_keyboard_key(ev->keycode, ev->state) &&
             (mode != input_event_processing_mode_t::NO_CLIENT))
         {
-            wlr_seat_keyboard_notify_key(seat->seat,
-                ev->time_msec, ev->keycode, ev->state);
+            if (seat->keyboard_focus)
+            {
+                seat->keyboard_focus->get_keyboard_focus().handle_keyboard_key(*ev);
+            } else
+            {
+                // Just forward the event to the seat
+                wlr_seat_keyboard_notify_key(seat->seat,
+                    ev->time_msec, ev->keycode, ev->state);
+            }
         }
 
         wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat);
@@ -46,7 +53,7 @@ void wf::keyboard_t::setup_listeners()
         auto seat = wf::get_core().get_current_seat();
 
         wlr_seat_set_keyboard(seat, this->device);
-        wlr_seat_keyboard_send_modifiers(seat, &kbd->modifiers);
+        wlr_seat_keyboard_notify_modifiers(seat, &kbd->modifiers);
         wlr_idle_notify_activity(wf::get_core().protocols.idle, seat);
     });
 
@@ -318,12 +325,6 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
         }
 
         mod_binding_key = 0;
-    }
-
-    auto iv = interactive_view_from_view(seat->keyboard_focus.get());
-    if (iv && !handled_in_plugin)
-    {
-        iv->handle_key(key, state);
     }
 
     return handled_in_plugin;

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -301,45 +301,28 @@ uint32_t wf::seat_t::get_modifiers()
 
 void wf::seat_t::set_keyboard_focus(wayfire_view view)
 {
-    auto surface = view ? view->get_keyboard_focus_surface() : NULL;
-    auto iv  = interactive_view_from_view(view.get());
-    auto oiv = interactive_view_from_view(keyboard_focus.get());
-
-    if (oiv)
+    if (keyboard_focus)
     {
-        oiv->handle_keyboard_leave();
-    }
-
-    if (iv)
-    {
-        iv->handle_keyboard_enter();
+        keyboard_focus->get_keyboard_focus().handle_keyboard_leave();
     }
 
     /* Don't focus if we have an active grab */
     if (!wf::get_core_impl().input->active_grab)
     {
-        if (surface)
+        if (view)
         {
-            auto kbd = wlr_seat_get_keyboard(seat);
-            wlr_seat_keyboard_notify_enter(seat, surface,
-                kbd ? kbd->keycodes : NULL,
-                kbd ? kbd->num_keycodes : 0,
-                kbd ? &kbd->modifiers : NULL);
-        } else
-        {
-            wlr_seat_keyboard_notify_clear_focus(seat);
+            view->get_keyboard_focus().handle_keyboard_enter();
         }
 
         keyboard_focus = view;
     } else
     {
-        wlr_seat_keyboard_notify_clear_focus(seat);
         keyboard_focus = nullptr;
     }
 
     wf::keyboard_focus_changed_signal data;
     data.view    = view;
-    data.surface = surface;
+    data.surface = (view ? view->get_wlr_surface() : nullptr);
     wf::get_core().emit_signal("keyboard-focus-changed", &data);
 }
 

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -166,7 +166,7 @@ bool wayfire_focus::check_focus_surface(wf::focused_view_t focus)
 
     auto target_wo = focus.view()->get_output();
     auto old_focus = target_wo->get_active_view();
-    if (focus.view()->get_keyboard_focus_surface())
+    if (focus.view()->get_keyboard_focus().accepts_focus())
     {
         target_wo->focus_view(focus.view(), true);
     } else

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -69,7 +69,7 @@ void wf::output_impl_t::refocus(wayfire_view skip_view, uint32_t layers)
     const auto& suitable_for_focus = [&] (wayfire_view view)
     {
         return (view != skip_view) && view->is_mapped() &&
-               view->get_keyboard_focus_surface() && !view->minimized;
+               view->get_keyboard_focus().accepts_focus() && !view->minimized;
     };
 
     auto views = workspace->get_views_on_workspace(cur_ws, layers);
@@ -340,7 +340,7 @@ void wf::output_impl_t::focus_view(wayfire_view v, uint32_t flags)
     }
 
     /* If no keyboard focus surface is set, then we don't want to focus the view */
-    if (v->get_keyboard_focus_surface() || interactive_view_from_view(v.get()))
+    if (v->get_keyboard_focus().accepts_focus())
     {
         make_view_visible(v);
         if (!(flags & FOCUS_VIEW_NOBUMP))

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -80,11 +80,6 @@ wf::geometry_t wf::mirror_view_t::get_output_geometry()
     return geometry;
 }
 
-wlr_surface*wf::mirror_view_t::get_keyboard_focus_surface()
-{
-    return nullptr;
-}
-
 bool wf::mirror_view_t::is_focuseable() const
 {
     return false;
@@ -244,11 +239,6 @@ wf::geometry_t wf::color_rect_view_t::get_output_geometry()
     };
 }
 
-wlr_surface*wf::color_rect_view_t::get_keyboard_focus_surface()
-{
-    return nullptr;
-}
-
 bool wf::color_rect_view_t::is_focuseable() const
 {
     return false;
@@ -387,4 +377,28 @@ void wf::solid_bordered_surface_t::simple_render(
     }
 
     OpenGL::render_end();
+}
+
+bool wf::no_input_view_t::accepts_focus() const
+{
+    return false;
+}
+
+void wf::no_input_view_t::handle_keyboard_enter()
+{}
+
+void wf::no_input_view_t::handle_keyboard_leave()
+{}
+
+void wf::no_input_view_t::handle_keyboard_key(wlr_event_keyboard_key event)
+{}
+
+wf::keyboard_focus_view_t& wf::color_rect_view_t::get_keyboard_focus()
+{
+    return *this;
+}
+
+wf::keyboard_focus_view_t& wf::mirror_view_t::get_keyboard_focus()
+{
+    return *this;
 }

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -116,7 +116,8 @@ void view_damage_raw(wayfire_view view, const wlr_box& box);
  */
 class wlr_view_t :
     public wlr_surface_base_t,
-    public view_interface_t
+    public view_interface_t,
+    public keyboard_focus_view_t
 {
   public:
     wlr_view_t();
@@ -138,7 +139,11 @@ class wlr_view_t :
     virtual wf::geometry_t get_wm_geometry() override;
     virtual wf::geometry_t get_output_geometry() override;
 
-    virtual wlr_surface *get_keyboard_focus_surface() override;
+    virtual bool accepts_focus() const override;
+    virtual void handle_keyboard_enter() override;
+    virtual void handle_keyboard_leave() override;
+    virtual void handle_keyboard_key(wlr_event_keyboard_key event) override;
+    virtual keyboard_focus_view_t& get_keyboard_focus() override;
 
     virtual bool should_be_decorated() override;
     virtual void set_decoration_mode(bool use_csd);


### PR DESCRIPTION
Instead, we use a new unified interface for passing keyboard focus and key events to views, which can be used for both the wlroots and compositor path.
