### PR TITLE
update wlroots version to 0.15.0

### DIFF
--- a/plugins/single_plugins/preserve-output.cpp
+++ b/plugins/single_plugins/preserve-output.cpp
@@ -304,7 +304,7 @@ class wayfire_preserve_output : public wf::plugin_interface_t
   public:
     void init() override
     {
-        if (wlr_output_is_noop(output->handle))
+        if (wlr_output_is_headless(output->handle))
         {
             // Don't do anything for NO-OP outputs
             return;

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -82,9 +82,9 @@ extern "C"
 #if WLR_HAS_X11_BACKEND
     #include <wlr/backend/x11.h>
 #endif
-#include <wlr/backend/noop.h>
 #include <wlr/backend/wayland.h>
 #undef static
+#include <wlr/backend/headless.h>
 #include <wlr/backend/libinput.h>
 #include <wlr/backend/session.h>
 #include <wlr/util/log.h>

--- a/src/core/seat/touch.hpp
+++ b/src/core/seat/touch.hpp
@@ -73,7 +73,6 @@ class touch_interface_t
         int32_t id, uint32_t time, wf::pointf_t current);
 
     touch::gesture_state_t finger_state;
-    bool is_grabbed = false;
 
     /** Pressed a finger on a surface and dragging outside of it now */
     wf::surface_interface_t *grabbed_surface = nullptr;

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -30,37 +30,9 @@ void wayfire_exit::init()
         }
 
         idle_shutdown(nullptr);
-
         return true;
     };
 
-    // make sure to shut down wayfire if destroying the last
-    // nested backend output
-    on_output_removed.set_callback([=] (wf::signal_data_t *data)
-    {
-        auto output = wf::get_signaled_output(data);
-
-        bool is_nested_compositor = wlr_output_is_wl(output->handle);
-#if WLR_HAS_X11_BACKEND
-        is_nested_compositor |= wlr_output_is_x11(output->handle);
-#endif
-
-        int cnt_other_outputs = 0;
-        for (auto& wo : wf::get_core().output_layout->get_outputs())
-        {
-            if ((wo != output) && !wlr_output_is_noop(wo->handle))
-            {
-                ++cnt_other_outputs;
-            }
-        }
-
-        if (is_nested_compositor && (cnt_other_outputs == 0))
-        {
-            wl_event_loop_add_idle(wf::get_core().ev_loop, idle_shutdown, nullptr);
-        }
-    });
-
-    output->connect_signal("pre-remove", &on_output_removed);
     output->add_key(wf::create_option_string<wf::keybinding_t>(
         "<ctrl> <alt> KEY_BACKSPACE"), &key);
 }

--- a/src/core/wm.hpp
+++ b/src/core/wm.hpp
@@ -43,7 +43,6 @@ class wayfire_focus : public wf::plugin_interface_t
 class wayfire_exit : public wf::plugin_interface_t
 {
     wf::key_callback key;
-    wf::signal_connection_t on_output_removed;
 
   public:
     void init() override;

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -698,11 +698,6 @@ class wf::render_manager::impl
 
         on_frame.set_callback([&] (void*)
         {
-            if (wlr_output_is_noop(output->handle))
-            {
-                return;
-            }
-
             delay_manager->start_frame();
 
             auto repaint_delay = delay_manager->get_delay();


### PR DESCRIPTION
- output-layout: save output buffer ourselves on commit

It is used for mirroring later.

- output-layout: use headless instead of noop backend

First step towards #1386
