### PR TITLE
Add an option "rules" to window-rules with type "dynamic-list"

### DIFF
--- a/metadata/window-rules.xml
+++ b/metadata/window-rules.xml
@@ -4,5 +4,13 @@
 		<_short>Window Rules</_short>
 		<_long>A plugin to apply specific commands to windows by using various criteria.</_long>
 		<category>Window Management</category>
+		<option name="rules" type="dynamic-list">
+			<_short>Window rules</_short>
+			<_long>Apply specific commands to windows by using various criteria</_long>
+			<entry prefix="rule_" type="string">
+				<_short>Rule</_short>
+				<_long>Defines the rule to be applied</_long>
+			</entry>
+		</option>
 	</plugin>
 </wayfire>


### PR DESCRIPTION
Currently, window-rules does not have any option. Therefore, it's difficult for the parser to auto-magically load the stored rules. Furthermore, since it does not have any option defined, wcm also does not list the rules, or allow it's modification. This MR adds the "rules" option of type "dynamic-list" to window-rules.xml file.