### PR TITLE
input: allow directly specifying a keymap file

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -66,6 +66,11 @@
 				<_long>Sets the variant of the keyboard, like `dvorak` or `colemak`.</_long>
 				<default></default>
 			</option>
+			<option name="xkb_keymap_file" type="string">
+				<_short>XKB keymap file</_short>
+				<_long>Path to a complete XKB keymap to be used.  If this option is non-empty, the other xkb options are ignored in favor of it.</_long>
+				<default></default>
+			</option>
 		</group>
 		<!-- Mouse -->
 		<group>

--- a/src/core/seat/keyboard.hpp
+++ b/src/core/seat/keyboard.hpp
@@ -39,7 +39,7 @@ class keyboard_t
     void reload_input_options();
 
     wf::option_wrapper_t<std::string>
-    model, variant, layout, options, rules;
+    model, variant, layout, options, rules, keymap_file;
     wf::option_wrapper_t<int> repeat_rate, repeat_delay;
     /** Options have changed in the config file */
     bool dirty_options = true;


### PR DESCRIPTION
A new `xkb_keymap_file` option is added, with which a complete keymap
can be specified.
If this option is set, the keymap is loaded from the corresponding
file and the other xkb options  (rules, mnodel, layout, variant
and options) are ignored.