### PR TITLE
expo: ask the workspace_implementation about moveability

### DIFF
--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -414,6 +414,13 @@ class wayfire_expo : public wf::plugin_interface_t
             auto view = find_view_at_coordinates(to.x, to.y);
             if (view)
             {
+                auto workspace_impl =
+                    output->workspace->get_workspace_implementation();
+                if (!workspace_impl->view_movable(view))
+                {
+                    return;
+                }
+
                 auto ws_coords = input_coordinates_to_output_local_coordinates(to);
                 auto bbox = view->get_bounding_box("wobbly");
 


### PR DESCRIPTION
Something found while working on a #1381 related plugin. I wonder how nobody found this when working on tile :)

re: code style — I think skipping over `update_target_workspace(to.x, to.y);` with the `return` is fine, and the whole `if (view)` thing could've been ` if (!view) return;` to save an indent level, right?…