### PR TITLE
Add ability for plugins to avoid touchpad gesture conflicts

### DIFF
--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -83,6 +83,7 @@ enum class input_event_processing_mode_t
  *   pointer_motion, pointer_motion_absolute, pointer_button, pointer_axis,
  *   pointer_swipe_begin, pointer_swipe_update, pointer_swipe_end,
  *   pointer_pinch_begin, pointer_pinch_update, pointer_pinch_end,
+ *   pointer_hold_begin, pointer_hold_end,
  *   keyboard_key,
  *   touch_down, touch_up, touch_motion,
  *   tablet_proximity, tablet_axis, tablet_button, tablet_tip

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -118,6 +118,16 @@ struct input_event_signal : public wf::signal_data_t
      * pointer_button, keyboard_key, touch_down
      */
     input_event_processing_mode_t mode = input_event_processing_mode_t::FULL;
+
+    /**
+     * Whether the event has already been handled.
+     *
+     * This is useful for e.g. preventing conflicts between different plugins
+     * handling touchpad gestures.
+     *
+     * Setting this flag also implicitly sets the mode to NO_CLIENT.
+     */
+    bool carried_out = false;
 };
 
 /**

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -115,7 +115,10 @@ struct input_event_signal : public wf::signal_data_t
      *
      * This is currently supported for only a subset of signals, namely:
      *
-     * pointer_button, keyboard_key, touch_down
+     * pointer_button, keyboard_key, touch_down,
+     * pointer_swipe_begin, pointer_swipe_update, pointer_swipe_end,
+     * pointer_pinch_begin, pointer_pinch_update, pointer_pinch_end,
+     * pointer_hold_begin, pointer_hold_end
      */
     input_event_processing_mode_t mode = input_event_processing_mode_t::FULL;
 

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -77,6 +77,8 @@ void wf::cursor_t::setup_listeners()
     setup_passthrough_callback(pinch_begin);
     setup_passthrough_callback(pinch_update);
     setup_passthrough_callback(pinch_end);
+    setup_passthrough_callback(hold_begin);
+    setup_passthrough_callback(hold_end);
 #undef setup_passthrough_callback
 
     /**

--- a/src/core/seat/cursor.hpp
+++ b/src/core/seat/cursor.hpp
@@ -55,6 +55,7 @@ struct cursor_t
 
         on_swipe_begin, on_swipe_update, on_swipe_end,
         on_pinch_begin, on_pinch_update, on_pinch_end,
+        on_hold_begin, on_hold_end,
 
         on_tablet_tip, on_tablet_axis,
         on_tablet_button, on_tablet_proximity,

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -97,6 +97,11 @@ wf::input_event_processing_mode_t emit_device_event_signal(
     data.event = event;
     wf::get_core().emit_signal(event_name, &data);
 
+    if (data.carried_out)
+    {
+        data.mode = wf::input_event_processing_mode_t::NO_CLIENT;
+    }
+
     return data.mode;
 }
 

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -605,6 +605,22 @@ void wf::pointer_t::handle_pointer_pinch_end(wlr_event_pointer_pinch_end *ev,
         ev->time_msec, ev->cancelled);
 }
 
+void wf::pointer_t::handle_pointer_hold_begin(wlr_event_pointer_hold_begin *ev,
+    input_event_processing_mode_t mode)
+{
+    wlr_pointer_gestures_v1_send_hold_begin(
+        wf::get_core().protocols.pointer_gestures, seat->seat,
+        ev->time_msec, ev->fingers);
+}
+
+void wf::pointer_t::handle_pointer_hold_end(wlr_event_pointer_hold_end *ev,
+    input_event_processing_mode_t mode)
+{
+    wlr_pointer_gestures_v1_send_hold_end(
+        wf::get_core().protocols.pointer_gestures, seat->seat,
+        ev->time_msec, ev->cancelled);
+}
+
 void wf::pointer_t::handle_pointer_frame()
 {
     wlr_seat_pointer_notify_frame(seat->seat);

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -560,6 +560,11 @@ void wf::pointer_t::handle_pointer_axis(wlr_event_pointer_axis *ev,
 void wf::pointer_t::handle_pointer_swipe_begin(wlr_event_pointer_swipe_begin *ev,
     input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_swipe_begin(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->fingers);
@@ -568,6 +573,11 @@ void wf::pointer_t::handle_pointer_swipe_begin(wlr_event_pointer_swipe_begin *ev
 void wf::pointer_t::handle_pointer_swipe_update(
     wlr_event_pointer_swipe_update *ev, input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_swipe_update(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->dx, ev->dy);
@@ -576,6 +586,11 @@ void wf::pointer_t::handle_pointer_swipe_update(
 void wf::pointer_t::handle_pointer_swipe_end(wlr_event_pointer_swipe_end *ev,
     input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_swipe_end(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->cancelled);
@@ -584,6 +599,11 @@ void wf::pointer_t::handle_pointer_swipe_end(wlr_event_pointer_swipe_end *ev,
 void wf::pointer_t::handle_pointer_pinch_begin(wlr_event_pointer_pinch_begin *ev,
     input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_pinch_begin(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->fingers);
@@ -592,6 +612,11 @@ void wf::pointer_t::handle_pointer_pinch_begin(wlr_event_pointer_pinch_begin *ev
 void wf::pointer_t::handle_pointer_pinch_update(
     wlr_event_pointer_pinch_update *ev, input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_pinch_update(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->dx, ev->dy, ev->scale, ev->rotation);
@@ -600,6 +625,11 @@ void wf::pointer_t::handle_pointer_pinch_update(
 void wf::pointer_t::handle_pointer_pinch_end(wlr_event_pointer_pinch_end *ev,
     input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_pinch_end(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->cancelled);
@@ -608,6 +638,11 @@ void wf::pointer_t::handle_pointer_pinch_end(wlr_event_pointer_pinch_end *ev,
 void wf::pointer_t::handle_pointer_hold_begin(wlr_event_pointer_hold_begin *ev,
     input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_hold_begin(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->fingers);
@@ -616,6 +651,11 @@ void wf::pointer_t::handle_pointer_hold_begin(wlr_event_pointer_hold_begin *ev,
 void wf::pointer_t::handle_pointer_hold_end(wlr_event_pointer_hold_end *ev,
     input_event_processing_mode_t mode)
 {
+    if (mode != input_event_processing_mode_t::FULL)
+    {
+        return;
+    }
+
     wlr_pointer_gestures_v1_send_hold_end(
         wf::get_core().protocols.pointer_gestures, seat->seat,
         ev->time_msec, ev->cancelled);

--- a/src/core/seat/pointer.hpp
+++ b/src/core/seat/pointer.hpp
@@ -87,6 +87,10 @@ class pointer_t
         input_event_processing_mode_t mode);
     void handle_pointer_pinch_end(wlr_event_pointer_pinch_end *ev,
         input_event_processing_mode_t mode);
+    void handle_pointer_hold_begin(wlr_event_pointer_hold_begin *ev,
+        input_event_processing_mode_t mode);
+    void handle_pointer_hold_end(wlr_event_pointer_hold_end *ev,
+        input_event_processing_mode_t mode);
     void handle_pointer_frame();
 
     /** Whether there are pressed buttons currently */


### PR DESCRIPTION
(INCLUDES #1387)

Extend the `carried_out` pattern to input signals.

So… yeah, this is necessary for something really cool with touchpad gestures :)

UPD: by which I mean that I have [3-finger drag](https://github.com/DankBSD/wf-touchpad-gesture-drag) not conflicting with 3-finger vswipe! (and the same will extend to [globalgestures](https://github.com/DankBSD/wf-globalgestures))