### PR TITLE
Add tablet motion options

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -224,6 +224,28 @@
 				<min>0.0</min>
 			</option>
 		</group>
+		<!-- Tablet configuration -->
+		<group>
+			<_short>Tablet</_short>
+			<_long>Configure graphic tablets.</_long>
+			<option name="tablet_motion_mode" type="string">
+				<_short>Motion Mode</_short>
+				<_long>Sets the motion mode for graphic tablets.</_long>
+				<default>default</default>
+				<desc>
+					<value>default</value>
+					<_name>Default</_name>
+				</desc>
+				<desc>
+					<value>absolute</value>
+					<_name>Absolute</_name>
+				</desc>
+				<desc>
+					<value>relative</value>
+					<_name>Relative</_name>
+				</desc>
+			</option>
+		</group>
 		<!-- Cursor configuration -->
 		<group>
 			<_short>Cursor</_short>

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -18,6 +18,7 @@ struct pointing_device_t : public input_device_impl_t
         wf::option_wrapper_t<bool> middle_emulation;
         wf::option_wrapper_t<double> mouse_cursor_speed;
         wf::option_wrapper_t<double> mouse_scroll_speed;
+        wf::option_wrapper_t<std::string> tablet_motion_mode;
         wf::option_wrapper_t<double> touchpad_cursor_speed;
         wf::option_wrapper_t<double> touchpad_scroll_speed;
         wf::option_wrapper_t<std::string> touchpad_click_method;

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -321,19 +321,33 @@ void wf::tablet_t::handle_axis(wlr_event_tablet_tool_axis *ev,
     input_event_processing_mode_t mode)
 {
     auto& input = wf::get_core_impl().input;
+    std::string motion_mode = wf::option_wrapper_t<std::string>(
+        "input/tablet_motion_mode");
 
     /* Update cursor position */
-    switch (ev->tool->type)
+    if (motion_mode == "absolute")
     {
-      case WLR_TABLET_TOOL_TYPE_MOUSE:
-        wlr_cursor_move(cursor, ev->device, ev->dx, ev->dy);
-        break;
-
-      default:
         double x = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) ? ev->x : NAN;
         double y = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_Y) ? ev->y : NAN;
         wlr_cursor_warp_absolute(cursor, ev->device, x, y);
-    }
+    } else if (motion_mode == "relative")
+    {
+        wlr_cursor_move(cursor, ev->device, ev->dx, ev->dy);
+    } else 
+    {
+    	/* Use from libinput recommended defaults */
+		switch (ev->tool->type)
+		{
+		  case WLR_TABLET_TOOL_TYPE_MOUSE:
+		    wlr_cursor_move(cursor, ev->device, ev->dx, ev->dy);
+		    break;
+
+		  default:
+		    double x = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) ? ev->x : NAN;
+		    double y = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_Y) ? ev->y : NAN;
+		    wlr_cursor_warp_absolute(cursor, ev->device, x, y);
+		}
+	}
 
     if (input->input_grabbed())
     {

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -333,21 +333,21 @@ void wf::tablet_t::handle_axis(wlr_event_tablet_tool_axis *ev,
     } else if (motion_mode == "relative")
     {
         wlr_cursor_move(cursor, ev->device, ev->dx, ev->dy);
-    } else 
+    } else
     {
-    	/* Use from libinput recommended defaults */
-		switch (ev->tool->type)
-		{
-		  case WLR_TABLET_TOOL_TYPE_MOUSE:
-		    wlr_cursor_move(cursor, ev->device, ev->dx, ev->dy);
-		    break;
+        /* Use from libinput recommended defaults */
+        switch (ev->tool->type)
+        {
+          case WLR_TABLET_TOOL_TYPE_MOUSE:
+            wlr_cursor_move(cursor, ev->device, ev->dx, ev->dy);
+            break;
 
-		  default:
-		    double x = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) ? ev->x : NAN;
-		    double y = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_Y) ? ev->y : NAN;
-		    wlr_cursor_warp_absolute(cursor, ev->device, x, y);
-		}
-	}
+          default:
+            double x = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_X) ? ev->x : NAN;
+            double y = (ev->updated_axes & WLR_TABLET_TOOL_AXIS_Y) ? ev->y : NAN;
+            wlr_cursor_warp_absolute(cursor, ev->device, x, y);
+        }
+    }
 
     if (input->input_grabbed())
     {


### PR DESCRIPTION
> Fixes the issue about motion of graphical tablets opened from me a while ago: https://github.com/WayfireWM/wayfire/issues/1137

> I'm not an C++ developer and also do not really know how the wayfire internals work but I made this changes for myself and they seem to work. So maybe they can be merged with a couple of adjustments here and there.

New pull request to target master. Original has been #1414.