### PR TITLE
Avoid using [] which implicitly inserts.

### DIFF
--- a/plugins/animate/animate.cpp
+++ b/plugins/animate/animate.cpp
@@ -40,7 +40,7 @@ static constexpr int SHOWN  = 1;
 
 /* Represents an animation running for a specific view
  * animation_t is which animation to use (i.e fire, zoom, etc). */
-struct animation_hook_base : public wf::custom_data_t
+struct animation_hook_base
 {
     virtual void stop_hook(bool) = 0;
     virtual void reverse(wf_animation_type) = 0;

--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -267,7 +267,7 @@ inline std::vector<wayfire_view> get_target_views(wayfire_view grabbed,
 /**
  * An object for storing per-output data.
  */
-class output_data_t : public custom_data_t
+class output_data_t
 {
   public:
     output_data_t(wf::output_t *output, std::vector<dragged_view_t> views)

--- a/plugins/common/wayfire/plugins/common/shared-core-data.hpp
+++ b/plugins/common/wayfire/plugins/common/shared-core-data.hpp
@@ -19,9 +19,8 @@ namespace detail
 {
 /** Implementation detail: the actual data stored in core. */
 template<class T>
-class shared_data_t : public wf::custom_data_t
+struct shared_data_t
 {
-  public:
     T data;
     int32_t use_count = 0;
 };

--- a/plugins/common/wayfire/plugins/common/workspace-stream-sharing.hpp
+++ b/plugins/common/wayfire/plugins/common/workspace-stream-sharing.hpp
@@ -15,7 +15,7 @@ namespace wf
  * Using this interface allows all plugins to use the same OpenGL textures for
  * the workspaces, thereby reducing the memory overhead of a workspace stream.
  */
-class workspace_stream_pool_t : public wf::custom_data_t
+class workspace_stream_pool_t
 {
   public:
     /**

--- a/plugins/grid/grid.cpp
+++ b/plugins/grid/grid.cpp
@@ -19,9 +19,8 @@ const std::string grid_view_id = "grid-view";
 
 
 
-class wf_grid_slot_data : public wf::custom_data_t
+struct wf_grid_slot_data
 {
-  public:
     int slot;
 };
 

--- a/plugins/grid/wayfire/plugins/crossfade.hpp
+++ b/plugins/grid/wayfire/plugins/crossfade.hpp
@@ -97,7 +97,7 @@ class crossfade_t : public wf::view_2D
 /**
  * A class used for crossfade/wobbly animation of a change in a view's geometry.
  */
-class grid_animation_t : public wf::custom_data_t
+class grid_animation_t
 {
   public:
     enum type_t

--- a/plugins/scale/scale-title-overlay.cpp
+++ b/plugins/scale/scale-title-overlay.cpp
@@ -21,7 +21,7 @@ static wayfire_view find_toplevel_parent(wayfire_view view)
 /**
  * Class storing an overlay with a view's title, only stored for parent views.
  */
-struct view_title_texture_t : public wf::custom_data_t
+struct view_title_texture_t
 {
     wayfire_view view;
     wf::cairo_text_t overlay;

--- a/plugins/single_plugins/preserve-output.cpp
+++ b/plugins/single_plugins/preserve-output.cpp
@@ -20,9 +20,8 @@
  * View last output info
  */
 
-class last_output_info_t : public wf::custom_data_t
+struct last_output_info_t
 {
-  public:
     std::string output_identifier;
     wf::geometry_t geometry;
     bool fullscreen = false;

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -32,7 +32,7 @@ class tile_workspace_implementation_t : public wf::workspace_implementation_t
  * 3. We now know we will receive attach as next event.
  *    Check for view_auto_tile_t, and tile the view again.
  */
-class view_auto_tile_t : public wf::custom_data_t
+class view_auto_tile_t
 {};
 
 class tile_plugin_t : public wf::plugin_interface_t

--- a/plugins/tile/tree.cpp
+++ b/plugins/tile/tree.cpp
@@ -249,7 +249,7 @@ split_node_t::split_node_t(split_direction_t dir)
 }
 
 /* -------------------- view_node_t implementation -------------------------- */
-struct view_node_custom_data_t : public custom_data_t
+struct view_node_custom_data_t
 {
     nonstd::observer_ptr<view_node_t> ptr;
     view_node_custom_data_t(view_node_t *node)

--- a/plugins/window-rules/lambda-rules-registration.hpp
+++ b/plugins/window-rules/lambda-rules-registration.hpp
@@ -110,7 +110,7 @@ struct lambda_rule_registration_t
  * wf:core, and lazy-init if the
  * instance is not yet present.
  */
-class lambda_rules_registrations_t : public custom_data_t
+class lambda_rules_registrations_t
 {
   public:
     /**

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -27,6 +27,8 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
 
     bool toggle_keep_above(wayfire_view view)
     {
+        struct marker_t {};
+
         if (!view || !output->can_activate_plugin(this->grab_interface))
         {
             return false;
@@ -40,7 +42,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
         } else
         {
             output->workspace->add_view_to_sublayer(view, always_above);
-            view->store_data(std::make_unique<wf::custom_data_t>(),
+            view->store_data(std::make_unique<marker_t>(),
                 "wm-actions-above");
         }
 
@@ -249,9 +251,11 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
             {
                 if (!view->minimized)
                 {
+                    struct marker_t {};
+
                     view->minimize_request(true);
                     view->store_data(
-                        std::make_unique<wf::custom_data_t>(),
+                        std::make_unique<marker_t>(),
                         "wm-actions-showdesktop");
                 }
             }

--- a/src/api/wayfire/object.hpp
+++ b/src/api/wayfire/object.hpp
@@ -98,12 +98,6 @@ class signal_provider_t
 };
 
 /**
- * DEPRECATED: Subclasses of custom_data_t can be stored inside an object_base_t
- */
-class custom_data_t
-{};
-
-/**
  * A base class for "objects". Objects provide signals and ways for plugins to
  * store custom data about the object.
  */

--- a/src/api/wayfire/object.hpp
+++ b/src/api/wayfire/object.hpp
@@ -149,9 +149,10 @@ class object_base_t : public signal_provider_t
             return data;
         } else
         {
-            store_data<T>(std::make_unique<T>(), name);
-
-            return get_data<T>(name);
+            auto new_data = std::make_unique<T>();
+            data = new_data.get();
+            store_data<T>(std::move(new_data), std::move(name));
+            return data;
         }
     }
 
@@ -161,7 +162,7 @@ class object_base_t : public signal_provider_t
     nonstd::observer_ptr<T> get_data(
         std::string name = typeid(T).name())
     {
-        return nonstd::make_observer((T*)_fetch_data(name));
+        return nonstd::make_observer((T*)_fetch_data(std::move(name)));
     }
 
     /* Assigns the given data to the given name */
@@ -172,7 +173,7 @@ class object_base_t : public signal_provider_t
         _store_data(std::unique_ptr<void,
             object_data_deleter_t>((void*)stored_data.release(),
                 object_data_deleter_t::for_type<T>()),
-            name);
+            std::move(name));
     }
 
     /* Returns true if there is saved data under the given name */
@@ -205,7 +206,7 @@ class object_base_t : public signal_provider_t
             return {nullptr};
         }
 
-        auto data = _fetch_erase(name);
+        auto data = _fetch_erase(std::move(name));
         return std::unique_ptr<T>((T*)(data.release()));
     }
 

--- a/src/api/wayfire/singleton-plugin.hpp
+++ b/src/api/wayfire/singleton-plugin.hpp
@@ -6,7 +6,7 @@ namespace wf
 namespace detail
 {
 template<class Plugin>
-struct singleton_data_t : public custom_data_t
+struct singleton_data_t
 {
     Plugin ptr;
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -634,7 +634,7 @@ void wf::compositor_core_impl_t::add_view(
 {
     auto v = view->self(); /* non-owning copy */
     views.push_back(std::move(view));
-    id_to_view[std::to_string(v->get_id())] = v;
+    (void)id_to_view.try_emplace(std::to_string(v->get_id()), v);
 
     assert(active_output);
     if (!v->get_output())

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -83,7 +83,7 @@ wf::signal_provider_t::~signal_provider_t()
 void wf::signal_provider_t::connect_signal(std::string name,
     signal_connection_t *callback)
 {
-    const auto it = sprovider_priv->signals.try_emplace(name).first;
+    const auto it = sprovider_priv->signals.try_emplace(std::move(name)).first;
     it->second.push_back(callback);
     callback->priv->add(this);
 }
@@ -109,7 +109,7 @@ void wf::signal_provider_t::disconnect_signal(signal_connection_t *connection)
 /* Emit the given signal. No type checking for data is required */
 void wf::signal_provider_t::emit_signal(std::string name, wf::signal_data_t *data)
 {
-    const auto it = sprovider_priv->signals.find(name);
+    const auto it = sprovider_priv->signals.find(std::move(name));
     if (it != sprovider_priv->signals.end())
     {
         it->second.for_each([data] (auto call)
@@ -149,12 +149,12 @@ uint32_t wf::object_base_t::get_id() const
 
 bool wf::object_base_t::has_data(std::string name)
 {
-    return obase_priv->data.count(name) != 0;
+    return obase_priv->data.count(std::move(name)) != 0;
 }
 
 void wf::object_base_t::erase_data(std::string name)
 {
-    const auto it = obase_priv->data.find(name);
+    const auto it = obase_priv->data.find(std::move(name));
     if (it != obase_priv->data.end())
     {
         it->second.reset();
@@ -164,7 +164,7 @@ void wf::object_base_t::erase_data(std::string name)
 
 void*wf::object_base_t::_fetch_data(std::string name)
 {
-    const auto it = obase_priv->data.find(name);
+    const auto it = obase_priv->data.find(std::move(name));
     if (it == obase_priv->data.end())
     {
         return nullptr;
@@ -176,7 +176,7 @@ void*wf::object_base_t::_fetch_data(std::string name)
 auto wf::object_base_t::_fetch_erase(std::string name) -> std::unique_ptr<void,
     object_data_deleter_t>
 {
-    const auto it = obase_priv->data.find(name);
+    const auto it = obase_priv->data.find(std::move(name));
     if (it != obase_priv->data.end())
     {
         auto data = std::move(it->second);
@@ -192,7 +192,7 @@ void wf::object_base_t::_store_data(std::unique_ptr<void,
     object_data_deleter_t> data,
     std::string name)
 {
-    (void)obase_priv->data.insert_or_assign(name, std::move(data));
+    (void)obase_priv->data.insert_or_assign(std::move(name), std::move(data));
 }
 
 void wf::object_base_t::_clear_data()

--- a/src/output/gtk-shell.cpp
+++ b/src/output/gtk-shell.cpp
@@ -50,11 +50,13 @@ static void handle_gtk_surface_set_dbus_properties(wl_client *client,
  */
 static void handle_gtk_surface_set_modal(wl_client *client, wl_resource *resource)
 {
+    struct marker_t {};
+
     auto surface = static_cast<wf_gtk_surface*>(wl_resource_get_user_data(resource));
     wayfire_view view = wf::wl_surface_to_wayfire_view(surface->wl_surface);
     if (view)
     {
-        view->store_data(std::make_unique<wf::custom_data_t>(), "gtk-shell-modal");
+        view->store_data(std::make_unique<marker_t>(), "gtk-shell-modal");
     }
 }
 


### PR DESCRIPTION
`[]` should be avoided where possible as it causes things that look like
simple lookups to actually perform insertions.

`[]` replaced with explicit operators where possible.

`[] = ...` assignments aren't too confusing but `try_emplace()` is much
clearer.

C++ magic looks very pretty but can be very dangerous.