### PR TITLE
Feat: Implement wlr_foregin_toplevel_handle's fullscreen management

### DIFF
--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -202,6 +202,7 @@ class wlr_view_t :
         toplevel_handle_v1_activate_request,
         toplevel_handle_v1_minimize_request,
         toplevel_handle_v1_set_rectangle_request,
+        toplevel_handle_v1_fullscreen_request,
         toplevel_handle_v1_close_request;
 
     /* Create/destroy the toplevel_handle */


### PR DESCRIPTION
**Notice: Wayfire's development is temporarily happening in the `stabilize-api` branch. If you open a pull request for the master branch, it will likely not be merged before the stabilize-api branch is itself merged into master.**

I'm closing the [older PR](https://github.com/WayfireWM/wayfire/pull/1557) in favor of this. There is no difference between that and this, except for the uncrustify.