### PR TITLE
add a threadpool to wayfire

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "subprojects/wf-touch"]
 	path = subprojects/wf-touch
 	url = https://github.com/WayfireWM/wf-touch
+[submodule "subprojects/thread-pool"]
+	path = subprojects/thread-pool
+	url = https://github.com/bshoshany/thread-pool

--- a/plugins/animate/fire/particle.hpp
+++ b/plugins/animate/fire/particle.hpp
@@ -82,8 +82,7 @@ class ParticleSystem
     std::vector<float> center;
 
     OpenGL::program_t program;
-    void exec_worker_threads(std::function<void(int, int)> spawn_worker);
-    void update_worker(float time, int start, int end);
+    void update_worker(float time, int i);
     void create_program();
 };
 

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -7,6 +7,8 @@
 #include <wayfire/config-backend.hpp>
 
 #include <sys/types.h>
+#include <functional>
+#include <future>
 #include <limits>
 #include <vector>
 #include <wayfire/nonstd/observer_ptr.h>
@@ -353,6 +355,15 @@ class compositor_core_t : public wf::object_base_t
      * @return The current state of the compositor.
      */
     virtual compositor_state_t get_current_state() = 0;
+
+    /**
+     * Submit a task to the thread-pool.
+     *
+     * @param task The function to submit.
+     * @param args The arguments to pass to the function.
+     * @return A future to wait on for the function to finish executing.
+     */
+    virtual std::future<void> submit_task(std::function<void(void *)> task, void *args) = 0;
 
     /**
      * Shut down the whole compositor.

--- a/src/core/BS_thread_pool.hpp
+++ b/src/core/BS_thread_pool.hpp
@@ -1,0 +1,1 @@
+../../subprojects/thread-pool/BS_thread_pool.hpp

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -5,6 +5,8 @@
 #include "wayfire/util.hpp"
 #include <wayfire/nonstd/wlroots-full.hpp>
 
+#include <functional>
+#include <future>
 #include <set>
 #include <unordered_map>
 
@@ -16,6 +18,7 @@ namespace wf
 class seat_t;
 class input_manager_t;
 class input_method_relay;
+class thread_pool;
 class compositor_core_impl_t : public compositor_core_t
 {
   public:
@@ -102,6 +105,7 @@ class compositor_core_impl_t : public compositor_core_t
     pid_t run(std::string command) override;
     void shutdown() override;
     compositor_state_t get_current_state() override;
+    std::future<void> submit_task(std::function<void(void *)> task, void *args) override;
 
   protected:
     wf::wl_listener_wrapper decoration_created;
@@ -134,6 +138,8 @@ class compositor_core_impl_t : public compositor_core_t
     wf::signal_connection_t on_new_output;
 
     compositor_state_t state = compositor_state_t::UNKNOWN;
+
+    std::unique_ptr<thread_pool> pool;
 
     compositor_core_impl_t();
     virtual ~compositor_core_impl_t();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -30,6 +30,7 @@
 #include "main.hpp"
 
 #include "core-impl.hpp"
+#include "thread-pool.hpp"
 
 /* decorations impl */
 struct wf_server_decoration_t
@@ -306,6 +307,8 @@ void wf::compositor_core_impl_t::init()
 
     init_last_view_tracking();
     this->state = compositor_state_t::START_BACKEND;
+
+    this->pool = std::make_unique<thread_pool>();
 }
 
 void wf::compositor_core_impl_t::init_last_view_tracking()
@@ -870,6 +873,11 @@ void wf::compositor_core_impl_t::move_view_to_output(wayfire_view v,
     }
 
     this->emit_signal("view-moved-to-output", &data);
+}
+
+std::future<void> wf::compositor_core_impl_t::submit_task(std::function<void(void *)> task, void *args)
+{
+  return this->pool->submit_task(task, args);
 }
 
 wf::compositor_core_t::compositor_core_t()

--- a/src/core/thread-pool.hpp
+++ b/src/core/thread-pool.hpp
@@ -1,0 +1,22 @@
+#ifndef WF_CORE_THREAD_POOL_HPP
+#define WF_CORE_THREAD_POOL_HPP
+
+#include "BS_thread_pool.hpp"
+
+namespace wf
+{
+
+class thread_pool: public BS::thread_pool
+{
+public:
+  using BS::thread_pool::thread_pool;
+
+  std::future<void> submit_task(std::function<void(void *)> &task, void *args)
+  {
+    return submit(task, args);
+  }
+};
+
+}
+
+#endif /* end of include guard: WF_CORE_THREAD_POOL_HPP */


### PR DESCRIPTION
implement threadpool TODOs from fire/particle.cpp
add a threadpool to wayfire

the threadpool is also available to plugins to submit tasks, via submit_task. reduces the burden on each plugin to implement their own worker threads and managing tasks. currently only exposes a very small subset of functionality which can be later expanded on demand.

Signed-off-by: Aisha Tammy <aisha@bsd.ac>

---

**Notice: Wayfire's development is temporarily happening in the `stabilize-api` branch. If you open a pull request for the master branch, it will likely not be merged before the stabilize-api branch is itself merged into master.**
