### PR TITLE
Delete pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-**Notice: Wayfire's development is temporarily happening in the `stabilize-api` branch. If you open a pull request for the master branch, it will likely not be merged before the stabilize-api branch is itself merged into master.**


### PR DESCRIPTION
The stabilize-api branch is not that useful, because the planned changes to Wayfire are going much slower than expected. Therefore, development just continues in master as usual, some PRs may however be delayed.
