### PR TITLE
debug: enable compilation without execinfo.h

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libexecinfo-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive

--- a/src/debug-func.hpp
+++ b/src/debug-func.hpp
@@ -2,8 +2,12 @@
 #include <wayfire/debug.hpp>
 #include <sstream>
 #include <iomanip>
-#include <execinfo.h>
-#include <cxxabi.h>
+
+#if __has_include(<execinfo.h>)
+    #include <execinfo.h>
+    #include <cxxabi.h>
+#endif
+
 #include <cstdio>
 #include <dlfcn.h>
 #include <sys/stat.h>
@@ -11,6 +15,7 @@
 #define MAX_FRAMES 256
 #define MAX_FUNCTION_NAME 1024
 
+#if __has_include(<execinfo.h>)
 struct demangling_result
 {
     std::string executable;
@@ -253,6 +258,15 @@ void wf::print_trace(bool fast_mode)
 
     free(symbollist);
 }
+
+#else // has <execinfo.h>
+void wf::print_trace(bool)
+{
+    LOGE("Compiled without execinfo.h, cannot provide a backtrace!",
+        " Try using address sanitizer.");
+}
+
+#endif
 
 /* ------------------- Impl of debugging functions ---------------------------*/
 #include <iomanip>


### PR DESCRIPTION
Otherwise, the CI breaks, as Alpine does not have execinfo anymore. If not present, we cannot generate a backtrace, so we just print that.

**Notice: Wayfire's development is temporarily happening in the `stabilize-api` branch. If you open a pull request for the master branch, it will likely not be merged before the stabilize-api branch is itself merged into master.**
