### PR TITLE
Scenegraph: make scanout a scenegraph operation

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -38,5 +38,9 @@
       Exceptions are made for options not available via wlr-output-management, like output mirroring and custom modelines.</_long>
       <default>false</default>
     </option>
+    <option name="remove_output_limits" type="bool">
+      <_short>Allow views to overlap between multiple outputs. Many of the core plugins will not behave properly with this option set!</_short>
+      <default>false</default>
+    </option>
 	</plugin>
 </wayfire>

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -281,6 +281,12 @@ class blur_render_instance_t : public render_instance_t
         OpenGL::render_end();
     }
 
+    direct_scanout try_scanout(wf::output_t *output) override
+    {
+        // Enable direct scanout if it is possible
+        return scene::try_scanout_from_list(view_instance, output);
+    }
+
     bool has_instances()
     {
         return !view_instance.empty();

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -14,6 +14,7 @@
 #include "plugins/common/wayfire/plugins/common/shared-core-data.hpp"
 #include "wayfire/core.hpp"
 #include "wayfire/debug.hpp"
+#include "wayfire/geometry.hpp"
 #include "wayfire/object.hpp"
 #include "wayfire/opengl.hpp"
 #include "wayfire/region.hpp"
@@ -297,7 +298,7 @@ class blur_node_t : public floating_inner_node_t
     }
 
     void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback push_damage) override
+        damage_callback push_damage, const std::optional<wf::geometry_t>&) override
     {
         instances.push_back(std::make_unique<blur_render_instance_t>(
             this, provider, push_damage));

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -99,7 +99,7 @@ class blur_render_instance_t : public render_instance_t
 
   public:
     blur_render_instance_t(node_t *self, blur_algorithm_provider provider,
-        damage_callback push_damage, std::optional<wf::geometry_t> vp)
+        damage_callback push_damage, wf::output_t *shown_on)
     {
         this->self     = self;
         this->provider = provider;
@@ -113,7 +113,7 @@ class blur_render_instance_t : public render_instance_t
         this->cached_damage |= self->get_bounding_box();
         for (auto& ch : self->get_children())
         {
-            ch->gen_render_instances(view_instance, push_damage_child, vp);
+            ch->gen_render_instances(view_instance, push_damage_child, shown_on);
         }
     }
 
@@ -303,11 +303,10 @@ class blur_node_t : public floating_inner_node_t
     }
 
     void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback push_damage,
-        const std::optional<wf::geometry_t>& vp) override
+        damage_callback push_damage, wf::output_t *shown_on) override
     {
         auto uptr = std::make_unique<blur_render_instance_t>(
-            this, provider, push_damage, vp);
+            this, provider, push_damage, shown_on);
 
         if (uptr->has_instances())
         {

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -273,6 +273,25 @@ class wayfire_move : public wf::plugin_interface_t
 
     bool initiate(wayfire_view view)
     {
+        // First, make sure that the view is on the output the input is.
+        auto pos = get_global_input_coords();
+        auto target_output =
+            wf::get_core().output_layout->get_output_at(pos.x, pos.y);
+
+        if (target_output && (view->get_output() != target_output))
+        {
+            auto offset = wf::origin(view->get_output()->get_layout_geometry()) +
+                -wf::origin(target_output->get_layout_geometry());
+
+            wf::get_core().move_view_to_output(view, target_output, false);
+            view->move(view->get_wm_geometry().x + offset.x,
+                view->get_wm_geometry().y + offset.y);
+
+            // On the new output
+            view->move_request();
+            return false;
+        }
+
         wayfire_view grabbed_view = view;
         view = get_target_view(view);
         if (!can_move_view(view))

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -98,9 +98,7 @@ class tile_plugin_t : public wf::plugin_interface_t
                 tiled_sublayer[i][j] =
                     std::make_shared<wf::scene::floating_inner_node_t>(false);
 
-                wf::scene::add_front(
-                    output->node_for_layer(wf::scene::layer::WORKSPACE)->dynamic,
-                    tiled_sublayer[i][j]);
+                wf::scene::add_front(output->get_wset(), tiled_sublayer[i][j]);
             }
         }
 
@@ -605,9 +603,7 @@ class tile_plugin_t : public wf::plugin_interface_t
     void destroy_sublayer(wf::scene::floating_inner_ptr sublayer)
     {
         // Transfer views to the top
-        auto root = output->node_for_layer(
-            wf::scene::layer::WORKSPACE)->dynamic;
-
+        auto root     = output->get_wset();
         auto children = root->get_children();
         auto sublayer_children = sublayer->get_children();
         sublayer->set_children_list({});

--- a/src/api/wayfire/debug.hpp
+++ b/src/api/wayfire/debug.hpp
@@ -59,13 +59,15 @@ namespace log
 enum class logging_category : size_t
 {
     // Transactions - general
-    TXN  = 0,
+    TXN     = 0,
     // Transactions - view instructions
-    TXNV = 1,
+    TXNV    = 1,
     // Transactions - instructions lifetime (pending, ready, timeout, etc.)
-    TXNI = 2,
+    TXNI    = 2,
     // Wlroots messages
-    WLR  = 3,
+    WLR     = 3,
+    // Direct scanout
+    SCANOUT = 4,
     TOTAL,
 };
 

--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -104,6 +104,12 @@ class output_t : public wf::object_base_t
         wf::scene::layer layer) const = 0;
 
     /**
+     * Get the workspace set of the output. This is a floating node which contains
+     * all the regular views of an output in the WORKSPACE layer.
+     */
+    virtual scene::floating_inner_ptr get_wset() const = 0;
+
+    /**
      * Checks if a plugin can activate. This may not succeed if a plugin
      * with the same abilities is already active or if input is inhibited.
      *

--- a/src/api/wayfire/scene-input.hpp
+++ b/src/api/wayfire/scene-input.hpp
@@ -15,19 +15,6 @@ using node_ptr = std::shared_ptr<node_t>;
 }
 
 /**
- * When a node receives any type of input, it should report how it handled the
- * event. Thus, depending on the node, the input event may be propagated to other
- * nodes or not.
- */
-enum class input_action
-{
-    /** Do not propagate events further, current node consumed the event. */
-    CONSUME,
-    /** Event processed by the node, but other nodes should also receive it. */
-    PROPAGATE,
-};
-
-/**
  * An interface for scene nodes which interact with the keyboard.
  *
  * Note that by default, nodes do not receive keyboard input. Nodes which wish
@@ -63,10 +50,8 @@ class keyboard_interaction_t
      *
      * @return What should happen with the further processing of the event.
      */
-    virtual input_action handle_keyboard_key(wlr_event_keyboard_key event)
-    {
-        return input_action::PROPAGATE;
-    }
+    virtual void handle_keyboard_key(wlr_event_keyboard_key event)
+    {}
 
     keyboard_interaction_t() = default;
     virtual ~keyboard_interaction_t()
@@ -117,11 +102,9 @@ class pointer_interaction_t
      * @param pointer_position The position where the pointer is currently at.
      * @param button The wlr event describing the event.
      */
-    virtual input_action handle_pointer_button(
+    virtual void handle_pointer_button(
         const wlr_event_pointer_button& event)
-    {
-        return input_action::PROPAGATE;
-    }
+    {}
 
     /**
      * The user moved the pointer.
@@ -129,11 +112,9 @@ class pointer_interaction_t
      * @param pointer_position The new position of the pointer.
      * @param time_ms The time reported by the device when the event happened.
      */
-    virtual input_action handle_pointer_motion(wf::pointf_t pointer_position,
+    virtual void handle_pointer_motion(wf::pointf_t pointer_position,
         uint32_t time_ms)
-    {
-        return input_action::PROPAGATE;
-    }
+    {}
 
     /**
      * The user scrolled.
@@ -141,10 +122,8 @@ class pointer_interaction_t
      * @param pointer_position The position where the pointer is currently at.
      * @param event A structure describing the event.
      */
-    virtual input_action handle_pointer_axis(const wlr_event_pointer_axis& event)
-    {
-        return input_action::PROPAGATE;
-    }
+    virtual void handle_pointer_axis(const wlr_event_pointer_axis& event)
+    {}
 };
 
 /**

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -32,11 +32,7 @@ class output_layout_t;
  * Level 3: in each layer, there is a special output node for each currently
  *   enabled output. By default, this node's bounding box is limited to the
  *   extents of the output, so that no nodes overlap multiple outputs.
- * Level 4: in each output node, there is a static and a dynamic container.
- *   Static containers contain views which do not change when workspace sets
- *   are changed, for example layer-shell views. Dynamic containers contain
- *   the views which are bound to the current workspace set.
- * Level 5 and beyond: These levels typically contain views and group of views,
+ * Level 4 and beyond: These levels typically contain views and group of views,
  *   or special effects (particle systems and the like).
  *
  * Each level may contain additional nodes added by plugins (or by core in the
@@ -57,13 +53,12 @@ class output_layout_t;
  *
  * - A similar 'trick' can be used for grabbing all input on a particular output
  *   and is the preferred way to do what input grabs used to do prior to Wayfire
- *   0.8.0. To emulate a grab, create an input-only scene node in the OVERRIDE
- *   layer on an output (it thus gets all touch and pointer input automatically)
- *   and make it use an exclusive keyboard input mode to grab the keyboard as
- *   well.
+ *   0.8.0. To emulate a grab, create an input-only scene node and place it above
+ *   every other node. Thus it will always be selected for input on the output it
+ *   is visible on.
  *
- * - Always-on-top views are simply nodes which are placed above the dynamic
- *   container of the workspace layer of each output.
+ * - Always-on-top views are simply nodes which are placed above the workspace
+ *   set of each output.
  *
  * Regarding coordinate systems: each node possesses a coordinate system. Some
  * nodes (for example, nodes which simply group other nodes together) share the
@@ -354,21 +349,6 @@ class output_node_t final : public floating_inner_node_t
     wf::geometry_t get_bounding_box() override;
 
     std::optional<input_node_t> find_node_at(const wf::pointf_t& at) override;
-
-    /**
-     * A container for the static child nodes.
-     * Static child nodes are always below the dynamic nodes of an output and
-     * are usually not modified when the workspace on the output changes, so
-     * things like backgrounds and panels are usually static.
-     */
-    std::shared_ptr<floating_inner_node_t> _static;
-
-    /**
-     * A container for the dynamic child nodes.
-     * These nodes move together with the output's workspaces.
-     * These nodes are most commonly views.
-     */
-    std::shared_ptr<floating_inner_node_t> dynamic;
 
     /**
      * Get the output this node is responsible for.

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -196,19 +196,16 @@ class node_t : public std::enable_shared_from_this<node_t>,
      *   are sorted from the foremost (or topmost) to the last (bottom-most).
      * @param push_damage A callback used to report damage on the new render
      *   instance.
-     * @param viewport An optional parameter describing the target area which
-     *   will be rendered to. It may be too big (or infinite if not set). This
-     *   information can be used as a hint to avoid adding render instances which
-     *   are not needed - for example to avoid render instances for views on
-     *   outputs they will never be visible on. Note that this is a conservative
-     *   approximation, that is, render instances may be added if they are not
-     *   needed, but they must be added if they are ever to become visible in the
-     *   target viewport.
+     * @param output An optional parameter describing which output the render
+     *   instances will be shown on. It can be used to avoid generating instances
+     *   on outputs where the node should not be shown. However, this should be
+     *   conservatively approximated - it is fine to generate more render
+     *   instances than necessary, but not less.
      */
     virtual void gen_render_instances(
         std::vector<render_instance_uptr>& instances,
         damage_callback push_damage,
-        const std::optional<wf::geometry_t>& viewport = {});
+        wf::output_t *output = nullptr);
 
     /**
      * Generate a texture from the node.
@@ -357,7 +354,7 @@ class output_node_t final : public floating_inner_node_t
     void gen_render_instances(
         std::vector<render_instance_uptr>& instances,
         damage_callback push_damage,
-        const std::optional<wf::geometry_t>& viewport) override;
+        wf::output_t *output) override;
 
     wf::geometry_t get_bounding_box() override;
     std::optional<input_node_t> find_node_at(const wf::pointf_t& at) override;

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -196,9 +196,19 @@ class node_t : public std::enable_shared_from_this<node_t>,
      *   are sorted from the foremost (or topmost) to the last (bottom-most).
      * @param push_damage A callback used to report damage on the new render
      *   instance.
+     * @param viewport An optional parameter describing the target area which
+     *   will be rendered to. It may be too big (or infinite if not set). This
+     *   information can be used as a hint to avoid adding render instances which
+     *   are not needed - for example to avoid render instances for views on
+     *   outputs they will never be visible on. Note that this is a conservative
+     *   approximation, that is, render instances may be added if they are not
+     *   needed, but they must be added if they are ever to become visible in the
+     *   target viewport.
      */
-    virtual void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback push_damage);
+    virtual void gen_render_instances(
+        std::vector<render_instance_uptr>& instances,
+        damage_callback push_damage,
+        const std::optional<wf::geometry_t>& viewport = {});
 
     /**
      * Generate a texture from the node.
@@ -344,10 +354,12 @@ class output_node_t final : public floating_inner_node_t
      * The output's render instance simply adjusts damage, rendering, etc. to
      * account for the output's position in the output layout.
      */
-    void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback push_damage) override;
-    wf::geometry_t get_bounding_box() override;
+    void gen_render_instances(
+        std::vector<render_instance_uptr>& instances,
+        damage_callback push_damage,
+        const std::optional<wf::geometry_t>& viewport) override;
 
+    wf::geometry_t get_bounding_box() override;
     std::optional<input_node_t> find_node_at(const wf::pointf_t& at) override;
 
     /**

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -197,7 +197,8 @@ class node_t : public std::enable_shared_from_this<node_t>,
      * The default implementation just generates render instances from its
      * children.
      *
-     * @param instances A vector of render instances to add to.
+     * @param instances A vector of render instances to add to. The instances
+     *   are sorted from the foremost (or topmost) to the last (bottom-most).
      * @param push_damage A callback used to report damage on the new render
      *   instance.
      */

--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -228,7 +228,7 @@ class surface_root_node_t : public wf::scene::floating_inner_node_t
     void gen_render_instances(
         std::vector<render_instance_uptr>& instances,
         damage_callback damage,
-        const std::optional<wf::geometry_t>& viewport) override;
+        wf::output_t *output) override;
     wf::geometry_t get_bounding_box() override;
 
   private:
@@ -254,7 +254,7 @@ class surface_node_t : public wf::scene::node_t
     void gen_render_instances(
         std::vector<render_instance_uptr>& instances,
         damage_callback damage,
-        const std::optional<wf::geometry_t>& viewport) override;
+        wf::output_t *output) override;
     wf::geometry_t get_bounding_box() override;
 
   private:

--- a/src/api/wayfire/surface.hpp
+++ b/src/api/wayfire/surface.hpp
@@ -225,8 +225,10 @@ class surface_root_node_t : public wf::scene::floating_inner_node_t
     wf::pointf_t to_global(const wf::pointf_t& point) override;
 
     std::string stringify() const override;
-    void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback damage) override;
+    void gen_render_instances(
+        std::vector<render_instance_uptr>& instances,
+        damage_callback damage,
+        const std::optional<wf::geometry_t>& viewport) override;
     wf::geometry_t get_bounding_box() override;
 
   private:
@@ -249,8 +251,10 @@ class surface_node_t : public wf::scene::node_t
         return si;
     }
 
-    void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback damage) override;
+    void gen_render_instances(
+        std::vector<render_instance_uptr>& instances,
+        damage_callback damage,
+        const std::optional<wf::geometry_t>& viewport) override;
     wf::geometry_t get_bounding_box() override;
 
   private:

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -622,8 +622,10 @@ class view_node_t : public scene::floating_inner_node_t
      * Views currently gather damage, etc. manually from the surfaces,
      * and sometimes render them, sometimes not ...
      */
-    void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback push_damage) override;
+    void gen_render_instances(
+        std::vector<render_instance_uptr>& instances,
+        damage_callback push_damage,
+        const std::optional<wf::geometry_t>& viewport) override;
 
     std::optional<wf::texture_t> to_texture() const override;
     wf::geometry_t get_bounding_box() override;

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -625,7 +625,7 @@ class view_node_t : public scene::floating_inner_node_t
     void gen_render_instances(
         std::vector<render_instance_uptr>& instances,
         damage_callback push_damage,
-        const std::optional<wf::geometry_t>& viewport) override;
+        wf::output_t *output) override;
 
     std::optional<wf::texture_t> to_texture() const override;
     wf::geometry_t get_bounding_box() override;

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -295,11 +295,16 @@ class output_render_instance_t : public default_render_instance_t
 
   public:
     output_render_instance_t(output_node_t *self, damage_callback callback,
-        wf::output_t *output) :
+        wf::output_t *output, std::optional<wf::geometry_t> vp) :
         default_render_instance_t(self, transform_damage(callback))
     {
         this->self   = self;
         this->output = output;
+
+        if (vp)
+        {
+            vp = vp.value() + -wf::origin(output->get_layout_geometry());
+        }
 
         // Children are stored as a sublist, because we need to translate every
         // time between global and output-local geometry.
@@ -308,7 +313,7 @@ class output_render_instance_t : public default_render_instance_t
             if (child->is_enabled())
             {
                 child->gen_render_instances(children,
-                    transform_damage(callback));
+                    transform_damage(callback), vp);
             }
         }
     }
@@ -379,7 +384,7 @@ void output_node_t::gen_render_instances(
     }
 
     instances.push_back(
-        std::make_unique<output_render_instance_t>(this, push_damage, output));
+        std::make_unique<output_render_instance_t>(this, push_damage, output, vp));
 }
 
 wf::geometry_t output_node_t::get_bounding_box()

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -137,26 +137,6 @@ static int get_layer_index(const wf::scene::node_t *node)
     return -1;
 }
 
-static bool is_dynamic_output(const wf::scene::node_t *node)
-{
-    if (auto output = dynamic_cast<wf::scene::output_node_t*>(node->parent()))
-    {
-        return node == output->dynamic.get();
-    }
-
-    return false;
-}
-
-static bool is_static_output(const wf::scene::node_t *node)
-{
-    if (auto output = dynamic_cast<wf::scene::output_node_t*>(node->parent()))
-    {
-        return node == output->_static.get();
-    }
-
-    return false;
-}
-
 std::string node_t::stringify() const
 {
     std::string description = "node ";
@@ -178,12 +158,6 @@ std::string node_t::stringify() const
             (size_t)layer::ALL_LAYERS);
         description  = "layer_";
         description += layer_names[layer_idx];
-    } else if (is_static_output(this))
-    {
-        description = "static";
-    } else if (is_dynamic_output(this))
-    {
-        description = "dynamic";
     }
 
     return description + " " + stringify_flags();
@@ -283,10 +257,7 @@ wf::geometry_t node_t::get_bounding_box()
 // remove them dynamically ...
 output_node_t::output_node_t(wf::output_t *output) : floating_inner_node_t(false)
 {
-    this->output  = output;
-    this->_static = std::make_shared<floating_inner_node_t>(true);
-    this->dynamic = std::make_shared<floating_inner_node_t>(true);
-    set_children_unchecked({dynamic, _static});
+    this->output = output;
 }
 
 std::string output_node_t::stringify() const

--- a/src/core/seat/drag-icon.cpp
+++ b/src/core/seat/drag-icon.cpp
@@ -90,7 +90,7 @@ class dnd_root_icon_root_node_t : public floating_inner_node_t
      * and sometimes render them, sometimes not ...
      */
     void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback push_damage, const std::optional<wf::geometry_t>&) override
+        damage_callback push_damage, wf::output_t *output) override
     {
         instances.push_back(std::make_unique<dnd_icon_root_render_instance_t>(
             this, icon, push_damage));

--- a/src/core/seat/drag-icon.cpp
+++ b/src/core/seat/drag-icon.cpp
@@ -90,7 +90,7 @@ class dnd_root_icon_root_node_t : public floating_inner_node_t
      * and sometimes render them, sometimes not ...
      */
     void gen_render_instances(std::vector<render_instance_uptr>& instances,
-        damage_callback push_damage) override
+        damage_callback push_damage, const std::optional<wf::geometry_t>&) override
     {
         instances.push_back(std::make_unique<dnd_icon_root_render_instance_t>(
             this, icon, push_damage));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,6 +189,11 @@ void parse_extended_debugging(const std::vector<std::string>& categories)
             LOGD("Enabling extended debugging for wlroots");
             wf::log::enabled_categories.set(
                 (size_t)wf::log::logging_category::WLR, 1);
+        } else if (cat == "scanout")
+        {
+            LOGD("Enabling extended debugging for direct scanout");
+            wf::log::enabled_categories.set(
+                (size_t)wf::log::logging_category::SCANOUT, 1);
         } else
         {
             LOGE("Unrecognized debugging category \"", cat, "\"");

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -16,6 +16,7 @@ class output_impl_t : public output_t
 {
   private:
     std::shared_ptr<scene::output_node_t> nodes[TOTAL_LAYERS];
+    scene::floating_inner_ptr wset;
 
   private:
     std::unordered_multiset<wf::plugin_grab_interface_t*> active_plugins;
@@ -66,8 +67,9 @@ class output_impl_t : public output_t
     /**
      * Implementations of the public APIs
      */
-    virtual std::shared_ptr<wf::scene::output_node_t> node_for_layer(
+    std::shared_ptr<wf::scene::output_node_t> node_for_layer(
         wf::scene::layer layer) const override;
+    scene::floating_inner_ptr get_wset() const override;
     bool can_activate_plugin(const plugin_grab_interface_uptr& owner,
         uint32_t flags = 0) override;
     bool can_activate_plugin(uint32_t caps, uint32_t flags = 0) override;

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -11,6 +11,7 @@
 #include "wayfire-shell.hpp"
 #include "../core/seat/input-manager.hpp"
 #include "../view/xdg-shell.hpp"
+#include <memory>
 #include <wayfire/util/log.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
 
@@ -34,6 +35,9 @@ wf::output_impl_t::output_impl_t(wlr_output *handle,
         scene::add_back(root->layers[layer], nodes[layer]);
     }
 
+    wset = std::make_shared<scene::floating_inner_node_t>(false);
+    scene::add_front(node_for_layer(scene::layer::WORKSPACE), wset);
+
     workspace = std::make_unique<workspace_manager>(this);
     render    = std::make_unique<render_manager>(this);
 
@@ -49,6 +53,11 @@ std::shared_ptr<wf::scene::output_node_t> wf::output_impl_t::node_for_layer(
     wf::scene::layer layer) const
 {
     return nodes[(int)layer];
+}
+
+wf::scene::floating_inner_ptr wf::output_impl_t::get_wset() const
+{
+    return this->wset;
 }
 
 void wf::output_impl_t::start_plugins()

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -27,11 +27,18 @@ wf::output_impl_t::output_impl_t(wlr_output *handle,
     this->set_effective_size(effective_size);
     this->handle = handle;
 
+    wf::option_wrapper_t<bool> remove_output_limits{
+        "workarounds/remove_output_limits"};
+
     auto& root = wf::get_core().scene();
     for (size_t layer = 0; layer < (size_t)scene::layer::ALL_LAYERS; layer++)
     {
         nodes[layer] = std::make_shared<scene::output_node_t>(this);
-        nodes[layer]->limit_region = get_layout_geometry();
+        if (!remove_output_limits)
+        {
+            nodes[layer]->limit_region = get_layout_geometry();
+        }
+
         scene::add_back(root->layers[layer], nodes[layer]);
     }
 

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -53,7 +53,7 @@ struct output_damage_t
         };
 
         render_instances.clear();
-        root->gen_render_instances(render_instances, push_damage);
+        root->gen_render_instances(render_instances, push_damage, {});
     }
 
     output_damage_t(output_t *output)

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -53,7 +53,8 @@ struct output_damage_t
         };
 
         render_instances.clear();
-        root->gen_render_instances(render_instances, push_damage, {});
+        root->gen_render_instances(render_instances, push_damage,
+            wo->get_layout_geometry());
     }
 
     output_damage_t(output_t *output)

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -53,8 +53,7 @@ struct output_damage_t
         };
 
         render_instances.clear();
-        root->gen_render_instances(render_instances, push_damage,
-            wo->get_layout_geometry());
+        root->gen_render_instances(render_instances, push_damage, wo);
     }
 
     output_damage_t(output_t *output)

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -93,8 +93,15 @@ class output_layer_manager_t
         damage_views(view);
         auto idx = (wf::scene::layer)layer_index_from_mask(layer);
         scene::remove_child(view->get_root_node());
-        scene::add_front(output->node_for_layer(idx)->dynamic,
-            view->get_root_node());
+
+        if (layer == LAYER_WORKSPACE)
+        {
+            scene::add_front(output->get_wset(), view->get_root_node());
+        } else
+        {
+            scene::add_front(output->node_for_layer(idx), view->get_root_node());
+        }
+
         damage_views(view);
     }
 

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -15,6 +15,7 @@
 #include "../view/view-impl.hpp"
 #include "output-impl.hpp"
 #include "wayfire/debug.hpp"
+#include "wayfire/option-wrapper.hpp"
 #include "wayfire/scene-input.hpp"
 #include "wayfire/scene.hpp"
 
@@ -652,14 +653,21 @@ class workspace_manager::impl
     wf::output_t *output;
     wf::geometry_t output_geometry;
 
+    wf::option_wrapper_t<bool> remove_output_limits{
+        "workarounds/remove_output_limits"};
+
+
     signal_connection_t output_geometry_changed = [&] (void*)
     {
         using namespace wf::scene;
 
-        for (int i = 0; i < (int)wf::scene::layer::ALL_LAYERS; i++)
+        if (!remove_output_limits)
         {
-            output->node_for_layer((layer)i)->limit_region =
-                output->get_layout_geometry();
+            for (int i = 0; i < (int)wf::scene::layer::ALL_LAYERS; i++)
+            {
+                output->node_for_layer((layer)i)->limit_region =
+                    output->get_layout_geometry();
+            }
         }
 
         wf::scene::update(wf::get_core().scene(), update_flag::INPUT_STATE);

--- a/src/view/surface-node.cpp
+++ b/src/view/surface-node.cpp
@@ -99,7 +99,7 @@ class surface_render_instance_t : public render_instance_t
 
 void surface_node_t::gen_render_instances(
     std::vector<render_instance_uptr> & instances, damage_callback damage,
-    const std::optional<wf::geometry_t>&)
+    wf::output_t *output)
 {
     instances.push_back(std::make_unique<surface_render_instance_t>(this->si));
 }

--- a/src/view/surface-node.cpp
+++ b/src/view/surface-node.cpp
@@ -98,7 +98,8 @@ class surface_render_instance_t : public render_instance_t
 };
 
 void surface_node_t::gen_render_instances(
-    std::vector<render_instance_uptr> & instances, damage_callback damage)
+    std::vector<render_instance_uptr> & instances, damage_callback damage,
+    const std::optional<wf::geometry_t>&)
 {
     instances.push_back(std::make_unique<surface_render_instance_t>(this->si));
 }

--- a/src/view/surface-pointer-interaction.cpp
+++ b/src/view/surface-pointer-interaction.cpp
@@ -184,8 +184,7 @@ class surface_pointer_interaction_t final : public wf::pointer_interaction_t
         this->surface = si;
     }
 
-    wf::input_action handle_pointer_button(const wlr_event_pointer_button& event)
-    final
+    void handle_pointer_button(const wlr_event_pointer_button& event) final
     {
         auto& seat = wf::get_core_impl().seat;
         bool drag_was_active = seat->drag_active;
@@ -211,8 +210,6 @@ class surface_pointer_interaction_t final : public wf::pointer_interaction_t
                     node->local_coords.x, node->local_coords.y);
             }
         }
-
-        return wf::input_action::CONSUME;
     }
 
     void handle_pointer_enter(wf::pointf_t local) final
@@ -237,8 +234,7 @@ class surface_pointer_interaction_t final : public wf::pointer_interaction_t
         wf::get_core().connect_signal("pointer_motion", &on_pointer_motion);
     }
 
-    wf::input_action handle_pointer_motion(wf::pointf_t local,
-        uint32_t time_ms) final
+    void handle_pointer_motion(wf::pointf_t local, uint32_t time_ms) final
     {
         auto& seat = wf::get_core_impl().seat;
         if (seat->drag_active)
@@ -248,7 +244,7 @@ class surface_pointer_interaction_t final : public wf::pointer_interaction_t
             // possible events. It then needs to make sure that the correct node
             // receives the event.
             handle_motion_dnd(time_ms);
-            return wf::input_action::CONSUME;
+            return;
         }
 
         if (auto cs = wf::compositor_surface_from_surface(surface))
@@ -258,11 +254,9 @@ class surface_pointer_interaction_t final : public wf::pointer_interaction_t
         {
             wlr_seat_pointer_notify_motion(seat->seat, time_ms, local.x, local.y);
         }
-
-        return wf::input_action::CONSUME;
     }
 
-    wf::input_action handle_pointer_axis(const wlr_event_pointer_axis& ev) final
+    void handle_pointer_axis(const wlr_event_pointer_axis& ev) final
     {
         if (auto cs = wf::compositor_surface_from_surface(surface))
         {
@@ -273,8 +267,6 @@ class surface_pointer_interaction_t final : public wf::pointer_interaction_t
             wlr_seat_pointer_notify_axis(seat, ev.time_msec, ev.orientation,
                 ev.delta, ev.delta_discrete, ev.source);
         }
-
-        return wf::input_action::CONSUME;
     }
 
     void handle_pointer_leave() final

--- a/src/view/surface-root-node.cpp
+++ b/src/view/surface-root-node.cpp
@@ -113,7 +113,7 @@ class surface_root_render_instance_t : public render_instance_t
 
 void surface_root_node_t::gen_render_instances(
     std::vector<render_instance_uptr>& instances, damage_callback damage,
-    const std::optional<wf::geometry_t>&)
+    wf::output_t *output)
 {
     instances.push_back(
         std::make_unique<surface_root_render_instance_t>(si, damage));

--- a/src/view/surface-root-node.cpp
+++ b/src/view/surface-root-node.cpp
@@ -1,5 +1,6 @@
 #include "surface-impl.hpp"
 #include "wayfire/debug.hpp"
+#include "wayfire/geometry.hpp"
 #include "wayfire/scene.hpp"
 #include <memory>
 #include <wayfire/surface.hpp>
@@ -111,7 +112,8 @@ class surface_root_render_instance_t : public render_instance_t
 };
 
 void surface_root_node_t::gen_render_instances(
-    std::vector<render_instance_uptr>& instances, damage_callback damage)
+    std::vector<render_instance_uptr>& instances, damage_callback damage,
+    const std::optional<wf::geometry_t>&)
 {
     instances.push_back(
         std::make_unique<surface_root_render_instance_t>(si, damage));

--- a/src/view/view-keyboard-interaction.cpp
+++ b/src/view/view-keyboard-interaction.cpp
@@ -48,7 +48,7 @@ class view_keyboard_interaction_t : public wf::keyboard_interaction_t
         }
     }
 
-    wf::input_action handle_keyboard_key(wlr_event_keyboard_key event) override
+    void handle_keyboard_key(wlr_event_keyboard_key event) override
     {
         auto iv = interactive_view_from_view(view.get());
         if (iv)
@@ -59,7 +59,5 @@ class view_keyboard_interaction_t : public wf::keyboard_interaction_t
         auto seat = wf::get_core().get_current_seat();
         wlr_seat_keyboard_notify_key(seat,
             event.time_msec, event.keycode, event.state);
-
-        return wf::input_action::CONSUME;
     }
 };

--- a/src/view/view-node.cpp
+++ b/src/view/view-node.cpp
@@ -168,7 +168,7 @@ class view_render_instance_t : public render_instance_t
 };
 
 void view_node_t::gen_render_instances(std::vector<render_instance_uptr> & instances,
-    damage_callback push_damage)
+    damage_callback push_damage, const std::optional<wf::geometry_t>&)
 {
     instances.push_back(std::make_unique<wf::scene::view_render_instance_t>(
         this->view, push_damage));

--- a/src/view/view-node.cpp
+++ b/src/view/view-node.cpp
@@ -165,6 +165,61 @@ class view_render_instance_t : public render_instance_t
             ch->presentation_feedback(output);
         }
     }
+
+    direct_scanout try_scanout(wf::output_t *output) override
+    {
+        auto og = output->get_relative_geometry();
+        if (!(this->view->get_bounding_box() & og))
+        {
+            return direct_scanout::SKIP;
+        }
+
+        // The candidate must cover the whole output
+        if (view->get_output_geometry() != output->get_relative_geometry())
+        {
+            return direct_scanout::OCCLUSION;
+        }
+
+        // The view must have only a single surface and no transformers
+        if (view->has_transformer() ||
+            !view->priv->surface_children_above.empty() ||
+            !view->children.empty())
+        {
+            return direct_scanout::OCCLUSION;
+        }
+
+        // Must have a wlr surface with the correct scale and transform
+        auto surface = view->get_wlr_surface();
+        if (!surface ||
+            (surface->current.scale != output->handle->scale) ||
+            (surface->current.transform != output->handle->transform))
+        {
+            return direct_scanout::OCCLUSION;
+        }
+
+        // Finally, the opaque region must be the full surface.
+        wf::region_t non_opaque = output->get_relative_geometry();
+        non_opaque ^= view->get_opaque_region(wf::point_t{0, 0});
+        if (!non_opaque.empty())
+        {
+            return direct_scanout::OCCLUSION;
+        }
+
+        wlr_presentation_surface_sampled_on_output(
+            wf::get_core().protocols.presentation, surface, output->handle);
+        wlr_output_attach_buffer(output->handle, &surface->buffer->base);
+
+        if (wlr_output_commit(output->handle))
+        {
+            LOGC(SCANOUT, "Scanned out ", view, " on output ", output->to_string());
+            return direct_scanout::SUCCESS;
+        } else
+        {
+            LOGC(SCANOUT, "Failed to scan out ", view, " on output ",
+                output->to_string());
+            return direct_scanout::OCCLUSION;
+        }
+    }
 };
 
 void view_node_t::gen_render_instances(std::vector<render_instance_uptr> & instances,

--- a/src/view/view-node.cpp
+++ b/src/view/view-node.cpp
@@ -168,8 +168,20 @@ class view_render_instance_t : public render_instance_t
 };
 
 void view_node_t::gen_render_instances(std::vector<render_instance_uptr> & instances,
-    damage_callback push_damage, const std::optional<wf::geometry_t>&)
+    damage_callback push_damage, const std::optional<wf::geometry_t>& vp)
 {
+    if ((this->view->role == VIEW_ROLE_DESKTOP_ENVIRONMENT) &&
+        this->view->sticky)
+    {
+        // FIXME: this code should be layer-shell-node-specific
+        // Special case: layer-shell views live only inside their outputs and
+        // have no benefit from being rendered on other outputs.
+        if (vp && !(*vp & view->get_bounding_box()))
+        {
+            return;
+        }
+    }
+
     instances.push_back(std::make_unique<wf::scene::view_render_instance_t>(
         this->view, push_damage));
 }

--- a/src/view/view-node.cpp
+++ b/src/view/view-node.cpp
@@ -168,7 +168,7 @@ class view_render_instance_t : public render_instance_t
 };
 
 void view_node_t::gen_render_instances(std::vector<render_instance_uptr> & instances,
-    damage_callback push_damage, const std::optional<wf::geometry_t>& vp)
+    damage_callback push_damage, wf::output_t *shown_on)
 {
     if ((this->view->role == VIEW_ROLE_DESKTOP_ENVIRONMENT) &&
         this->view->sticky)
@@ -176,7 +176,7 @@ void view_node_t::gen_render_instances(std::vector<render_instance_uptr> & insta
         // FIXME: this code should be layer-shell-node-specific
         // Special case: layer-shell views live only inside their outputs and
         // have no benefit from being rendered on other outputs.
-        if (vp && !(*vp & view->get_bounding_box()))
+        if (shown_on && (this->view->get_output() != shown_on))
         {
             return;
         }


### PR DESCRIPTION
The direct scanout was implemented in an suboptimal way: the output was listing all views and using their properties to figure out which can be scanned out.
From a design perspective, this is quite bad because the output needs to know the internals of views.
This series of commits simplify the scenegraph structure a bit and make direct scanout a scenegraph operation.
This way, nodes themselves are free to choose whether and how to support scanout.

In addition, the workarounds/remove_output_limits option has been added. This allows an experimental mode where views may be visible on multiple outputs.
This, however, breaks some assumptions elsewhere in the code, so bugs are expected.
