### PR TITLE
view: use focus_request for self-requests from xwayland and gtk-shell

### DIFF
--- a/plugins/protocols/gtk-shell.cpp
+++ b/plugins/protocols/gtk-shell.cpp
@@ -9,6 +9,7 @@
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/plugin.hpp>
 #include <wayfire/toplevel-view.hpp>
+#include <wayfire/window-manager.hpp>
 
 #include "gtk-shell.hpp"
 
@@ -91,14 +92,10 @@ static void handle_gtk_surface_present(wl_client *client, wl_resource *resource,
     uint32_t time)
 {
     auto surface = static_cast<wf_gtk_surface*>(wl_resource_get_user_data(resource));
-    wayfire_view view = wf::wl_surface_to_wayfire_view(surface->wl_surface);
+    wayfire_toplevel_view view = toplevel_cast(wf::wl_surface_to_wayfire_view(surface->wl_surface));
     if (view)
     {
-        wf::view_focus_request_signal data;
-        data.view = view;
-        data.self_request = true;
-        view->emit(&data);
-        wf::get_core().emit(&data);
+        wf::get_core().default_wm->focus_request(view, true);
     }
 }
 
@@ -113,14 +110,10 @@ static void handle_gtk_surface_request_focus(struct wl_client *client,
     const char *startup_id)
 {
     auto surface = static_cast<wf_gtk_surface*>(wl_resource_get_user_data(resource));
-    wayfire_view view = wf::wl_surface_to_wayfire_view(surface->wl_surface);
+    wayfire_toplevel_view view = toplevel_cast(wf::wl_surface_to_wayfire_view(surface->wl_surface));
     if (view)
     {
-        wf::view_focus_request_signal data;
-        data.view = view;
-        data.self_request = true;
-        view->emit(&data);
-        wf::get_core().emit(&data);
+        wf::get_core().default_wm->focus_request(view, true);
     }
 }
 

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -94,7 +94,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'09'03;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'09'22;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/window-manager.hpp
+++ b/src/api/wayfire/window-manager.hpp
@@ -45,7 +45,7 @@ class window_manager_t
     /**
      * Try to focus the view and its output.
      */
-    virtual void focus_request(wayfire_toplevel_view view);
+    virtual void focus_request(wayfire_toplevel_view view, bool self_request = false);
 
     /** Request that the view is (un)minimized */
     virtual void minimize_request(wayfire_toplevel_view view, bool minimized);

--- a/src/core/window-manager.cpp
+++ b/src/core/window-manager.cpp
@@ -104,13 +104,13 @@ void window_manager_t::resize_request(wayfire_toplevel_view view, uint32_t edges
     }
 }
 
-void window_manager_t::focus_request(wayfire_toplevel_view view)
+void window_manager_t::focus_request(wayfire_toplevel_view view, bool self_request)
 {
     if (view->get_output())
     {
         view_focus_request_signal data;
         data.view = view;
-        data.self_request = false;
+        data.self_request = self_request;
 
         view->emit(&data);
         wf::get_core().emit(&data);

--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -205,11 +205,7 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
         {
             if (!this->activated)
             {
-                wf::view_focus_request_signal data;
-                data.view = self();
-                data.self_request = true;
-                emit(&data);
-                wf::get_core().emit(&data);
+                wf::get_core().default_wm->focus_request({this}, true);
             }
         });
 


### PR DESCRIPTION
The code in xwayland and gtk-shell actually would not carry the request out!
Let's just use focus_request (which now has an argument for the self flag) rather than duplicating the carrying-out code.