### PR TITLE
Make signal API identify signals by their signal data and not arbitrary strings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libexecinfo-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive

--- a/src/api/wayfire/signal-provider.hpp
+++ b/src/api/wayfire/signal-provider.hpp
@@ -81,6 +81,14 @@ class connection_t final : public connection_base_t
         set_callback(callback);
     }
 
+    /** Initialize a signal connection with the given callback */
+    template<class T, class U = convertible_to_callback_t<T>>
+    connection_t& operator =(const T& callback)
+    {
+        set_callback(callback);
+        return *this;
+    }
+
     template<class T>
     connection_t(std::function<void(T*)>& callback) : connection_t()
     {

--- a/src/api/wayfire/signal-provider.hpp
+++ b/src/api/wayfire/signal-provider.hpp
@@ -1,0 +1,215 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <unordered_set>
+#include <wayfire/nonstd/safe-list.hpp>
+#include <cassert>
+#include <typeindex>
+
+namespace wf
+{
+namespace signal
+{
+class provider_t;
+
+/**
+ * A base class for all connection_t, needed to store list of connections in a
+ * type-safe way.
+ */
+class connection_base_t
+{
+  public:
+    connection_base_t(const connection_base_t&) = delete;
+    connection_base_t(connection_base_t&&) = delete;
+    connection_base_t& operator =(const connection_base_t&) = delete;
+    connection_base_t& operator =(connection_base_t&&) = delete;
+
+    /**
+     * Automatically disconnects from every connected provider.
+     */
+    virtual ~connection_base_t()
+    {
+        disconnect();
+    }
+
+    /** Disconnect from all connected signal providers */
+    void disconnect();
+
+  protected:
+    connection_base_t()
+    {}
+
+    // Allow provider to deregister itself
+    friend class provider_t;
+    std::unordered_set<provider_t*> connected_to;
+};
+
+namespace detail
+{
+template<class Type, class U = void>
+struct has_c_name : public std::false_type {};
+template<class Type>
+struct has_c_name<Type, decltype(Type::c_name)> : public std::true_type {};
+}
+
+/**
+ * A connection to a signal on an object.
+ * Uses RAII to automatically disconnect the signal when it goes out of scope.
+ */
+template<class SignalType>
+class connection_t final : public connection_base_t
+{
+  public:
+    using callback = std::function<void (SignalType*)>;
+
+    /** Initialize an empty signal connection */
+    connection_t()
+    {}
+
+    /** Automatically disconnects from all providers */
+    virtual ~connection_t()
+    {}
+
+    template<class CallbackType> using convertible_to_callback_t =
+        std::enable_if_t<std::is_constructible_v<callback, CallbackType>, void>;
+
+    /** Initialize a signal connection with the given callback */
+    template<class T, class U = convertible_to_callback_t<T>>
+    connection_t(const T& callback) : connection_t()
+    {
+        set_callback(callback);
+    }
+
+    template<class T>
+    connection_t(std::function<void(T*)>& callback) : connection_t()
+    {
+        set_callback(callback);
+    }
+
+    /** Set the signal callback or override the existing signal callback. */
+    void set_callback(callback cb)
+    {
+        this->current_callback = cb;
+    }
+
+    /** Call the stored callback with the given data. */
+    void emit(SignalType *data)
+    {
+        if (current_callback)
+        {
+            current_callback(data);
+        }
+    }
+
+  private:
+    // Non-copyable and non-movable, as that would require updating/duplicating
+    // the signal handler. But this is usually not what users of this API want.
+    // Also provider_t holds pointers to this object.
+    connection_t(const connection_t&) = delete;
+    connection_t(connection_t&&) = delete;
+    connection_t& operator =(const connection_t&) = delete;
+    connection_t& operator =(connection_t&&) = delete;
+
+    callback current_callback;
+};
+
+class provider_t
+{
+  public:
+    /**
+     * Signals are designed to be useful for C++ plugins, however, they are
+     * generally quite difficult to bind in other languages.
+     * To avoid this problem, signal::provider_t also provides C-friendlier
+     * callback support.
+     *
+     * The order of arguments is: (this_pointer, signal_name, data_pointer)
+     */
+    using c_api_callback = std::function<void (void*, const char*, void*)>;
+
+    /** Register a connection to be called when the given signal is emitted. */
+    template<class SignalType>
+    void connect(connection_t<SignalType> *callback)
+    {
+        typed_connections[index<SignalType>()].push_back(callback);
+        callback->connected_to.insert(this);
+    }
+
+    void connect(c_api_callback *cb)
+    {
+        untyped_connections.push_back(cb);
+    }
+
+    /** Unregister a connection. */
+    void disconnect(connection_base_t *callback)
+    {
+        callback->connected_to.erase(this);
+        for (auto& [id, connected] : typed_connections)
+        {
+            connected.remove_all(callback);
+        }
+    }
+
+    void disconnect(c_api_callback *cb)
+    {
+        untyped_connections.remove_all(cb);
+    }
+
+    /** Emit the given signal. */
+    template<class SignalType>
+    void emit(SignalType *data)
+    {
+        auto& conns = typed_connections[std::type_index(typeid(SignalType))];
+        conns.for_each([&] (connection_base_t *tc)
+        {
+            auto real_type = dynamic_cast<connection_t<SignalType>*>(tc);
+            assert(real_type);
+            real_type->emit(data);
+        });
+
+        // If the signal provides C-style signal name, then emit it to C-API
+        // users as well.
+        if constexpr (detail::has_c_name<SignalType>::value)
+        {
+            untyped_connections.for_each([&] (c_api_callback *cb)
+            {
+                (*cb)(this, SignalType::c_name, data);
+            });
+        }
+    }
+
+    provider_t()
+    {}
+
+    ~provider_t()
+    {
+        for (auto& [id, connected] : typed_connections)
+        {
+            connected.for_each([&] (connection_base_t *base)
+            {
+                base->connected_to.erase(this);
+            });
+        }
+    }
+
+    // Non-movable, non-copyable: connection_t keeps reference to this object.
+    // Unclear what happens if this object is duplicated, and plugins usually
+    // don't want this either.
+    provider_t(const provider_t& other) = delete;
+    provider_t& operator =(const provider_t& other) = delete;
+    provider_t(provider_t&& other) = delete;
+    provider_t& operator =(provider_t&& other) = delete;
+
+  private:
+    template<class SignalType>
+    static inline std::type_index index()
+    {
+        return std::type_index(typeid(SignalType));
+    }
+
+    wf::safe_list_t<c_api_callback*> untyped_connections;
+    std::unordered_map<std::type_index, wf::safe_list_t<connection_base_t*>>
+    typed_connections;
+};
+}
+}

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -3,6 +3,17 @@
 #include <unordered_map>
 #include <set>
 
+#include <wayfire/signal-provider.hpp>
+
+void wf::signal::connection_base_t::disconnect()
+{
+    auto connected_copy = this->connected_to;
+    for (auto& x : connected_copy)
+    {
+        x->disconnect(this);
+    }
+}
+
 /* Implementation note: because of circular dependencies between
  * signal_connection_t and signal_provider_t, the chosen way to resolve
  * them is to have signal_provider_t directly modify signal_connection_t

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -2,8 +2,12 @@
 #include <wayfire/debug.hpp>
 #include <sstream>
 #include <iomanip>
-#include <execinfo.h>
-#include <cxxabi.h>
+
+#if __has_include(<execinfo.h>)
+    #include <execinfo.h>
+    #include <cxxabi.h>
+#endif
+
 #include <cstdio>
 #include <dlfcn.h>
 #include <sys/stat.h>
@@ -11,6 +15,7 @@
 #define MAX_FRAMES 256
 #define MAX_FUNCTION_NAME 1024
 
+#if __has_include(<execinfo.h>)
 struct demangling_result
 {
     std::string executable;
@@ -253,6 +258,15 @@ void wf::print_trace(bool fast_mode)
 
     free(symbollist);
 }
+
+#else // has <execinfo.h>
+void wf::print_trace(bool)
+{
+    LOGE("Compiled without execinfo.h, cannot provide a backtrace!",
+        " Try using address sanitizer.");
+}
+
+#endif
 
 /* ------------------- Impl of debugging functions ---------------------------*/
 #include <iomanip>


### PR DESCRIPTION
@Javyre thoughts ?

Eventually, this should fix #1307 

If anybody is interested in why I want to do this change, some of the rationale is described here: https://github.com/WayfireWM/wayfire/commit/22741481159b28a7c7204c87d3d3530b85902e83

Also, this new implementation can be improved even further to use static storage for different signals (thus eliminating the unordered_map lookup), also we can use a simpler `safe_vector_t`-like type to make iteration cache-efficient and lower the overhead of signals even further, if need be. Currently, signals are not that critical for performance and I have opted for a simpler (and a bit slower) implementation.