### PR TITLE
Add maximize_regions option for outputs

### DIFF
--- a/metadata/output.xml
+++ b/metadata/output.xml
@@ -14,5 +14,8 @@
     <option name="transform" type="string">
       <default>normal</default>
     </option>
+    <option name="maximize_regions" type="string">
+      <default></default>
+    </option>
   </object>
 </wayfire>

--- a/plugins/grid/wayfire/plugins/grid.hpp
+++ b/plugins/grid/wayfire/plugins/grid.hpp
@@ -35,6 +35,9 @@ struct grid_query_geometry_signal : public wf::signal_data_t
     // The slot to calculate geometry for
     slot_t slot;
 
+    // The point of this request
+    wf::point_t input_coords;
+
     // Will be filled in by grid
     wf::geometry_t out_geometry;
 };

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -341,7 +341,8 @@ class wayfire_move : public wf::plugin_interface_t
      * is released at output-local coordinates (x, y) */
     wf::grid::slot_t calc_slot(wf::point_t point)
     {
-        auto g = output->workspace->get_workarea();
+        wf::geometry_t vg = { point.x, point.y, 1, 1 };
+        auto g = output->workspace->get_maximize_region(vg);
         if (!(output->get_relative_geometry() & point))
         {
             return wf::grid::SLOT_NONE;
@@ -471,9 +472,11 @@ class wayfire_move : public wf::plugin_interface_t
         /* Show a preview overlay */
         if (new_slot_id)
         {
+            auto input = get_input_coords();
             wf::grid::grid_query_geometry_signal query;
             query.slot = new_slot_id;
             query.out_geometry = {0, 0, -1, -1};
+            query.input_coords = input;
             output->emit_signal("grid-query-geometry", &query);
 
             /* Unknown slot geometry, can't show a preview */
@@ -482,7 +485,6 @@ class wayfire_move : public wf::plugin_interface_t
                 return;
             }
 
-            auto input   = get_input_coords();
             auto preview =
                 new wf::preview_indication_view_t({input.x, input.y, 1, 1});
             wf::get_core().add_view(

--- a/src/api/wayfire/output-layout.hpp
+++ b/src/api/wayfire/output-layout.hpp
@@ -47,6 +47,8 @@ struct output_state_t
     wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
     /* The scale of the output */
     double scale = 1.0;
+    /* The maximize regions of the output */
+    std::vector<wf::geometry_t> *maximize_regions;
 
     /* Output to take the image from. Valid only if source is mirror */
     std::string mirror_from;

--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -87,6 +87,8 @@ class output_t : public wf::object_base_t
      */
     wf::geometry_t get_layout_geometry() const;
 
+    virtual const std::vector<wf::geometry_t> *get_maximize_regions() const = 0;
+
     /**
      * Moves the pointer so that it is inside the output
      *

--- a/src/api/wayfire/workspace-manager.hpp
+++ b/src/api/wayfire/workspace-manager.hpp
@@ -287,6 +287,11 @@ class workspace_manager
      */
     wf::geometry_t get_workarea();
 
+    /**
+     * @return the area a view can be maximized to on an output
+     */
+    wf::geometry_t get_maximize_region(wf::geometry_t view_geometry);
+
     workspace_manager(output_t *output);
     ~workspace_manager();
 

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -53,6 +53,7 @@ class output_impl_t : public output_t
     void focus_view(wayfire_view view, uint32_t flags);
 
     wf::dimensions_t effective_size;
+    const std::vector<wf::geometry_t> *maximize_regions;
 
   public:
     output_impl_t(wlr_output *output, const wf::dimensions_t& effective_size);
@@ -84,6 +85,7 @@ class output_impl_t : public output_t
     void focus_view(wayfire_view v, bool raise) override;
     void refocus(wayfire_view skip_view, uint32_t layers) override;
     wf::dimensions_t get_screen_size() const override;
+    const std::vector<wf::geometry_t> *get_maximize_regions() const override;
 
     wf::binding_t *add_key(option_sptr_t<keybinding_t> key,
         wf::key_callback*) override;
@@ -120,6 +122,10 @@ class output_impl_t : public output_t
 
     /** Set the effective resolution of the output */
     void set_effective_size(const wf::dimensions_t& size);
+
+    /** set the maximize regions of the output */
+    void set_maximize_regions(
+        const std::vector<wf::geometry_t> *maximize_regions);
 };
 
 /**

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -191,6 +191,17 @@ wf::dimensions_t wf::output_impl_t::get_screen_size() const
     return this->effective_size;
 }
 
+void wf::output_impl_t::set_maximize_regions(
+    const std::vector<wf::geometry_t> *maximize_regions)
+{
+    this->maximize_regions = maximize_regions;
+}
+
+const std::vector<wf::geometry_t> *wf::output_impl_t::get_maximize_regions() const
+{
+    return this->maximize_regions;
+}
+
 wf::geometry_t wf::output_t::get_relative_geometry() const
 {
     auto size = get_screen_size();

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -560,6 +560,25 @@ class output_workarea_manager_t
         return current_workarea;
     }
 
+    wf::geometry_t get_maximize_region(wf::geometry_t view_geometry)
+    {
+       int new_area = 0;
+       int last_area = 0;
+       wf::geometry_t best_region = current_workarea;
+       wf::geometry_t intersection;
+       for (auto r : *output->get_maximize_regions())
+       {
+           intersection = geometry_intersection(view_geometry, r);
+           new_area = intersection.width * intersection.height;
+           if (new_area > last_area)
+           {
+               best_region = geometry_intersection(current_workarea, r);
+               last_area = new_area;
+           }
+       }
+       return best_region;
+    }
+
     wf::geometry_t calculate_anchored_geometry(
         const workspace_manager::anchored_area& area)
     {
@@ -1006,5 +1025,10 @@ void workspace_manager::reflow_reserved_areas()
 wf::geometry_t workspace_manager::get_workarea()
 {
     return pimpl->workarea_manager.get_workarea();
+}
+
+wf::geometry_t workspace_manager::get_maximize_region(wf::geometry_t view_region)
+{
+    return pimpl->workarea_manager.get_maximize_region(view_region);
 }
 } // namespace wf

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -621,7 +621,8 @@ void wf::view_interface_t::tile_request(uint32_t edges, wf::point_t workspace)
     data.view  = self();
     data.edges = edges;
     data.workspace    = workspace;
-    data.desired_size = edges ? get_output()->workspace->get_workarea() :
+    data.desired_size = edges ?
+        get_output()->workspace->get_maximize_region(get_wm_geometry()) :
         view_impl->calculate_windowed_geometry(get_output());
 
     set_tiled(edges);
@@ -705,7 +706,8 @@ void wf::view_interface_t::fullscreen_request(wf::output_t *out, bool state,
     if (!state)
     {
         data.desired_size = this->tiled_edges ?
-            this->get_output()->workspace->get_workarea() :
+            this->get_output()->workspace->get_maximize_region(
+                get_wm_geometry()) :
             this->view_impl->calculate_windowed_geometry(get_output());
     }
 
@@ -811,7 +813,8 @@ void wf::view_interface_t::set_decoration(
         target_wm_geometry = get_output()->get_relative_geometry();
     } else if (this->tiled_edges)
     {
-        target_wm_geometry = get_output()->workspace->get_workarea();
+        target_wm_geometry = get_output()->workspace->get_maximize_region(
+                get_wm_geometry());
     }
 
     // notify the frame of the current size


### PR DESCRIPTION
I have a 5120x1440 monitor, which is easier to use as 3 separate regions. I can do that in X with `xrandr --setmonitor` commands.

Here I'm reproducing that functionality with a new option. It also affects the behavior of the grid plugin. Fullscreen still uses the output's full size.

Example configuration:

```
[output:DP-3]
maximize_regions = 1280x1440+0+0,2560x1440+1280+0,1280x1440+3840+0
```

This could still use more validation of the set of maximize regions are valid within the output, but is working for me.