### PR TITLE
Updates for latest master of wlroots

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1423,8 +1423,9 @@ class output_layout_t::impl
                 wlr_output_layout_add_auto(output_layout, handle);
 
                 /* Get the correct position */
-                auto box = wlr_output_layout_get_box(output_layout, handle);
-                assert(box);
+                wlr_box box;
+                wlr_output_layout_get_box(output_layout, handle, &box);
+                assert(!wlr_box_empty(&box));
                 lo->apply_state(state);
             }
         }
@@ -1473,11 +1474,12 @@ class output_layout_t::impl
             auto head = wlr_output_configuration_head_v1_create(
                 wlr_configuration, output.first);
 
-            auto box = wlr_output_layout_get_box(output_layout, output.first);
-            if (box)
+            wlr_box box;
+            wlr_output_layout_get_box(output_layout, output.first, &box);
+            if (!wlr_box_empty(&box))
             {
-                head->state.x = box->x;
-                head->state.y = box->y;
+                head->state.x = box.x;
+                head->state.y = box.y;
             }
         }
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -163,11 +163,12 @@ wf::geometry_t wf::output_t::get_relative_geometry() const
 
 wf::geometry_t wf::output_t::get_layout_geometry() const
 {
-    auto box = wlr_output_layout_get_box(
-        wf::get_core().output_layout->get_handle(), handle);
-    if (box)
+    wlr_box box;
+    wlr_output_layout_get_box(
+        wf::get_core().output_layout->get_handle(), handle, &box);
+    if (!wlr_box_empty(&box))
     {
-        return *box;
+        return box;
     } else
     {
         LOGE("Get layout geometry for an invalid output!");

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -165,7 +165,7 @@ void wayfire_xdg_popup::close()
     {
         if (is_mapped())
         {
-            wlr_xdg_popup_destroy(popup->base);
+            wlr_xdg_popup_destroy(popup);
         }
     });
 }
@@ -241,7 +241,7 @@ void wayfire_xdg_view::initialize()
     on_set_parent.set_callback([&] (void*)
     {
         auto parent = xdg_toplevel->parent ?
-            wf::wf_view_from_void(xdg_toplevel->parent->data)->self() : nullptr;
+            wf::wf_view_from_void(xdg_toplevel->parent->base->data)->self() : nullptr;
         set_toplevel_parent(parent);
     });
     on_ping_timeout.set_callback([&] (void*)
@@ -263,9 +263,8 @@ void wayfire_xdg_view::initialize()
     });
     on_request_fullscreen.set_callback([&] (void *data)
     {
-        auto ev = static_cast<wlr_xdg_toplevel_set_fullscreen_event*>(data);
-        auto wo = wf::get_core().output_layout->find_output(ev->output);
-        fullscreen_request(wo, ev->fullscreen);
+        auto wo = wf::get_core().output_layout->find_output(xdg_toplevel->requested.fullscreen_output);
+        fullscreen_request(wo, xdg_toplevel->requested.fullscreen);
     });
 
     on_map.connect(&xdg_toplevel->base->events.map);
@@ -381,14 +380,14 @@ void wayfire_xdg_view::set_activated(bool act)
     }
 
     last_configure_serial =
-        wlr_xdg_toplevel_set_activated(xdg_toplevel->base, act);
+        wlr_xdg_toplevel_set_activated(xdg_toplevel, act);
     wf::wlr_view_t::set_activated(act);
 }
 
 void wayfire_xdg_view::set_tiled(uint32_t edges)
 {
-    wlr_xdg_toplevel_set_tiled(xdg_toplevel->base, edges);
-    last_configure_serial = wlr_xdg_toplevel_set_maximized(xdg_toplevel->base,
+    wlr_xdg_toplevel_set_tiled(xdg_toplevel, edges);
+    last_configure_serial = wlr_xdg_toplevel_set_maximized(xdg_toplevel,
         (edges == wf::TILED_EDGES_ALL));
     wlr_view_t::set_tiled(edges);
 }
@@ -397,7 +396,7 @@ void wayfire_xdg_view::set_fullscreen(bool full)
 {
     wf::wlr_view_t::set_fullscreen(full);
     last_configure_serial =
-        wlr_xdg_toplevel_set_fullscreen(xdg_toplevel->base, full);
+        wlr_xdg_toplevel_set_fullscreen(xdg_toplevel, full);
 }
 
 void wayfire_xdg_view::resize(int w, int h)
@@ -413,21 +412,21 @@ void wayfire_xdg_view::resize(int w, int h)
     {
         this->last_size_request = {w, h};
         last_configure_serial   =
-            wlr_xdg_toplevel_set_size(xdg_toplevel->base, w, h);
+            wlr_xdg_toplevel_set_size(xdg_toplevel, w, h);
     }
 }
 
 void wayfire_xdg_view::request_native_size()
 {
     last_configure_serial =
-        wlr_xdg_toplevel_set_size(xdg_toplevel->base, 0, 0);
+        wlr_xdg_toplevel_set_size(xdg_toplevel, 0, 0);
 }
 
 void wayfire_xdg_view::close()
 {
     if (xdg_toplevel)
     {
-        wlr_xdg_toplevel_send_close(xdg_toplevel->base);
+        wlr_xdg_toplevel_send_close(xdg_toplevel);
         wf::wlr_view_t::close();
     }
 }


### PR DESCRIPTION
- wlr_output_layout_get_box (now takes box as param)

- wlr_xdg_toplevel_set_fullscreen_event has been replaced by fields in
  struct wlr_xdg_toplevel_requested

I understand if you want to close this and not follow wlroots' master quite so closely. This fixes a crash for me on nvidia proprietary (wlr_renderer_init_wl_display: Assertion `argb8888 && xrgb8888" failed). I think the good commit comes from https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/59b9518f072527ac59593e51df7f5d5331a34f0e so I was hoping we could get at least to that new.