### PR TITLE
Fix window position error

### DIFF
--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -229,6 +229,8 @@ class view_interface_t : public surface_interface_t
      * If the view is tiled to all edges, it is considered maximized. */
     uint32_t tiled_edges = 0;
 
+    bool is_positioned = false;
+
     /** Set the minimized state of the view. */
     virtual void set_minimized(bool minimized);
     /** Set the tiled edges of the view */

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -139,6 +139,7 @@ void wf::wlr_view_t::set_position(int x, int y,
     }
 
     last_bounding_box = get_bounding_box();
+    is_positioned = true;
 }
 
 void wf::wlr_view_t::move(int x, int y)
@@ -363,7 +364,7 @@ void wf::emit_ping_timeout_signal(wayfire_view view)
 
 void wf::view_interface_t::emit_view_map()
 {
-    emit_view_map_signal(self(), false);
+    emit_view_map_signal(self(), is_positioned);
 }
 
 void wf::view_interface_t::emit_view_unmap()


### PR DESCRIPTION
The window is positioned by client, but it will be placed to center by
the place plugin. Set is_positioned to place plugin to avoid this issue.

Signed-off-by: Chaojiang Luo <luochaojiang@uniontech.com>
Change-Id: I925ced36e9750667afc3c196db98e0e050b3c0c7

**Notice: Wayfire's development is temporarily happening in the `stabilize-api` branch. If you open a pull request for the master branch, it will likely not be merged before the stabilize-api branch is itself merged into master.**
