### PR TITLE
Take plugin name as --config-backend argument

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -162,28 +162,8 @@ static wf::config_backend_t *load_backend(const std::string& backend)
         if (backend.compare(0, 1, "/") != 0)
         {
             // Not a full path so try to get the full path.
-            std::vector<std::string> plugin_prefixes;
-            if (char *plugin_path = getenv("WAYFIRE_PLUGIN_PATH"))
-            {
-                std::stringstream ss(plugin_path);
-                std::string entry;
-                while (std::getline(ss, entry, ':'))
-                {
-                    plugin_prefixes.push_back(entry);
-                }
-            }
-
-            plugin_prefixes.push_back(PLUGIN_PATH);
-
-            for (std::filesystem::path plugin_prefix : plugin_prefixes)
-            {
-                auto plugin_path = plugin_prefix / ("lib" + backend + ".so");
-                if (std::filesystem::exists(plugin_path))
-                {
-                    config_plugin = plugin_path;
-                    break;
-                }
-            }
+            std::vector<std::string> plugin_prefixes = wf::get_plugin_paths();
+            config_plugin = wf::get_plugin_path_for_name(plugin_prefixes, backend);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,13 +158,9 @@ static wf::config_backend_t *load_backend(const std::string& backend)
 
     if (backend.size())
     {
-        /** Get the full path if the given name is not a full path */
-        if (backend.compare(0, 1, "/") != 0)
-        {
-            // Not a full path so try to get the full path.
-            std::vector<std::string> plugin_prefixes = wf::get_plugin_paths();
-            config_plugin = wf::get_plugin_path_for_name(plugin_prefixes, backend);
-        }
+        // Not a full path so try to get the full path.
+        std::vector<std::string> plugin_prefixes = wf::get_plugin_paths();
+        config_plugin = wf::get_plugin_path_for_name(plugin_prefixes, backend);
     }
 
     auto [_, init_ptr] = wf::get_new_instance_handle(config_plugin);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,9 +158,9 @@ static wf::config_backend_t *load_backend(const std::string& backend)
 
     if (backend.size())
     {
-        // Not a full path so try to get the full path.
         std::vector<std::string> plugin_prefixes = wf::get_plugin_paths();
-        config_plugin = wf::get_plugin_path_for_name(plugin_prefixes, backend);
+        config_plugin =
+            wf::get_plugin_path_for_name(plugin_prefixes, backend).value_or("");
     }
 
     auto [_, init_ptr] = wf::get_new_instance_handle(config_plugin);

--- a/src/output/plugin-loader.cpp
+++ b/src/output/plugin-loader.cpp
@@ -175,12 +175,6 @@ void plugin_manager::reload_dynamic_plugins()
     {
         if (plugin_name.size())
         {
-            if (plugin_name.at(0) == '/')
-            {
-                next_plugins.push_back(plugin_name);
-                continue;
-            }
-
             auto plugin_path =
                 wf::get_plugin_path_for_name(plugin_paths, plugin_name);
             if (plugin_path.size())
@@ -274,6 +268,11 @@ std::vector<std::string> wf::get_plugin_paths()
 std::string wf::get_plugin_path_for_name(std::vector<std::string> plugin_paths,
     std::string plugin_name)
 {
+    if (plugin_name.at(0) == '/')
+    {
+        return plugin_name;
+    }
+
     for (std::filesystem::path plugin_prefix : plugin_paths)
     {
         auto plugin_path = plugin_prefix / ("lib" + plugin_name + ".so");

--- a/src/output/plugin-loader.cpp
+++ b/src/output/plugin-loader.cpp
@@ -168,19 +168,7 @@ void plugin_manager::reload_dynamic_plugins()
     std::stringstream stream(plugin_list);
     std::vector<std::string> next_plugins;
 
-    auto plugin_prefix = std::string(PLUGIN_PATH "/");
-    std::vector<std::string> plugin_prefixes;
-    if (char *plugin_path = getenv("WAYFIRE_PLUGIN_PATH"))
-    {
-        std::stringstream ss(plugin_path);
-        std::string entry;
-        while (std::getline(ss, entry, ':'))
-        {
-            plugin_prefixes.push_back(entry);
-        }
-    }
-
-    plugin_prefixes.push_back(PLUGIN_PATH);
+    std::vector<std::string> plugin_paths = wf::get_plugin_paths();
 
     std::string plugin_name;
     while (stream >> plugin_name)
@@ -193,19 +181,12 @@ void plugin_manager::reload_dynamic_plugins()
                 continue;
             }
 
-            bool plugin_found = false;
-            for (std::filesystem::path plugin_prefix : plugin_prefixes)
+            auto plugin_path =
+                wf::get_plugin_path_for_name(plugin_paths, plugin_name);
+            if (plugin_path.size())
             {
-                auto plugin_path = plugin_prefix / ("lib" + plugin_name + ".so");
-                if (std::filesystem::exists(plugin_path))
-                {
-                    plugin_found = true;
-                    next_plugins.push_back(plugin_path);
-                    break;
-                }
-            }
-
-            if (!plugin_found)
+                next_plugins.push_back(plugin_path);
+            } else
             {
                 LOGE("Failed to load plugin \"", plugin_name, "\". ",
                     "Make sure it is installed in ", PLUGIN_PATH,
@@ -270,4 +251,37 @@ void plugin_manager::load_static_plugins()
     init_plugin(loaded_plugins["_exit"]);
     init_plugin(loaded_plugins["_focus"]);
     init_plugin(loaded_plugins["_close"]);
+}
+
+std::vector<std::string> wf::get_plugin_paths()
+{
+    std::vector<std::string> plugin_prefixes;
+    if (char *plugin_path = getenv("WAYFIRE_PLUGIN_PATH"))
+    {
+        std::stringstream ss(plugin_path);
+        std::string entry;
+        while (std::getline(ss, entry, ':'))
+        {
+            plugin_prefixes.push_back(entry);
+        }
+    }
+
+    plugin_prefixes.push_back(PLUGIN_PATH);
+
+    return plugin_prefixes;
+}
+
+std::string wf::get_plugin_path_for_name(std::vector<std::string> plugin_paths,
+    std::string plugin_name)
+{
+    for (std::filesystem::path plugin_prefix : plugin_paths)
+    {
+        auto plugin_path = plugin_prefix / ("lib" + plugin_name + ".so");
+        if (std::filesystem::exists(plugin_path))
+        {
+            return plugin_path;
+        }
+    }
+
+    return std::string("");
 }

--- a/src/output/plugin-loader.cpp
+++ b/src/output/plugin-loader.cpp
@@ -177,9 +177,9 @@ void plugin_manager::reload_dynamic_plugins()
         {
             auto plugin_path =
                 wf::get_plugin_path_for_name(plugin_paths, plugin_name);
-            if (plugin_path.size())
+            if (plugin_path)
             {
-                next_plugins.push_back(plugin_path);
+                next_plugins.push_back(plugin_path.value());
             } else
             {
                 LOGE("Failed to load plugin \"", plugin_name, "\". ",
@@ -265,7 +265,8 @@ std::vector<std::string> wf::get_plugin_paths()
     return plugin_prefixes;
 }
 
-std::string wf::get_plugin_path_for_name(std::vector<std::string> plugin_paths,
+std::optional<std::string> wf::get_plugin_path_for_name(
+    std::vector<std::string> plugin_paths,
     std::string plugin_name)
 {
     if (plugin_name.at(0) == '/')

--- a/src/output/plugin-loader.cpp
+++ b/src/output/plugin-loader.cpp
@@ -283,5 +283,5 @@ std::optional<std::string> wf::get_plugin_path_for_name(
         }
     }
 
-    return std::string("");
+    return {};
 }

--- a/src/output/plugin-loader.hpp
+++ b/src/output/plugin-loader.hpp
@@ -77,7 +77,8 @@ std::vector<std::string> get_plugin_paths();
  * @param plugin_name The plugin to be searched. If @param plugin_name is an
  *   absolute path, then it is retuned without modifiction.
  */
-std::string get_plugin_path_for_name(std::vector<std::string> plugin_paths,
+std::optional<std::string> get_plugin_path_for_name(
+    std::vector<std::string> plugin_paths,
     std::string plugin_name);
 }
 

--- a/src/output/plugin-loader.hpp
+++ b/src/output/plugin-loader.hpp
@@ -62,6 +62,22 @@ B union_cast(A object)
  * @return (dlopen() handle, newInstance pointer)
  */
 std::pair<void*, void*> get_new_instance_handle(const std::string& path);
+
+/**
+ * List the locations where wayfire's plugins are installed.
+ * This function takes care of env variable WAYFIRE_PLUGIN_PATH,
+ * as well as the default location.
+ */
+std::vector<std::string> get_plugin_paths();
+
+/**
+ * Search each path specified in @param plugin_paths for a plugin named @param
+ * plugin_name
+ * @param plugin_paths A list of locations where wayfire plugins are installed
+ * @param plugin_name The plugin to be searched.
+ */
+std::string get_plugin_path_for_name(std::vector<std::string> plugin_paths,
+    std::string plugin_name);
 }
 
 #endif /* end of include guard: PLUGIN_LOADER_HPP */

--- a/src/output/plugin-loader.hpp
+++ b/src/output/plugin-loader.hpp
@@ -74,7 +74,7 @@ std::vector<std::string> get_plugin_paths();
  * Search each path specified in @param plugin_paths for a plugin named @param
  * plugin_name
  * @param plugin_paths A list of locations where wayfire plugins are installed
- * @param plugin_name The plugin to be searched. If @param plugin_name is an 
+ * @param plugin_name The plugin to be searched. If @param plugin_name is an
  *   absolute path, then it is retuned without modifiction.
  */
 std::string get_plugin_path_for_name(std::vector<std::string> plugin_paths,

--- a/src/output/plugin-loader.hpp
+++ b/src/output/plugin-loader.hpp
@@ -74,7 +74,8 @@ std::vector<std::string> get_plugin_paths();
  * Search each path specified in @param plugin_paths for a plugin named @param
  * plugin_name
  * @param plugin_paths A list of locations where wayfire plugins are installed
- * @param plugin_name The plugin to be searched.
+ * @param plugin_name The plugin to be searched. If @param plugin_name is an 
+ *   absolute path, then it is retuned without modifiction.
  */
 std::string get_plugin_path_for_name(std::vector<std::string> plugin_paths,
     std::string plugin_name);


### PR DESCRIPTION
As an alternative to providing the full path, provide plugin name as the option's argument:
```
wayfire --config-backend hjson-config-backend
```

The current behaviour (which is providing the full path) is still valid.
```
wayfire --config-backend /usr/lib/wayfire/libdefault-config-backend.so
```