### PR TITLE
vswitch: check target_ws and ws before setting last_dir

### DIFF
--- a/plugins/vswitch/wayfire/plugins/vswitch.hpp
+++ b/plugins/vswitch/wayfire/plugins/vswitch.hpp
@@ -507,7 +507,10 @@ class control_bindings_t
         // and not just move a view around.
         if (!window_only)
         {
-            this->last_dir = target_ws - ws;
+            if (target_ws != ws)
+            {
+                this->last_dir = target_ws - ws;
+            }
         }
 
         return callback(target_ws - ws, view, window_only);


### PR DESCRIPTION
**Notice: Wayfire's development is temporarily happening in the `stabilize-api` branch. If you open a pull request for the master branch, it will likely not be merged before the stabilize-api branch is itself merged into master.**

This PR fixes a small annoyance with the `binding_last` functionality of `vswitch` (thanks for this btw :-))

Basically, if I'm in e.g. workspace 1, go to workspace 2, then go again to workspace 2 (by pressing the key for `binding_2`), `last_dir` becomes 2, and essentially "forgets" 1.

With this PR `last_dir` is only set when `target_ws` differs from `ws`.
