### PR TITLE
use wlroots stable

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ jobs:
     steps:
     - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libexecinfo-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake
     - uses: actions/checkout@v1
+    - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
     - run: meson build -Dtests=enabled
     - run: ninja -v -Cbuild
@@ -25,6 +26,7 @@ jobs:
 
       # Build Wayfire
     - uses: actions/checkout@v1
+    - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
     - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build
     - run: ninja -v -Cbuild

--- a/meson.build
+++ b/meson.build
@@ -31,7 +31,7 @@ pixman         = dependency('pixman-1')
 threads        = dependency('threads')
 xkbcommon      = dependency('xkbcommon')
 libdl          = meson.get_compiler('cpp').find_library('dl')
-wlroots        = dependency('wlroots', version: ['>=0.16.0', '<0.17.0'], required: get_option('use_system_wlroots'))
+wlroots        = dependency('wlroots', version: ['>=0.15.0', '<0.16.0'], required: get_option('use_system_wlroots'))
 wfconfig       = dependency('wf-config', version: ['>=0.8.0', '<0.9.0'], required: get_option('use_system_wfconfig'))
 
 use_system_wlroots = not get_option('use_system_wlroots').disabled() and wlroots.found()

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -23,7 +23,6 @@ extern "C"
 // Rendering
 #define static
 #include <wlr/types/wlr_compositor.h>
-#include <wlr/types/wlr_subcompositor.h>
 #include <wlr/render/wlr_renderer.h>
 #include <wlr/render/allocator.h>
 #include <wlr/render/gles2.h>
@@ -44,6 +43,7 @@ extern "C"
     #include <wlr/types/wlr_xdg_shell.h>
     #include <wlr/types/wlr_xdg_decoration_v1.h>
 #endif
+#include <wlr/types/wlr_surface.h>
 
 #include <wlr/types/wlr_foreign_toplevel_management_v1.h>
 #include <wlr/types/wlr_server_decoration.h>

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -183,7 +183,6 @@ void wf::compositor_core_impl_t::init()
      * init_desktop_apis() should come before input.
      * 4. GTK expects primary selection early. */
     compositor = wlr_compositor_create(display, renderer);
-    wlr_subcompositor_create(display);
 
     protocols.data_device = wlr_data_device_manager_create(display);
     protocols.primary_selection_v1 =


### PR DESCRIPTION
As discussed previously on IRC, Wayfire-git will no longer follow wlroots-git.
Instead, Wayfire will always depend on a particular wlroots release.
This should make it easier to build Wayfire-git, since the current situation is that Wayfire  lags behind wlroots-git most of the time.
