### PR TITLE
Add debug IPC

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -5,3 +5,4 @@ option('xwayland', type: 'feature', value: 'auto', description: 'Build with xway
 option('default_config_backend', type: 'string', value: 'default', description: 'Default configuration backend to use')
 option('print_trace', type: 'boolean', value: true, description: 'Print stack trace in debug logs (disables coredump)')
 option('tests', type: 'feature', value: 'auto', description: 'Enable unit tests')
+option('debug_ipc', type: 'boolean', value: 'true', description: 'Enable debugging IPC')

--- a/plugins/ipc/ipc.cpp
+++ b/plugins/ipc/ipc.cpp
@@ -1,0 +1,303 @@
+#include "ipc.hpp"
+#include <wayfire/util/log.hpp>
+#include <wayfire/core.hpp>
+
+#include <fcntl.h>
+#include <sys/socket.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+/**
+ * Handle WL_EVENT_READABLE on the socket.
+ * Indicates a new connection.
+ */
+int wl_loop_handle_ipc_fd_connection(int, uint32_t, void *data)
+{
+    auto ipc = (wf::ipc::server_t*)data;
+    ipc->accept_new_client();
+    return 0;
+}
+
+wf::ipc::server_t::server_t(std::string socket_path)
+{
+    this->fd = setup_socket(socket_path.c_str());
+    if (fd == -1)
+    {
+        LOGE("Failed to create debug IPC socket!");
+        return;
+    }
+
+    listen(fd, 3);
+    source = wl_event_loop_add_fd(wl_display_get_event_loop(
+        wf::get_core().display), fd,
+        WL_EVENT_READABLE, wl_loop_handle_ipc_fd_connection, this);
+}
+
+wf::ipc::server_t::~server_t()
+{
+    close(fd);
+    unlink(saddr.sun_path);
+    wl_event_source_remove(source);
+}
+
+void wf::ipc::server_t::register_method(
+    std::string method, method_cb handler)
+{
+    this->methods[method] = handler;
+}
+
+void wf::ipc::server_t::unregister_method(std::string method)
+{
+    this->methods.erase(method);
+}
+
+nlohmann::json wf::ipc::server_t::call_method(std::string method,
+    nlohmann::json data)
+{
+    if (this->methods.count(method))
+    {
+        return this->methods[method](std::move(data));
+    }
+
+    return {
+        {"error", "No such method found!"}
+    };
+}
+
+int wf::ipc::server_t::setup_socket(const char *address)
+{
+    int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+    if (fd == -1)
+    {
+        return -1;
+    }
+
+    if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1)
+    {
+        return -1;
+    }
+
+    if (fcntl(fd, F_SETFL, O_NONBLOCK) == -1)
+    {
+        return -1;
+    }
+
+    // Ensure no old instance left after a crash or similar
+    unlink(address);
+
+    saddr.sun_family = AF_UNIX;
+    strncpy(saddr.sun_path, address, sizeof(saddr.sun_path) - 1);
+
+    int r = bind(fd, (sockaddr*)&saddr, sizeof(saddr));
+    if (r != 0)
+    {
+        LOGE("Failed to bind debug IPC socket at address ", address, " !");
+        // TODO: shutdown socket?
+        return -1;
+    }
+
+    return fd;
+}
+
+void wf::ipc::server_t::accept_new_client()
+{
+    // Heavily inspired by Sway
+    int cfd = accept(this->fd, NULL, NULL);
+    if (cfd == -1)
+    {
+        LOGW("Error accepting client connection");
+        return;
+    }
+
+    int flags;
+    if (((flags = fcntl(cfd, F_GETFD)) == -1) ||
+        (fcntl(cfd, F_SETFD, flags | FD_CLOEXEC) == -1))
+    {
+        LOGE("Failed setting CLOEXEC");
+        close(cfd);
+        return;
+    }
+
+    if (((flags = fcntl(cfd, F_GETFL)) == -1) ||
+        (fcntl(cfd, F_SETFL, flags | O_NONBLOCK) == -1))
+    {
+        LOGE("Failed setting NONBLOCK");
+        close(cfd);
+        return;
+    }
+
+    this->clients.push_back(std::make_unique<client_t>(this, cfd));
+}
+
+void wf::ipc::server_t::client_disappeared(client_t *client)
+{
+    LOGI("Removing IPC client");
+    auto it = std::remove_if(clients.begin(), clients.end(),
+        [&] (const auto& cl) { return cl.get() == client; });
+    clients.erase(it, clients.end());
+}
+
+/* --------------------------- Per-client code ------------------------------*/
+
+int wl_loop_handle_ipc_client_fd_event(int, uint32_t mask, void *data)
+{
+    auto client = (wf::ipc::client_t*)data;
+    client->handle_fd_activity(mask);
+    return 0;
+}
+
+static constexpr int MAX_MESSAGE_LEN = (1 << 20);
+static constexpr int HEADER_LEN = 4;
+
+wf::ipc::client_t::client_t(server_t *ipc, int fd)
+{
+    LOGD("New IPC client, fd ", fd);
+
+    this->fd  = fd;
+    this->ipc = ipc;
+
+    auto ev_loop = wf::get_core().ev_loop;
+    source = wl_event_loop_add_fd(ev_loop, fd, WL_EVENT_READABLE,
+        wl_loop_handle_ipc_client_fd_event, this);
+
+    // +1 for null byte at the end
+    buffer.resize(MAX_MESSAGE_LEN + 1);
+}
+
+// -1 error, 0 success, 1 try again later
+int wf::ipc::client_t::read_up_to(int n, int *available)
+{
+    int need = n - current_buffer_valid;
+    int want = std::min(need, *available);
+
+    while (want > 0)
+    {
+        int r = read(fd, buffer.data() + current_buffer_valid, want);
+        if (r <= 0)
+        {
+            LOGI("Read: EOF or error (%d) %s\n", r, strerror(errno));
+            return -1;
+        }
+
+        want -= r;
+        *available -= r;
+        current_buffer_valid += r;
+    }
+
+    if (current_buffer_valid < n)
+    {
+        // didn't read all n letters
+        return 1;
+    }
+
+    return 0;
+}
+
+void wf::ipc::client_t::handle_fd_activity(uint32_t event_mask)
+{
+    if (event_mask & (WL_EVENT_ERROR | WL_EVENT_HANGUP))
+    {
+        ipc->client_disappeared(this);
+        // this no longer exists
+        return;
+    }
+
+    int available = 0;
+    if (ioctl(this->fd, FIONREAD, &available) != 0)
+    {
+        LOGE("Failed to inspect message buffer!");
+        ipc->client_disappeared(this);
+        return;
+    }
+
+    while (available > 0)
+    {
+        if (current_buffer_valid < HEADER_LEN)
+        {
+            if (read_up_to(HEADER_LEN, &available) < 0)
+            {
+                ipc->client_disappeared(this);
+                return;
+            }
+
+            continue;
+        }
+
+        const uint32_t len = *((uint32_t*)buffer.data());
+        if (len > MAX_MESSAGE_LEN - HEADER_LEN)
+        {
+            LOGE("Client tried to pass too long a message!");
+            ipc->client_disappeared(this);
+            return;
+        }
+
+        const int next_target = HEADER_LEN + len;
+        int r = read_up_to(next_target, &available);
+        LOGE("We got ", r);
+        if (r < 0)
+        {
+            ipc->client_disappeared(this);
+            return;
+        }
+
+        if (r > 0)
+        {
+            // Try again
+            continue;
+        }
+
+        // Finally, received the message, make sure we have a terminating NULL byte
+        buffer[current_buffer_valid] = '\0';
+        char *str    = buffer.data() + HEADER_LEN;
+        auto message = nlohmann::json::parse(str, nullptr, false);
+        if (message.is_discarded())
+        {
+            LOGE("Client's message could not be parsed: ", str);
+            ipc->client_disappeared(this);
+            return;
+        }
+
+        if (!message.contains("method"))
+        {
+            LOGE("Client's message does not contain a method to be called!");
+            ipc->client_disappeared(this);
+            return;
+        }
+
+        send_json(ipc->call_method(message["method"], message["data"]));
+        // Reset for next message
+        current_buffer_valid = 0;
+    }
+}
+
+wf::ipc::client_t::~client_t()
+{
+    wl_event_source_remove(source);
+    shutdown(fd, SHUT_RDWR);
+    close(this->fd);
+}
+
+static bool write_exact(int fd, char *buf, int n)
+{
+    while (n > 0)
+    {
+        int w = write(fd, buf, n);
+        if (w <= 0)
+        {
+            return false;
+        }
+
+        n -= w;
+    }
+
+    return true;
+}
+
+void wf::ipc::client_t::send_json(nlohmann::json json)
+{
+    std::string buffer = json.dump();
+    uint32_t len = buffer.length();
+
+    write_exact(fd, (char*)&len, 4);
+    write_exact(fd, buffer.data(), len);
+}

--- a/plugins/ipc/ipc.hpp
+++ b/plugins/ipc/ipc.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+#include <sys/un.h>
+#include <wayfire/object.hpp>
+#include <variant>
+#include <wayland-server.h>
+
+namespace wf
+{
+namespace ipc
+{
+struct error_response_t
+{
+    std::string message;
+    nlohmann::json data;
+};
+
+/**
+ * Represents a single connected client to the IPC.
+ */
+class server_t;
+class client_t
+{
+  public:
+    client_t(server_t *ipc, int fd);
+    ~client_t();
+
+    /** Handle incoming data on the socket */
+    void handle_fd_activity(uint32_t event_mask);
+    void send_json(nlohmann::json json);
+
+  private:
+    int fd;
+    wl_event_source *source;
+    server_t *ipc;
+
+    int current_buffer_valid = 0;
+    std::vector<char> buffer;
+    int read_up_to(int n, int *available);
+
+    client_t(const client_t&) = delete;
+    client_t(client_t&&) = delete;
+    client_t& operator =(const client_t&) = delete;
+    client_t& operator =(client_t&&) = delete;
+};
+
+class server_t
+{
+  public:
+    using method_cb = std::function<nlohmann::json(nlohmann::json)>;
+
+    server_t(std::string socket_path);
+    ~server_t();
+
+    // Register a handler for the given method
+    // It will get the params object from the request, and must return either a valid
+    // json object indicating the
+    // response or an error.
+    void register_method(std::string method, method_cb handler);
+    void unregister_method(std::string method);
+
+    // non-copyable, non-movable
+    server_t(const server_t&) = delete;
+    server_t(server_t&&) = delete;
+    server_t& operator =(const server_t&) = delete;
+    server_t& operator =(server_t&&) = delete;
+
+    nlohmann::json call_method(std::string method, nlohmann::json data);
+
+    void accept_new_client();
+    void client_disappeared(client_t *client);
+
+  private:
+    int fd;
+    /**
+     * Setup a socket at the given address, and set it as CLOEXEC and non-blocking.
+     */
+    int setup_socket(const char *address);
+
+    sockaddr_un saddr;
+    wl_event_source *source;
+
+    std::map<std::string, method_cb> methods;
+    std::vector<std::unique_ptr<client_t>> clients;
+};
+}
+}

--- a/plugins/ipc/meson.build
+++ b/plugins/ipc/meson.build
@@ -1,0 +1,10 @@
+json = subproject('json').get_variable('nlohmann_json_dep')
+evdev = dependency('libevdev')
+
+
+ipc = shared_module('ipc',
+    ['ipc.cpp', 'stipc.cpp'],
+    include_directories: [wayfire_api_inc, plugins_common_inc],
+    dependencies: [wlroots, pixman, wfconfig, wftouch, json, evdev],
+    install: true,
+    install_dir: conf_data.get('PLUGIN_PATH'))

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -1,0 +1,102 @@
+#include <wayfire/singleton-plugin.hpp>
+#include <wayfire/view.hpp>
+#include <wayfire/output.hpp>
+#include <wayfire/workspace-manager.hpp>
+#include <getopt.h>
+
+#include "ipc.hpp"
+
+namespace wf
+{
+static nlohmann::json geometry_to_json(wf::geometry_t g)
+{
+    nlohmann::json j;
+    j["x"]     = g.x;
+    j["y"]     = g.y;
+    j["width"] = g.width;
+    j["height"] = g.height;
+    return j;
+}
+
+static std::string layer_to_string(uint32_t layer)
+{
+    switch (layer)
+    {
+      case LAYER_BACKGROUND:
+        return "background";
+
+      case LAYER_BOTTOM:
+        return "bottom";
+
+      case LAYER_WORKSPACE:
+        return "workspace";
+
+      case LAYER_TOP:
+        return "top";
+
+      case LAYER_UNMANAGED:
+        return "unmanaged";
+
+      case LAYER_LOCK:
+        return "lock";
+
+      case LAYER_DESKTOP_WIDGET:
+        return "dew";
+
+      case LAYER_MINIMIZED:
+        return "minimized";
+
+      default:
+        break;
+    }
+
+    return "none";
+}
+
+class ipc_plugin_t
+{
+  public:
+    ipc_plugin_t()
+    {
+        char *pre_socket   = getenv("_WAYFIRE_SOCKET");
+        const auto& dname  = wf::get_core().wayland_display;
+        std::string socket = pre_socket ?: "/tmp/wayfire-" + dname + ".socket";
+        setenv("WAYFIRE_SOCKET", socket.c_str(), 1);
+
+        server = std::make_unique<ipc::server_t>(socket);
+        server->register_method("core/list_views", list_views);
+    }
+
+    using method_t = ipc::server_t::method_cb;
+
+    method_t list_views = [] (nlohmann::json)
+    {
+        auto response = nlohmann::json::array();
+
+        for (auto& view : wf::get_core().get_all_views())
+        {
+            nlohmann::json v;
+            v["title"]    = view->get_title();
+            v["app-id"]   = view->get_app_id();
+            v["geometry"] = geometry_to_json(view->get_wm_geometry());
+            v["base-geometry"] = geometry_to_json(view->get_output_geometry());
+            v["state"] = {
+                {"tiled", view->tiled_edges},
+                {"fullscreen", view->fullscreen},
+                {"minimized", view->minimized},
+            };
+
+            auto layer = view->get_output()->workspace->get_view_layer(view);
+            v["layer"] = layer_to_string(layer);
+
+            response.push_back(v);
+        }
+
+        return response;
+    };
+
+    std::unique_ptr<ipc::server_t> server;
+};
+}
+
+DECLARE_WAYFIRE_PLUGIN((wf::singleton_plugin_t<wf::ipc_plugin_t, false>));

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -175,6 +175,7 @@ class ipc_plugin_t
         server->register_method("core/move_cursor", move_cursor);
         server->register_method("core/run", run);
         server->register_method("core/ping", ping);
+        server->register_method("core/get_display", get_display);
     }
 
     using method_t = ipc::server_t::method_cb;
@@ -353,6 +354,14 @@ class ipc_plugin_t
     method_t ping = [=] (nlohmann::json data)
     {
         return get_ok();
+    };
+
+    method_t get_display = [=] (nlohmann::json data)
+    {
+        nlohmann::json dpy;
+        dpy["wayland"]  = wf::get_core().wayland_display;
+        dpy["xwayland"] = wf::get_core().get_xwayland_display();
+        return dpy;
     };
 
     std::unique_ptr<ipc::server_t> server;

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -335,6 +335,17 @@ class ipc_plugin_t
         return get_ok();
     };
 
+    method_t run = [=] (nlohmann::json data)
+    {
+        if (!data.count("cmd") || !data["cmd"].is_string())
+        {
+            return get_error("run command needs a cmd to run");
+        }
+
+        wf::get_core().run(data["cmd"]);
+        return get_ok();
+    };
+
     std::unique_ptr<ipc::server_t> server;
     std::unique_ptr<headless_input_backend_t> input;
 };

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -347,8 +347,9 @@ class ipc_plugin_t
             return get_error("run command needs a cmd to run");
         }
 
-        wf::get_core().run(data["cmd"]);
-        return get_ok();
+        auto response = get_ok();
+        response["pid"] = wf::get_core().run(data["cmd"]);
+        return response;
     };
 
     method_t ping = [=] (nlohmann::json data)

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -171,6 +171,10 @@ class ipc_plugin_t
         server->register_method("core/list_views", list_views);
         server->register_method("core/create_wayland_output", create_wayland_output);
         server->register_method("core/feed_key", feed_key);
+        server->register_method("core/feed_button", feed_button);
+        server->register_method("core/move_cursor", move_cursor);
+        server->register_method("core/run", run);
+        server->register_method("core/ping", ping);
     }
 
     using method_t = ipc::server_t::method_cb;
@@ -343,6 +347,11 @@ class ipc_plugin_t
         }
 
         wf::get_core().run(data["cmd"]);
+        return get_ok();
+    };
+
+    method_t ping = [=] (nlohmann::json data)
+    {
         return get_ok();
     };
 

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,5 +1,9 @@
 subdir('common')
-subdir('ipc')
+
+if get_option('debug_ipc')
+  subdir('ipc')
+endif
+
 subdir('vswitch')
 subdir('wobbly')
 subdir('grid')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,4 +1,5 @@
 subdir('common')
+subdir('ipc')
 subdir('vswitch')
 subdir('wobbly')
 subdir('grid')

--- a/subprojects/json.wrap
+++ b/subprojects/json.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = nlohmann_json-3.9.1
+lead_directory_missing = true
+source_url = https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip
+source_filename = nlohmann_json-3.9.1.zip
+source_hash = 6bea5877b1541d353bd77bdfbdb2696333ae5ed8f9e8cc22df657192218cad91
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/nlohmann_json/3.9.1/1/get_zip
+patch_filename = nlohmann_json-3.9.1-1-wrap.zip
+patch_hash = 1774e5506fbe3897d652f67e41973194b948d2ab851cf464a742f35f160a1435
+
+[provide]
+nlohmann_json = nlohmann_json_dep


### PR DESCRIPTION
This PR adds a simple IPC mechanism to Wayfire.

The purpose of this PR and all features it will ever implement are the bare minimum needed for automatic Wayfire tests. I have started working on some [tests](https://github.com/ammen99/wayfire-tests), however, the tests are quite opinionated and incomplete, so they are not included in the Wayfire organization yet.

Obviously, some users will (ab)use this IPC mechanism, especially as it will get more powerful features like querying workspaces. However, I do not recommend this, as this IPC **is not meant for users**, but for automatic tests. As a consequence, no features to the `stipc.cpp` plugin will be accepted which are not useful for the automatic tests.

The plugin is meant to be kept at the bare minimum necessary for the tests, as the idea is to simulate actual workflows. For example, it is preferrable to use the `core/move_cursor` and `core/feed_button` twice to maximize a client by clicking on its CSD than to add an IPC method which calls `view_interface_t::maximize_request` directly.
