### PR TITLE
add keepabove window rule

### DIFF
--- a/plugins/window-rules/view-action-interface.cpp
+++ b/plugins/window-rules/view-action-interface.cpp
@@ -77,6 +77,11 @@ bool view_action_interface_t::execute(const std::string & name,
         _unminimize();
 
         return false;
+    } else if (name == "keepabove")
+    {
+        _keepabove();
+
+        return false;
     } else if (name == "snap")
     {
         if ((args.size() < 1) || (wf::is_string(args.at(0)) == false))
@@ -204,6 +209,15 @@ void view_action_interface_t::_minimize()
 void view_action_interface_t::_unminimize()
 {
     _view->set_minimized(false);
+}
+
+void view_action_interface_t::_keepabove()
+{
+    auto output = _view->get_output();
+    nonstd::observer_ptr<wf::sublayer_t> always_above;
+    always_above = output->workspace->create_sublayer(
+            wf::LAYER_TOP, wf::SUBLAYER_DOCKED_ABOVE);
+    output->workspace->add_view_to_sublayer(_view, always_above);
 }
 
 std::tuple<bool, float> view_action_interface_t::_expect_float(

--- a/plugins/window-rules/view-action-interface.hpp
+++ b/plugins/window-rules/view-action-interface.hpp
@@ -24,6 +24,7 @@ class view_action_interface_t : public action_interface_t
     void _unmaximize();
     void _minimize();
     void _unminimize();
+    void _keepabove();
 
     std::tuple<bool, float> _expect_float(const std::vector<variant_t> & args,
         std::size_t position);


### PR DESCRIPTION
I've been trying to control the Z-order of various UI elements. In particular, I've been trying to get Waybar to appear over `wf-dock`. 

This allows setting up a window rule as such:

```
rule_1 = on created if app_id is "waybar" then keepabove
```

This isn't quite the same as the shortcut key as it sets `wf::LAYER_TOP` to force the window to the top. The keypress which targets workspace windows sets `wf::WORKSPACE` and `SUBLAYER_DOCKED_ABOVE`. 

This might need a different name? E.g. 

```
rule_1 = on created if app_id is "waybar" then toppanel # uipanel  depanel or whatever
```

