### PR TITLE
place: Add "nearmouse" mode for placing under cursor

### DIFF
--- a/metadata/place.xml
+++ b/metadata/place.xml
@@ -24,6 +24,10 @@
 				<value>random</value>
 				<_name>Random</_name>
 			</desc>
+			<desc>
+			  <value>nearmouse</value>
+			  <_name>Near Mouse</_name>
+			</desc>
 		</option>
 	</plugin>
 </wayfire>

--- a/plugins/single_plugins/place.cpp
+++ b/plugins/single_plugins/place.cpp
@@ -30,6 +30,9 @@ class wayfire_place_window : public wf::plugin_interface_t
         } else if (mode == "random")
         {
             random(view, workarea);
+        } else if (mode == "nearmouse")
+        {
+            nearmouse(view, workarea);
         } else
         {
             center(view, workarea);
@@ -106,6 +109,21 @@ class wayfire_place_window : public wf::plugin_interface_t
         pos_y = rand() % area.height + area.y;
 
         view->move(pos_x, pos_y);
+    }
+
+    void nearmouse(wayfire_view & view, wf::geometry_t workarea)
+    {
+        wf::geometry_t window = view->get_wm_geometry();
+        if ((window.width > workarea.width) || (window.height > workarea.height)) {
+            center(view, workarea);
+            return;
+        }
+        wf::pointf_t oc = output->get_cursor_position();
+        window.x = int(oc.x) - window.width / 2;
+        window.y = int(oc.y) - window.height / 2;
+
+        wf::geometry_t clamped = wf::clamp(window, workarea);
+        view->move(clamped.x, clamped.y);
     }
 
     void center(wayfire_view & view, wf::geometry_t workarea)


### PR DESCRIPTION
Add a new mode for placing new windows, where it will attempt to be placed centered under the mouse cursor. If it would run off the edge of the screen it is clamped. I think this mode is a lot friendlier than the default of placing in the center. Let me know what you think!

I saw your note about the stabilize-api branch--- but I couldn't get that one to compile. It's okay if this takes a while to merge though! No hurry.

I really love this project you've made. Thank you for your hard work and I hope I can help with it.