### PR TITLE
core: fix crash when connecting graphics tablet

### DIFF
--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -469,7 +469,7 @@ void wf::tablet_pad_t::update_focus(wlr_surface *focus_surface)
     {
         wlr_tablet_v2_tablet_pad_notify_enter(pad_v2,
             attached_to->tablet_v2, focus_surface);
-    } else
+    } else if (old_focus)
     {
         wlr_tablet_v2_tablet_pad_notify_leave(pad_v2, old_focus);
     }


### PR DESCRIPTION
Fixes issue #1415, which is a crash when plugging in a graphics tablet, by adding a null check. It appears to be necessary to have a window open and XWayland running to trigger the bug.

I developed this against `v0.7.2` but rebased to `master` for this pull request. I can switch to another branch as well - I'm a bit new to this whole open-source thing, so I'm not sure what's best to do.