### PR TITLE
simple-tile: fix use-after-move error in preview implementations

### DIFF
--- a/plugins/tile/tree-controller.cpp
+++ b/plugins/tile/tree-controller.cpp
@@ -244,7 +244,7 @@ void move_view_controller_t::ensure_preview(wf::point_t start)
     auto view = std::make_unique<wf::preview_indication_view_t>(start);
     this->preview = {view};
     wf::get_core().add_view(std::move(view));
-    view->set_output(output);
+    this->preview->set_output(output);
 }
 
 void move_view_controller_t::input_motion(wf::point_t input)


### PR DESCRIPTION
**Notice: Wayfire's development is temporarily happening in the `stabilize-api` branch. If you open a pull request for the master branch, it will likely not be merged before the stabilize-api branch is itself merged into master.**
