### PR TITLE
api: split views and surfaces

### DIFF
--- a/plugins/common/wayfire/plugins/common/preview-indication.hpp
+++ b/plugins/common/wayfire/plugins/common/preview-indication.hpp
@@ -35,6 +35,10 @@ class preview_indication_view_t : public wf::color_rect_view_t
     bool should_close = false;
 
   public:
+    preview_indication_view_t(const preview_indication_view_t&) = delete;
+    preview_indication_view_t(preview_indication_view_t&&) = delete;
+    preview_indication_view_t& operator =(const preview_indication_view_t&) = delete;
+    preview_indication_view_t& operator =(preview_indication_view_t&&) = delete;
 
     /**
      * Create a new indication preview on the indicated output.
@@ -54,9 +58,9 @@ class preview_indication_view_t : public wf::color_rect_view_t
         pre_paint = [=] () { update_animation(); };
         get_output()->render->add_effect(&pre_paint, wf::OUTPUT_EFFECT_PRE);
 
-        set_color(base_color);
-        set_border_color(base_border);
-        set_border(base_border_w);
+        get_color_surface()->set_color(base_color);
+        get_color_surface()->set_border_color(base_border);
+        get_color_surface()->set_border(base_border_w);
 
         this->role = VIEW_ROLE_DESKTOP_ENVIRONMENT;
     }
@@ -114,13 +118,15 @@ class preview_indication_view_t : public wf::color_rect_view_t
         }
 
         double alpha = animation.alpha;
-        if (base_color.a * alpha != _color.a)
+        if (base_color.a * alpha != get_color_surface()->_color.a)
         {
-            _color.a = alpha * base_color.a;
-            _border_color.a = alpha * base_border.a;
+            auto new_color  = get_color_surface()->_color;
+            auto new_border = get_color_surface()->_border_color;
+            new_color.a  = alpha * base_color.a;
+            new_border.a = alpha * base_border.a;
 
-            set_color(_color);
-            set_border_color(_border_color);
+            get_color_surface()->set_color(new_color);
+            get_color_surface()->set_border_color(new_border);
         }
 
         /* The end of unmap animation, just exit */

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -297,7 +297,7 @@ class simple_decorator_t : public wf::decorator_frame_t_t
 
         auto sub = std::make_unique<simple_decoration_surface>(view);
         deco = {sub};
-        view->add_subsurface(std::move(sub), true);
+        view->get_main_surface()->add_subsurface(std::move(sub), true);
         view->damage();
         view->connect_signal("subsurface-removed", &on_subsurface_removed);
     }
@@ -307,7 +307,7 @@ class simple_decorator_t : public wf::decorator_frame_t_t
         if (deco)
         {
             // subsurface_removed unmaps it
-            view->remove_subsurface(deco);
+            view->get_main_surface()->remove_subsurface(deco);
         }
     }
 

--- a/plugins/grid/wayfire/plugins/crossfade.hpp
+++ b/plugins/grid/wayfire/plugins/crossfade.hpp
@@ -20,6 +20,11 @@ namespace grid
 class crossfade_t : public wf::view_2D
 {
   public:
+    crossfade_t(const crossfade_t&) = delete;
+    crossfade_t(crossfade_t&&) = delete;
+    crossfade_t& operator =(const crossfade_t&) = delete;
+    crossfade_t& operator =(crossfade_t&&) = delete;
+
     crossfade_t(wayfire_view view) :
         wf::view_2D(view)
     {
@@ -37,7 +42,7 @@ class crossfade_t : public wf::view_2D
         OpenGL::render_end();
 
         auto og = view->get_output_geometry();
-        for (auto& surface : view->enumerate_surfaces())
+        for (auto& surface : view->get_main_surface()->enumerate_surfaces())
         {
             auto pos = wf::origin(og) + surface.position;
             wf::region_t damage =

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -271,6 +271,12 @@ class compositor_core_t : public wf::object_base_t
     virtual std::vector<wayfire_view> get_all_views() = 0;
 
     /**
+     * Find all views whose main surface is the given surface.
+     */
+    std::vector<wayfire_view> find_views_with_surface(
+        wf::surface_interface_t *surface);
+
+    /**
      * Set the keyboard focus view. The stacking order on the view's output
      * won't be changed.
      */

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -93,7 +93,7 @@ class keyboard_focus_view_t
  * view_interface_t is the base class for all "toplevel windows", i.e surfaces
  * which have no parent.
  */
-class view_interface_t : public surface_interface_t
+class view_interface_t : public wf::object_base_t
 {
   public:
     /**
@@ -135,6 +135,11 @@ class view_interface_t : public surface_interface_t
 
     /** Wrap the view into a nonstd::observer_ptr<> */
     wayfire_view self();
+
+    /**
+     * Get the view's main surface.
+     */
+    nonstd::observer_ptr<wf::surface_interface_t> get_main_surface();
 
     /**
      * Set the view's output.
@@ -513,8 +518,28 @@ class view_interface_t : public surface_interface_t
      */
     uint64_t last_focus_timestamp = 0;
 
+    /**
+     * Same as get_main_surface()->is_mapped()
+     */
+    virtual bool is_mapped() const;
+
   protected:
-    view_interface_t();
+    /**
+     * Create a new view interface.
+     *
+     * @param main_surface The main surface of the view. It is possible to skip
+     *   setting it in the constructor, but it should be set before the view is
+     *   initialized. In any case, the main surface can be only set once.
+     */
+    view_interface_t(
+        std::shared_ptr<wf::surface_interface_t> main_surface = nullptr);
+
+    /**
+     * Set the main surface.
+     * This should be done only once in the lifetime of the view and must
+     * happen before initializing the view!
+     */
+    void set_main_surface(std::shared_ptr<wf::surface_interface_t> main_surface);
 
     friend class compositor_core_impl_t;
     /**

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -626,6 +626,21 @@ std::vector<wayfire_view> wf::compositor_core_impl_t::get_all_views()
     return result;
 }
 
+std::vector<wayfire_view> wf::compositor_core_t::find_views_with_surface(
+    wf::surface_interface_t *surface)
+{
+    std::vector<wayfire_view> result;
+    for (auto view : get_all_views())
+    {
+        if (view->get_main_surface().get() == surface)
+        {
+            result.push_back(view);
+        }
+    }
+
+    return result;
+}
+
 /* sets the "active" view and gives it keyboard focus
  *
  * It maintains two different classes of "active views"

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -268,7 +268,7 @@ wf::focused_view_t wf::input_manager_t::input_surface_at(
         for (auto& view : v->enumerate_views())
         {
             if (!view->minimized && view->is_visible() &&
-                can_focus_surface({view, view.get()}))
+                can_focus_surface({view, view->get_main_surface().get()}))
             {
                 auto surface = view->map_input_coordinates(global, local);
                 if (surface)

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -155,7 +155,6 @@ void wf::pointer_t::update_cursor_focus(
     {
         auto constraint = focus.surface()->input().handle_pointer_enter(local,
             !focus_change);
-        LOGI("Got constraint ", constraint.has_value());
         set_pointer_constraint(constraint);
     } else
     {
@@ -176,7 +175,7 @@ wf::pointf_t wf::pointer_t::get_absolute_position_from_relative(
     relative.x += output_geometry.x;
     relative.y += output_geometry.y;
 
-    for (auto& surf : cursor_focus.view()->enumerate_surfaces())
+    for (auto& surf : cursor_focus.view()->get_main_surface()->enumerate_surfaces())
     {
         if (surf.surface == this->cursor_focus.surface())
         {

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -16,9 +16,9 @@
 
 /* ------------------------ Drag icon impl ---------------------------------- */
 wf::drag_icon_t::drag_icon_t(wlr_drag_icon *ic) :
-    wf::wlr_child_surface_base_t(this), icon(ic)
+    wf::wlr_surface_base_t(ic->surface), icon(ic)
 {
-    on_map.set_callback([&] (void*) { this->map(icon->surface); });
+    on_map.set_callback([&] (void*) { this->map(); });
     on_unmap.set_callback([&] (void*) { this->unmap(); });
     on_destroy.set_callback([&] (void*)
     {
@@ -45,6 +45,7 @@ wf::drag_icon_t::drag_icon_t(wlr_drag_icon *ic) :
             damage_surface_box_global(box + this->get_offset());
         }
     });
+    this->connect_signal("damage", &on_self_damage);
 }
 
 wf::point_t wf::drag_icon_t::get_offset()
@@ -119,7 +120,7 @@ wf::seat_t::seat_t()
             // In this case, when the drag starts, the icon is already mapped.
             if (d->icon->surface && wlr_surface_has_buffer(d->icon->surface))
             {
-                this->drag_icon->force_map();
+                this->drag_icon->map();
             }
         }
 
@@ -322,7 +323,7 @@ void wf::seat_t::set_keyboard_focus(wayfire_view view)
 
     wf::keyboard_focus_changed_signal data;
     data.view    = view;
-    data.surface = (view ? view->get_wlr_surface() : nullptr);
+    data.surface = (view ? view->get_main_surface()->get_wlr_surface() : nullptr);
     wf::get_core().emit_signal("keyboard-focus-changed", &data);
 }
 

--- a/src/core/seat/seat.hpp
+++ b/src/core/seat/seat.hpp
@@ -13,7 +13,7 @@ namespace wf
 struct cursor_t;
 class keyboard_t;
 
-struct drag_icon_t : public wlr_child_surface_base_t
+struct drag_icon_t : public wlr_surface_base_t
 {
     wlr_drag_icon *icon;
     wl_listener_wrapper on_map, on_unmap, on_destroy;
@@ -23,12 +23,6 @@ struct drag_icon_t : public wlr_child_surface_base_t
 
     /** Called each time the DnD icon position changes. */
     void damage();
-
-    /* Force map without receiving a wlroots event */
-    void force_map()
-    {
-        this->map(icon->surface);
-    }
 
   private:
     /** Last icon box. */

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -453,7 +453,8 @@ void wf::tablet_pad_t::update_focus()
     auto active_output = wf::get_core().get_active_output();
     auto focus_view    =
         active_output ? active_output->get_active_view() : nullptr;
-    auto focus_surface = focus_view ? focus_view->priv->wsurface : nullptr;
+    auto focus_surface =
+        focus_view ? focus_view->get_main_surface()->get_wlr_surface() : nullptr;
     update_focus(focus_surface);
 }
 

--- a/src/output/gtk-shell.cpp
+++ b/src/output/gtk-shell.cpp
@@ -377,7 +377,7 @@ std::string get_gtk_shell_app_id(wayfire_view view)
         return "";
     }
 
-    auto surface = view->get_wlr_surface();
+    auto surface = view->get_main_surface()->get_wlr_surface();
 
     if (!surface)
     {

--- a/src/view/layer-shell.cpp
+++ b/src/view/layer-shell.cpp
@@ -39,7 +39,7 @@ class wayfire_layer_shell_view : public wf::wlr_view_t
     wayfire_layer_shell_view& operator =(const wayfire_layer_shell_view&) = delete;
     wayfire_layer_shell_view& operator =(wayfire_layer_shell_view&&) = delete;
 
-    void map(wlr_surface *surface) override;
+    void map() override;
     void unmap() override;
     void commit() override;
     void close() override;
@@ -341,6 +341,9 @@ wayfire_layer_shell_view::wayfire_layer_shell_view(wlr_layer_surface_v1 *lsurf) 
     LOGD("Create a layer surface: namespace ", lsurf->namespace_t,
         " layer ", lsurf->current.layer);
 
+    auto surf = std::make_shared<wf::wlr_surface_base_t>(lsurf->surface);
+    this->set_main_surface(surf);
+
     role = wf::VIEW_ROLE_DESKTOP_ENVIRONMENT;
     std::memset(&this->prev_state, 0, sizeof(prev_state));
     sticky = true;
@@ -368,7 +371,7 @@ void wayfire_layer_shell_view::initialize()
     lsurface->output = get_output()->handle;
     lsurface->data   = dynamic_cast<wf::view_interface_t*>(this);
 
-    on_map.set_callback([&] (void*) { map(lsurface->surface); });
+    on_map.set_callback([&] (void*) { map(); });
     on_unmap.set_callback([&] (void*) { unmap(); });
     on_destroy.set_callback([&] (void*) { destroy(); });
     on_new_popup.set_callback([&] (void *data)
@@ -447,7 +450,7 @@ wf::layer_t wayfire_layer_shell_view::get_layer()
     }
 }
 
-void wayfire_layer_shell_view::map(wlr_surface *surface)
+void wayfire_layer_shell_view::map()
 {
     // Disconnect, from now on regular commits will work
     on_commit_unmapped.disconnect();
@@ -457,7 +460,7 @@ void wayfire_layer_shell_view::map(wlr_surface *surface)
     handle_app_id_changed(nonull(lsurface->namespace_t));
 
     get_output()->workspace->add_view(self(), get_layer());
-    wf::wlr_view_t::map(surface);
+    wf::wlr_view_t::map();
     wf_layer_shell_manager::get_instance().handle_map(this);
 }
 

--- a/src/view/subsurface.cpp
+++ b/src/view/subsurface.cpp
@@ -4,12 +4,12 @@
 #include <cassert>
 
 wf::subsurface_implementation_t::subsurface_implementation_t(wlr_subsurface *_sub) :
-    wlr_child_surface_base_t(this)
+    wlr_surface_base_t(_sub->surface)
 {
     this->sub = _sub;
     on_map.set_callback([&] (void*)
     {
-        this->map(this->sub->surface);
+        this->map();
     });
     on_unmap.set_callback([&] (void*) { this->unmap(); });
     on_destroy.set_callback([&] (void*)
@@ -41,8 +41,6 @@ wf::subsurface_implementation_t::subsurface_implementation_t(wlr_subsurface *_su
 
 wf::point_t wf::subsurface_implementation_t::get_offset()
 {
-    assert(is_mapped());
-
     return {
         sub->current.x,
         sub->current.y,

--- a/src/view/subsurface.hpp
+++ b/src/view/subsurface.hpp
@@ -1,12 +1,11 @@
-#ifndef WF_SUBSURFACE_HPP
-#define WF_SUBSURFACE_HPP
+#pragma once
 
 #include "surface-impl.hpp"
 #include <wayfire/nonstd/wlroots-full.hpp>
 
 namespace wf
 {
-class subsurface_implementation_t : public wlr_child_surface_base_t
+class subsurface_implementation_t : public wlr_surface_base_t
 {
     wl_listener_wrapper on_map, on_unmap, on_destroy;
     wlr_subsurface *sub;
@@ -18,6 +17,3 @@ class subsurface_implementation_t : public wlr_child_surface_base_t
     wf::point_t get_offset() final;
 };
 }
-
-
-#endif /* end of include guard: WF_SUBSURFACE_HPP */

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -24,7 +24,7 @@ class wayfire_xdg_popup : public wf::wlr_view_t
     void initialize() override;
 
     wlr_view_t *popup_parent;
-    virtual void map(wlr_surface *surface) override;
+    virtual void map() override;
     virtual void commit() override;
 
     virtual wf::point_t get_window_offset() override;
@@ -56,7 +56,7 @@ class wayfire_xdg_view : public wf::wlr_view_t
     wayfire_xdg_view(wlr_xdg_toplevel *toplevel);
     virtual ~wayfire_xdg_view();
 
-    void map(wlr_surface *surface) final;
+    void map() final;
     void commit() final;
 
     wf::point_t get_window_offset() final;


### PR DESCRIPTION
Instead of making `view_interface_t` a subclass of `surface_interface_t`, we use composition. Now each view has a main surface accessible via `get_main_surface()`.

This allows for cleaner separation of responsibilities, and we don't have to use hacks in `wlr_surface_base_t` to avoid double inheritance.

Also, this is a second step to supporting the same window being visible on multiple outputs, as we use shared pointers for surfaces.
Now, we can have multiple views which use the same surfaces.
This is of course also useful for plugins which need to override the way Wayfire handles surfaces - for example, by providing a custom Xwayland view implementation, but reusing the `wlr_surface` handling.
Another potential example are client-rendered server side decorations, or implementations of custom shells.

Preparation for the final part of #1309, which is splitting the desktop surface part out of the view.
