### PR TITLE
Enhancements to XML files for Hjson support

### DIFF
--- a/metadata/autostart.xml
+++ b/metadata/autostart.xml
@@ -7,7 +7,7 @@
 		<group>
 			<_short>Autostart</_short>
 			<_long>Specifies the shell commands to run on startup.</_long>
-			<option name="autostart" type="dynamic-list">
+			<option name="autostart" type="dynamic-list" type-hint="plain">
 				<_short>Autostart</_short>
 				<_long>Executes shell command with `sh` on startup. The program ID does not matter, but must be different for distinct commands.</_long>
 				<entry prefix="" type="string"/>

--- a/metadata/command.xml
+++ b/metadata/command.xml
@@ -4,43 +4,43 @@
 		<_short>Command</_short>
 		<_long>A plugin to bind key combo (key, button, touch) to execute shell commands.</_long>
 		<category>General</category>
-		<option name="bindings" type="dynamic-list">
+		<option name="bindings" type="dynamic-list" type-hint="dict">
 			<_short>Regular bindings</_short>
 			<_long>Regular bindings</_long>
-			<entry prefix="command_" type="string">
+			<entry prefix="command_" type="string" name="command">
 				<_short>Command</_short>
 				<_long>Sets the command to execute.</_long>
 				<hint>file</hint>
 			</entry>
-			<entry prefix="binding_" type="activator">
+			<entry prefix="binding_" type="activator" name="binding">
 				<_short>Binding</_short>
 				<_long>Sets the triggering activator binding.</_long>
 			</entry>
 		</option>
 
-		<option name="repeatable_bindings" type="dynamic-list">
+		<option name="repeatable_bindings" type="dynamic-list" type-hint="dict">
 			<_short>Repeatable bindings</_short>
 			<_long>Bindings which repeat their command if their key or button is held pressed.</_long>
-			<entry prefix="command_" type="string">
+			<entry prefix="command_" type="string" name="command">
 				<_short>Command</_short>
 				<_long>Sets the command to execute.</_long>
 				<hint>file</hint>
 			</entry>
-			<entry prefix="repeatable_binding_" type="activator">
+			<entry prefix="repeatable_binding_" type="activator" name="binding">
 				<_short>Binding</_short>
 				<_long>Sets the triggering activator binding.</_long>
 			</entry>
 		</option>
 
-		<option name="always_bindings" type="dynamic-list">
+		<option name="always_bindings" type="dynamic-list" type-hint="dict">
 			<_short>Always bindings</_short>
 			<_long>Sets the bindings which are always available, even when screen is locked.</_long>
-			<entry prefix="command_" type="string">
+			<entry prefix="command_" type="string" name="command">
 				<_short>Command</_short>
 				<_long>Sets the command to execute.</_long>
 				<hint>file</hint>
 			</entry>
-			<entry prefix="always_binding_" type="activator">
+			<entry prefix="always_binding_" type="activator" name="binding">
 				<_short>Binding</_short>
 				<_long>Sets the triggering activator binding.</_long>
 			</entry>

--- a/metadata/expo.xml
+++ b/metadata/expo.xml
@@ -42,10 +42,10 @@
 			<_long>Duration of the transition of brightness when a new workspace is selected in milliseconds.</_long>
 			<default>200</default>
 		</option>
-		<option name="workspace_bindings" type="dynamic-list">
+		<option name="workspace_bindings" type="dynamic-list" type-hint="dict">
 			<_short>Select workspace</_short>
 			<_long>When the binding is triggered while expo is active, the corresponding workspace will be focused and Expo will exit.</_long>
-      <entry prefix="select_workspace_" type="activator"/>
+			<entry prefix="select_workspace_" type="activator"/>
 		</option>
 	</plugin>
 </wayfire>

--- a/metadata/vswitch.xml
+++ b/metadata/vswitch.xml
@@ -80,7 +80,7 @@
 			<default></default>
 		</option>
 
-		<option name="workspace_bindings" type="dynamic-list">
+		<option name="workspace_bindings" type="dynamic-list" type-hint="dict">
 			<_short>Go-To-Workspace bindings</_short>
 			<_long>Go-To-Workspace bindings</_long>
 			<entry prefix="binding_" type="activator">
@@ -89,7 +89,7 @@
 			</entry>
 		</option>
 
-		<option name="workspace_bindings_win" type="dynamic-list">
+		<option name="workspace_bindings_win" type="dynamic-list" type-hint="dict">
 			<_short>Go-To-Workspace with window bindings</_short>
 			<_long>Go-To-Workspace with window bindings</_long>
 			<entry prefix="with_win_" type="activator">
@@ -98,7 +98,7 @@
 			</entry>
 		</option>
 
-		<option name="bindings_win" type="dynamic-list">
+		<option name="bindings_win" type="dynamic-list" type-hint="dict">
 			<_short>Go-To-Workspace with window bindings</_short>
 			<_long>Go-To-Workspace with window bindings</_long>
 			<entry prefix="send_win_" type="activator">

--- a/metadata/window-rules.xml
+++ b/metadata/window-rules.xml
@@ -4,10 +4,10 @@
 		<_short>Window Rules</_short>
 		<_long>A plugin to apply specific commands to windows by using various criteria.</_long>
 		<category>Window Management</category>
-		<option name="rules" type="dynamic-list">
+		<option name="rules" type="dynamic-list" type-hint="plain">
 			<_short>Window rules</_short>
 			<_long>Apply specific commands to windows by using various criteria</_long>
-			<entry prefix="rule_" type="string">
+			<entry prefix="" type="string">
 				<_short>Rule</_short>
 				<_long>Defines the rule to be applied</_long>
 			</entry>


### PR DESCRIPTION
These changes are completely backward compatible with the existing ini backend.

Following additions have been made:
1. To each `option` node of `dynamic-list` type, `type-hint` attribute is added.
    Options which are a simple list should specify `type-hint='plain'`. Example: autostart/autostart, window-rules/rules
    Options which need one or more (key, value) pair, should specify `type-hint='dict'`. Example: command/bindings, vswitch/workspace_bindings
    Options which take a list of strings should specify `type-hint='tuple'`. Potentially, session management.
2. To each 'entry' node of compound option, 'name' attribute is added.
    This attribute is specifcally needed to store dict type options.

These attributes are needed save the config in hjson format such that it's intuitive to the user.