### PR TITLE
Remove get_promoted_views() from header

### DIFF
--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -192,13 +192,15 @@ class wayfire_idle_singleton : public wf::singleton_plugin_t<wayfire_idle>
             &fullscreen_state_changed);
         disable_on_fullscreen.set_callback(disable_on_fullscreen_changed);
 
-        auto fs_views = output->workspace->get_promoted_views(
-            output->workspace->get_current_workspace());
+        if (output->get_active_view() && output->get_active_view()->fullscreen)
+        {
+            /* Currently, the fullscreen count would always be 0 or 1,
+             * since fullscreen-layer-focused is only emitted on changes between 0
+             * and 1
+             **/
+            has_fullscreen = true;
+        }
 
-        /* Currently, the fullscreen count would always be 0 or 1,
-         * since fullscreen-layer-focused is only emitted on changes between 0 and 1
-         **/
-        has_fullscreen = fs_views.size() > 0;
         update_fullscreen();
 
         screensaver_timeout.set_callback([=] ()

--- a/src/api/wayfire/workspace-manager.hpp
+++ b/src/api/wayfire/workspace-manager.hpp
@@ -168,14 +168,6 @@ class workspace_manager
     std::vector<wayfire_view> get_minimized_views();
 
     /**
-     * Get a list of reordered fullscreen views as explained in
-     * get_views_in_layer().
-     *
-     * This returns only the view on the given workspace.
-     */
-    std::vector<wayfire_view> get_promoted_views(wf::point_t workspace);
-
-    /**
      * @return The current workspace implementation
      */
     workspace_implementation_t *get_workspace_implementation();


### PR DESCRIPTION
The function was removed, which broke idle. Fix idle by counting fullscreen views manually instead of using get_promoted_views() and remove the function from the header.