### PR TITLE
input grab node demo

### DIFF
--- a/metadata/scale.xml
+++ b/metadata/scale.xml
@@ -22,11 +22,6 @@
 				<default>750</default>
 				<min>0</min>
 			</option>
-			<option name="interact" type="bool">
-				<_short>Interact With Views</_short>
-				<_long>If this option is set, views will accept input in scale state. Otherwise, all events will be ignored except left click, which will activate the clicked view and terminate scale.</_long>
-				<default>false</default>
-			</option>
 			<option name="allow_zoom" type="bool">
 				<_short>Allow Zoomed Views</_short>
 				<_long>Whether scaled views can have a size larger than their original size.</_long>

--- a/plugins/common/wayfire/plugins/common/input-grab.hpp
+++ b/plugins/common/wayfire/plugins/common/input-grab.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include "wayfire/core.hpp"
+#include "wayfire/output.hpp"
+#include "wayfire/scene-input.hpp"
+#include "wayfire/scene-operations.hpp"
+#include "wayfire/scene.hpp"
+#include <wayfire/debug.hpp>
+#include <memory>
+#include <string>
+namespace wf
+{
+namespace scene
+{
+/**
+ * A scene node which can be used to implement input grab on a particular output.
+ */
+class grab_node_t : public node_t
+{
+    std::string name;
+    wf::output_t *output;
+    keyboard_interaction_t *keyboard = nullptr;
+    pointer_interaction_t *pointer   = nullptr;
+    touch_interaction_t *touch = nullptr;
+
+  public:
+    grab_node_t(std::string name, wf::output_t *output,
+        keyboard_interaction_t *keyboard = NULL,
+        pointer_interaction_t *pointer   = NULL,
+        touch_interaction_t *touch = NULL) :
+        node_t(false), name(name), output(output),
+        keyboard(keyboard), pointer(pointer), touch(touch)
+    {}
+
+    std::optional<input_node_t> find_node_at(const wf::pointf_t& at) override
+    {
+        if (output->get_layout_geometry() & at)
+        {
+            input_node_t result;
+            result.node    = this;
+            result.surface = {};
+            result.local_coords = to_local(at);
+            return result;
+        }
+
+        return {};
+    }
+
+    wf::keyboard_focus_node_t keyboard_refocus(wf::output_t *output) override
+    {
+        if (output != this->output)
+        {
+            return wf::keyboard_focus_node_t{};
+        }
+
+        return wf::keyboard_focus_node_t{
+            .node = this,
+            .importance = focus_importance::REGULAR,
+            .allow_focus_below = false,
+        };
+    }
+
+    /**
+     * Get a textual representation of the node, used for debugging purposes.
+     * For example, see wf::dump_scene().
+     * The representation should therefore not contain any newline characters.
+     */
+    std::string stringify() const override
+    {
+        return name + "-input-grab";
+    }
+
+    keyboard_interaction_t& keyboard_interaction() override
+    {
+        return keyboard ? *keyboard : node_t::keyboard_interaction();
+    }
+
+    pointer_interaction_t& pointer_interaction() override
+    {
+        return pointer ? *pointer : node_t::pointer_interaction();
+    }
+
+    touch_interaction_t& touch_interaction() override
+    {
+        return touch ? *touch : node_t::touch_interaction();
+    }
+};
+}
+
+/**
+ * A helper class for managing input grabs on an output.
+ */
+class input_grab_t
+{
+    wf::output_t *output;
+    std::shared_ptr<scene::grab_node_t> grab_node;
+
+  public:
+    input_grab_t(std::string name, wf::output_t *output,
+        keyboard_interaction_t *keyboard = NULL,
+        pointer_interaction_t *pointer   = NULL,
+        touch_interaction_t *touch = NULL)
+    {
+        this->output = output;
+        grab_node    = std::make_shared<scene::grab_node_t>(name, output,
+            keyboard, pointer, touch);
+    }
+
+    /**
+     * Grab input from all layers from background to @layer_below.
+     */
+    void grab_input(wf::scene::layer layer_below)
+    {
+        wf::dassert(grab_node->parent() == nullptr, "Trying to grab twice!");
+
+        auto& root    = wf::get_core().scene();
+        auto children = root->get_children();
+
+        auto idx = std::find(children.begin(), children.end(),
+            root->layers[(int)layer_below]);
+
+        wf::dassert(idx != children.end(), "Could not find node for a layer: " +
+            std::to_string((int)layer_below));
+        children.insert(idx, grab_node);
+
+        root->set_children_list(children);
+        scene::update(root, scene::update_flag::CHILDREN_LIST);
+        output->refocus();
+    }
+
+    /**
+     * Ungrab the input.
+     */
+    void ungrab_input()
+    {
+        if (grab_node->parent())
+        {
+            wf::scene::remove_child(grab_node);
+        }
+
+        output->refocus();
+    }
+};
+}

--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -3,6 +3,7 @@
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
 #include <wayfire/nonstd/reverse.hpp>
+#include <wayfire/plugins/common/util.hpp>
 #include <wayfire/plugins/wobbly/wobbly-signal.hpp>
 #include <wayfire/object.hpp>
 #include <wayfire/output-layout.hpp>
@@ -720,7 +721,7 @@ inline void adjust_view_on_output(drag_done_signal *ev)
         }
 
         // check focus timestamp and select the last focused view to (re)focus
-        if (v.view->last_focus_timestamp > focus_view->last_focus_timestamp)
+        if (get_focus_timestamp(v.view) > get_focus_timestamp(focus_view))
         {
             focus_view = v.view;
         }

--- a/plugins/common/wayfire/plugins/common/util.hpp
+++ b/plugins/common/wayfire/plugins/common/util.hpp
@@ -1,0 +1,13 @@
+// A collection of small utility functions that plugins use.
+// FIXME: consider splitting into multiple files as util functions accumulate.
+#pragma once
+
+#include "wayfire/view.hpp"
+namespace wf
+{
+inline uint64_t get_focus_timestamp(wayfire_view view)
+{
+    const auto& node = view->get_surface_root_node();
+    return node->keyboard_interaction().last_focus_timestamp;
+}
+}

--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -1,3 +1,4 @@
+#include "wayfire/plugins/common/util.hpp"
 #include <wayfire/plugin.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/view-transform.hpp>
@@ -118,7 +119,7 @@ class wayfire_fast_switcher : public wf::plugin_interface_t
 
         std::sort(views.begin(), views.end(), [] (wayfire_view& a, wayfire_view& b)
         {
-            return a->last_focus_timestamp > b->last_focus_timestamp;
+            return wf::get_focus_timestamp(a) > wf::get_focus_timestamp(b);
         });
     }
 

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -388,7 +388,7 @@ class tile_plugin_t : public wf::plugin_interface_t
     signal_connection_t on_focus_changed = [=] (signal_data_t *data)
     {
         auto view = get_signaled_view(data);
-        if (tile::view_node_t::get_node(view) && !view->fullscreen)
+        if (view && tile::view_node_t::get_node(view) && !view->fullscreen)
         {
             auto vp = output->workspace->get_current_workspace();
             for_each_view(roots[vp.x][vp.y], [&] (wayfire_view view)

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -278,27 +278,6 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
     virtual void move_view_to_output(wayfire_view v,
         wf::output_t *new_output, bool reconfigure) = 0;
 
-    /**
-     * Add a request to focus the given layer, or update an existing request.
-     * Returns the UID of the request which was added/modified.
-     *
-     * Calling this with request >= 0 will have no effect if the given
-     * request doesn't exist, in which case -1 is returned
-     */
-    virtual int focus_layer(uint32_t layer, int request) = 0;
-
-    /**
-     * Removes a request from the list. No-op for requests that do not exist
-     * currently or for request < 0
-     */
-    virtual void unfocus_layer(int request) = 0;
-
-    /**
-     * @return The highest layer for which there exists a focus request, or 0, if
-     * no focus requests.
-     */
-    virtual uint32_t get_focused_layer() = 0;
-
     /** The wayland socket name of Wayfire */
     std::string wayland_display;
 

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -248,10 +248,10 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
     virtual std::vector<wayfire_view> get_all_views() = 0;
 
     /**
-     * Set the keyboard focus view. The stacking order on the view's output
-     * won't be changed.
+     * Set the keyboard focus node. Note that this changes only the focus state
+     * and does not reorder nodes or anything like this.
      */
-    virtual void set_active_view(wayfire_view v) = 0;
+    virtual void set_active_node(wf::scene::node_ptr node) = 0;
 
     /**
      * Focus the given view and its output (if necessary).

--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -182,7 +182,17 @@ class output_t : public wf::object_base_t
     /**
      * @return The most recently focused view on this output.
      */
-    virtual wayfire_view get_active_view() const = 0;
+    wayfire_view get_active_view() const;
+
+    /**
+     * The most recently focused node on this output. Focus here means keyboard
+     * focus, as pointer/touch/etc. focus is a global state which can be queried
+     * from core_interface_t.
+     *
+     * Note that the focused node does not have to be a view node, it could be a
+     * plugin grab or something similar.
+     */
+    virtual wf::scene::node_ptr get_focused_node() const = 0;
 
     /**
      * Attempt to give keyboard focus to the given view and set it as the

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2022'11'20;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2022'11'23;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/scene-input.hpp
+++ b/src/api/wayfire/scene-input.hpp
@@ -199,8 +199,11 @@ class touch_interaction_t
      *
      * @param finger_id The id of the finger being lifted. It is guaranteed that
      *   the finger will have been pressed on the node before.
+     * @param lift_off_position The last position the finger had before the
+     *   lift off.
      */
-    virtual void handle_touch_up(uint32_t time_ms, int finger_id)
+    virtual void handle_touch_up(uint32_t time_ms, int finger_id,
+        wf::pointf_t lift_off_position)
     {}
 
     /**

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -70,6 +70,7 @@ namespace scene
 {
 class node_t;
 using node_ptr = std::shared_ptr<node_t>;
+using node_weak_ptr = std::weak_ptr<node_t>;
 
 /**
  * Describes the current state of a node.

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -130,6 +130,20 @@ class node_t : public std::enable_shared_from_this<node_t>,
     virtual std::optional<input_node_t> find_node_at(const wf::pointf_t& at);
 
     /**
+     * Figure out which node should receive keyboard focus on the given output.
+     *
+     * Typically, the focus is set directly via core::set_active_node(). However,
+     * in some cases we need to re-elect a node to focus (for example if the
+     * focused node is destroyed). In these cases, the keyboard_refocus() method
+     * on a node is called. It should return the desired focus node.
+     *
+     * By default, a node tries to focus one of its focusable children with the
+     * highest focus_importance. In case of a tie, the node with the highest
+     * last_focus_timestamp is selected.
+     */
+    virtual wf::keyboard_focus_node_t keyboard_refocus(wf::output_t *output);
+
+    /**
      * Convert a point from the coordinate system the node resides in, to the
      * coordinate system of its children.
      *
@@ -473,4 +487,4 @@ void set_node_enabled(wf::scene::node_ptr node, bool enabled);
  */
 void update(node_ptr changed_node, uint32_t flags);
 }
-}
+} // namespace wf

--- a/src/api/wayfire/signal-provider.hpp
+++ b/src/api/wayfire/signal-provider.hpp
@@ -34,6 +34,11 @@ class connection_base_t
         disconnect();
     }
 
+    bool is_connected() const
+    {
+        return !connected_to.empty();
+    }
+
     /** Disconnect from all connected signal providers */
     void disconnect();
 

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -58,7 +58,7 @@ constexpr uint32_t TILED_EDGES_ALL =
  * view_interface_t is the base class for all "toplevel windows", i.e surfaces
  * which have no parent.
  */
-class view_interface_t : public surface_interface_t
+class view_interface_t : public surface_interface_t, public wf::signal::provider_t
 {
   public:
     /**

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -485,12 +485,6 @@ class view_interface_t : public surface_interface_t, public wf::signal::provider
     class view_priv_impl;
     std::unique_ptr<view_priv_impl> view_impl;
 
-    /**
-     * The last time(nanoseconds since epoch) when the view was focused.
-     * Updated automatically by core.
-     */
-    uint64_t last_focus_timestamp = 0;
-
   protected:
     view_interface_t();
 
@@ -606,6 +600,7 @@ class view_node_t : public scene::floating_inner_node_t
   public:
     view_node_t(wayfire_view view);
     std::optional<input_node_t> find_node_at(const wf::pointf_t& at) override;
+    wf::keyboard_focus_node_t keyboard_refocus(wf::output_t *output) override;
     std::string stringify() const override;
 
     wf::pointf_t to_local(const wf::pointf_t& point) override;

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -3,6 +3,7 @@
 
 #include "wayfire/core.hpp"
 #include "wayfire/scene-input.hpp"
+#include "wayfire/scene.hpp"
 #include "wayfire/util.hpp"
 #include <wayfire/nonstd/wlroots-full.hpp>
 
@@ -89,7 +90,7 @@ class compositor_core_impl_t : public compositor_core_t
 
     void add_view(std::unique_ptr<wf::view_interface_t> view) override;
     std::vector<wayfire_view> get_all_views() override;
-    void set_active_view(wayfire_view v) override;
+    void set_active_node(wf::scene::node_ptr node) override;
     void focus_view(wayfire_view win) override;
     void move_view_to_output(wayfire_view v, wf::output_t *new_output,
         bool reconfigure) override;
@@ -124,21 +125,7 @@ class compositor_core_impl_t : public compositor_core_t
     /* pairs (layer, request_id) */
     std::set<std::pair<uint32_t, int>> layer_focus_requests;
 
-    wayfire_view last_active_toplevel;
-
-    /**
-     * The last view which was attempted to be focused.
-     * The view might not actually have focus, because of plugin grabs.
-     */
-    wayfire_view last_active_view;
-
-    void init_last_view_tracking();
-
-    wf::signal_connection_t on_view_unmap;
-    wf::signal_connection_t on_new_output;
-
     compositor_state_t state = compositor_state_t::UNKNOWN;
-
     compositor_core_impl_t();
     virtual ~compositor_core_impl_t();
 };

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -97,9 +97,6 @@ class compositor_core_impl_t : public compositor_core_t
 
     void focus_output(wf::output_t *o) override;
     wf::output_t *get_active_output() override;
-    int focus_layer(uint32_t layer, int request) override;
-    void unfocus_layer(int request) override;
-    uint32_t get_focused_layer() override;
     std::string get_xwayland_display() override;
     pid_t run(std::string command) override;
     void shutdown() override;
@@ -121,9 +118,6 @@ class compositor_core_impl_t : public compositor_core_t
     std::unordered_map<std::string, wayfire_view> id_to_view;
 
     std::shared_ptr<scene::root_node_t> scene_root;
-
-    /* pairs (layer, request_id) */
-    std::set<std::pair<uint32_t, int>> layer_focus_requests;
 
     compositor_state_t state = compositor_state_t::UNKNOWN;
     compositor_core_impl_t();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -532,69 +532,6 @@ wf::output_t*wf::compositor_core_impl_t::get_active_output()
     return active_output;
 }
 
-int wf::compositor_core_impl_t::focus_layer(uint32_t layer, int32_t request_uid_hint)
-{
-    static int32_t last_request_uid = -1;
-    if (request_uid_hint >= 0)
-    {
-        /* Remove the old request, and insert the new one */
-        uint32_t old_layer = -1;
-        for (auto& req : layer_focus_requests)
-        {
-            if (req.second == request_uid_hint)
-            {
-                old_layer = req.first;
-            }
-        }
-
-        /* Request UID isn't valid */
-        if (old_layer == (uint32_t)-1)
-        {
-            return -1;
-        }
-
-        layer_focus_requests.erase({old_layer, request_uid_hint});
-    }
-
-    auto request_uid = request_uid_hint < 0 ?
-        ++last_request_uid : request_uid_hint;
-    layer_focus_requests.insert({layer, request_uid});
-    LOGD("focusing layer ", get_focused_layer());
-
-    if (active_output)
-    {
-        active_output->refocus();
-    }
-
-    return request_uid;
-}
-
-uint32_t wf::compositor_core_impl_t::get_focused_layer()
-{
-    if (layer_focus_requests.empty())
-    {
-        return 0;
-    }
-
-    return (--layer_focus_requests.end())->first;
-}
-
-void wf::compositor_core_impl_t::unfocus_layer(int request)
-{
-    for (auto& freq : layer_focus_requests)
-    {
-        if (freq.second == request)
-        {
-            layer_focus_requests.erase(freq);
-            LOGD("focusing layer ", get_focused_layer());
-
-            active_output->refocus(nullptr);
-
-            return;
-        }
-    }
-}
-
 void wf::compositor_core_impl_t::add_view(
     std::unique_ptr<wf::view_interface_t> view)
 {

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -207,8 +207,8 @@ void wf::input_manager_t::ungrab_input()
     active_grab = nullptr;
     if (wf::get_core().get_active_output())
     {
-        wf::get_core().set_active_view(
-            wf::get_core().get_active_output()->get_active_view());
+        wf::get_core().set_active_node(
+            wf::get_core().get_active_output()->get_focused_node());
     }
 
     // We must update cursor focus, however, if we update "too soon", the current

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include "pointer.hpp"
 #include "surface-map-state.hpp"
+#include "wayfire/core.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include "../core-impl.hpp"
 #include "../../output/output-impl.hpp"
@@ -207,8 +208,7 @@ void wf::input_manager_t::ungrab_input()
     active_grab = nullptr;
     if (wf::get_core().get_active_output())
     {
-        wf::get_core().set_active_node(
-            wf::get_core().get_active_output()->get_focused_node());
+        wf::get_core().get_active_output()->refocus();
     }
 
     // We must update cursor focus, however, if we update "too soon", the current
@@ -293,7 +293,7 @@ void wf::input_manager_t::set_exclusive_focus(wl_client *client)
      * focus to the topmost view */
     if (!client)
     {
-        wf::get_core().get_active_output()->refocus(nullptr);
+        wf::get_core().get_active_output()->refocus();
     }
 }
 

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -87,9 +87,6 @@ void wf::pointer_t::update_cursor_position(int64_t time_msec, bool real_update)
         const auto& scene = wf::get_core().scene();
         auto isec = scene->find_node_at(gc);
         update_cursor_focus(isec ? isec->node->shared_from_this() : nullptr);
-        /* We switched focus, so send motion event in any case, so that the
-         * new focus knows where the pointer is */
-        real_update = true;
     }
 
     if (real_update)

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -164,7 +164,7 @@ void wf::touch_interface_t::set_touch_focus(wf::scene::node_ptr node,
 
     if (focus[id])
     {
-        focus[id]->touch_interaction().handle_touch_up(time, id);
+        focus[id]->touch_interaction().handle_touch_up(time, id, point);
     }
 
     focus[id] = node;
@@ -282,12 +282,15 @@ void wf::touch_interface_t::handle_touch_motion(int32_t id, uint32_t time,
 void wf::touch_interface_t::handle_touch_up(int32_t id, uint32_t time,
     input_event_processing_mode_t mode)
 {
+    const auto lift_off_position = finger_state.fingers[id].current;
+
     const wf::touch::gesture_event_t gesture_event = {
         .type   = wf::touch::EVENT_TYPE_TOUCH_UP,
         .time   = time,
         .finger = id,
-        .pos    = finger_state.fingers[id].current
+        .pos    = lift_off_position,
     };
+
     update_gestures(gesture_event);
     finger_state.update(gesture_event);
 
@@ -303,7 +306,8 @@ void wf::touch_interface_t::handle_touch_up(int32_t id, uint32_t time,
         return;
     }
 
-    set_touch_focus(nullptr, id, time, {0, 0});
+    set_touch_focus(nullptr, id, time,
+        {lift_off_position.x, lift_off_position.y});
 }
 
 void wf::touch_interface_t::update_cursor_state()

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -1,6 +1,7 @@
 #include "wayfire/output.hpp"
 #include "plugin-loader.hpp"
 #include "../core/seat/bindings-repository.hpp"
+#include "wayfire/scene-input.hpp"
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
 #include "wayfire/signal-provider.hpp"
@@ -17,6 +18,7 @@ class output_impl_t : public output_t
   private:
     std::shared_ptr<scene::output_node_t> nodes[TOTAL_LAYERS];
     scene::floating_inner_ptr wset;
+    uint64_t last_timestamp = 0;
 
   private:
     std::unordered_multiset<wf::plugin_grab_interface_t*> active_plugins;
@@ -32,17 +34,12 @@ class output_impl_t : public output_t
         FOCUS_VIEW_RAISE        = (1 << 0),
         /* Close popups of non-focused views */
         FOCUS_VIEW_CLOSE_POPUPS = (1 << 1),
-        /* Inhibit updating the focus timestamp of the view */
-        FOCUS_VIEW_NOBUMP       = (1 << 2),
     };
 
     /**
      * Set the given view as the active view.
-     * If the output has focus, try to focus the view as well.
-     *
-     * @param flags bitmask of @focus_view_flags_t
      */
-    void update_active_view(wayfire_view view, uint32_t flags);
+    void update_active_view(wayfire_view view);
 
     /**
      * Close all popups on the output which do not belong to the active view.
@@ -54,6 +51,8 @@ class output_impl_t : public output_t
 
     wf::dimensions_t effective_size;
 
+    void do_update_focus(wf::scene::node_t *node);
+
   public:
     output_impl_t(wlr_output *output, const wf::dimensions_t& effective_size);
     /**
@@ -62,8 +61,8 @@ class output_impl_t : public output_t
     void start_plugins();
 
     virtual ~output_impl_t();
-
-    wf::scene::node_ptr focused_node;
+    wayfire_view active_view = nullptr;
+    wayfire_view last_active_toplevel = nullptr;
 
     /**
      * Implementations of the public APIs
@@ -81,9 +80,7 @@ class output_impl_t : public output_t
     bool is_plugin_active(std::string owner_name) const override;
     bool call_plugin(const std::string& activator,
         const wf::activator_data_t& data) const override;
-    wf::scene::node_ptr get_focused_node() const override;
     void focus_view(wayfire_view v, bool raise) override;
-    void refocus(wayfire_view skip_view, uint32_t layers) override;
     wf::dimensions_t get_screen_size() const override;
 
     wf::binding_t *add_key(option_sptr_t<keybinding_t> key,
@@ -96,6 +93,11 @@ class output_impl_t : public output_t
         wf::activator_callback*) override;
     void rem_binding(wf::binding_t *binding) override;
     void rem_binding(void *callback) override;
+
+    wayfire_view get_active_view() const override;
+    void focus_node(wf::scene::node_ptr new_focus) override;
+    void refocus() override;
+    uint64_t get_last_focus_timestamp() const override;
 
     /**
      * Set the output as inhibited, so that no plugins can be activated

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -62,7 +62,8 @@ class output_impl_t : public output_t
     void start_plugins();
 
     virtual ~output_impl_t();
-    wayfire_view active_view;
+
+    wf::scene::node_ptr focused_node;
 
     /**
      * Implementations of the public APIs
@@ -80,7 +81,7 @@ class output_impl_t : public output_t
     bool is_plugin_active(std::string owner_name) const override;
     bool call_plugin(const std::string& activator,
         const wf::activator_data_t& data) const override;
-    wayfire_view get_active_view() const override;
+    wf::scene::node_ptr get_focused_node() const override;
     void focus_view(wayfire_view v, bool raise) override;
     void refocus(wayfire_view skip_view, uint32_t layers) override;
     wf::dimensions_t get_screen_size() const override;

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -532,7 +532,7 @@ class output_viewport_manager_t
         }
 
         // Finally, do a refocus to update the keyboard focus
-        output->refocus(nullptr, wf::MIDDLE_LAYERS);
+        output->refocus();
         output->emit_signal("workspace-changed", &data);
     }
 };

--- a/src/view/surface-touch-interaction.cpp
+++ b/src/view/surface-touch-interaction.cpp
@@ -4,6 +4,7 @@
 #include "../core/core-impl.hpp"
 #include <wayfire/compositor-surface.hpp>
 #include "view-impl.hpp"
+#include "wayfire/geometry.hpp"
 
 namespace wf
 {
@@ -45,7 +46,7 @@ class surface_touch_interaction_t final : public wf::touch_interaction_t
         }
     }
 
-    void handle_touch_up(uint32_t time_ms, int finger_id) override
+    void handle_touch_up(uint32_t time_ms, int finger_id, wf::pointf_t) override
     {
         auto seat = wf::get_core().get_current_seat();
         if (auto cs = compositor_surface_from_surface(surface))

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -357,6 +357,7 @@ void wf::view_interface_t::emit_view_unmap()
     }
 
     emit_signal("unmapped", &data);
+    this->emit(&data);
 }
 
 void wf::view_interface_t::emit_view_pre_unmap()

--- a/src/view/view-keyboard-interaction.cpp
+++ b/src/view/view-keyboard-interaction.cpp
@@ -13,43 +13,14 @@ class view_keyboard_interaction_t : public wf::keyboard_interaction_t
 {
     wayfire_view view;
 
-    // The 'active' state is used to denote the last toplevel view which was
-    // focused. When focusing a view, we need to make sure that this state
-    // is correctly updated.
-    static wayfire_view last_focused_toplevel;
-
-    wf::signal::connection_t<wf::view_unmapped_signal> view_unmapped =
-        [] (wf::view_unmapped_signal *signal)
-    {
-        if (signal->view == last_focused_toplevel)
-        {
-            last_focused_toplevel = nullptr;
-        }
-    };
-
   public:
     view_keyboard_interaction_t(wayfire_view _view)
     {
         this->view = _view;
-        view->connect(&view_unmapped);
     }
 
     void handle_keyboard_enter() override
     {
-        if (this->view->role == wf::VIEW_ROLE_TOPLEVEL)
-        {
-            if (last_focused_toplevel != this->view)
-            {
-                if (last_focused_toplevel)
-                {
-                    last_focused_toplevel->set_activated(false);
-                }
-
-                this->view->set_activated(true);
-                last_focused_toplevel = this->view;
-            }
-        }
-
         auto iv = interactive_view_from_view(view.get());
         if (iv)
         {
@@ -92,5 +63,3 @@ class view_keyboard_interaction_t : public wf::keyboard_interaction_t
             event.time_msec, event.keycode, event.state);
     }
 };
-
-wayfire_view view_keyboard_interaction_t::last_focused_toplevel;

--- a/src/view/view-keyboard-interaction.cpp
+++ b/src/view/view-keyboard-interaction.cpp
@@ -1,3 +1,5 @@
+#include "wayfire/signal-definitions.hpp"
+#include "wayfire/signal-provider.hpp"
 #include <wayfire/view.hpp>
 #include <wayfire/scene-input.hpp>
 #include <wayfire/compositor-view.hpp>
@@ -11,14 +13,43 @@ class view_keyboard_interaction_t : public wf::keyboard_interaction_t
 {
     wayfire_view view;
 
+    // The 'active' state is used to denote the last toplevel view which was
+    // focused. When focusing a view, we need to make sure that this state
+    // is correctly updated.
+    static wayfire_view last_focused_toplevel;
+
+    wf::signal::connection_t<wf::view_unmapped_signal> view_unmapped =
+        [] (wf::view_unmapped_signal *signal)
+    {
+        if (signal->view == last_focused_toplevel)
+        {
+            last_focused_toplevel = nullptr;
+        }
+    };
+
   public:
     view_keyboard_interaction_t(wayfire_view _view)
     {
         this->view = _view;
+        view->connect(&view_unmapped);
     }
 
     void handle_keyboard_enter() override
     {
+        if (this->view->role == wf::VIEW_ROLE_TOPLEVEL)
+        {
+            if (last_focused_toplevel != this->view)
+            {
+                if (last_focused_toplevel)
+                {
+                    last_focused_toplevel->set_activated(false);
+                }
+
+                this->view->set_activated(true);
+                last_focused_toplevel = this->view;
+            }
+        }
+
         auto iv = interactive_view_from_view(view.get());
         if (iv)
         {
@@ -61,3 +92,5 @@ class view_keyboard_interaction_t : public wf::keyboard_interaction_t
             event.time_msec, event.keycode, event.state);
     }
 };
+
+wayfire_view view_keyboard_interaction_t::last_focused_toplevel;

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -393,6 +393,7 @@ void wf::view_interface_t::set_minimized(bool minim)
 
     if (this->view_impl->actually_minimized == minim)
     {
+        desktop_state_updated();
         return;
     }
 

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -665,7 +665,7 @@ void wf::view_interface_t::minimize_request(bool state)
         {
             minimized = state;
             desktop_state_updated();
-            get_output()->refocus(self());
+            get_output()->refocus();
         } else
         {
             /* Do the default minimization */

--- a/test/mock-core.cpp
+++ b/test/mock-core.cpp
@@ -107,19 +107,6 @@ wf::output_t*mock_core_t::get_active_output()
     return nullptr;
 }
 
-int mock_core_t::focus_layer(uint32_t layer, int32_t request_uid_hint)
-{
-    return 0;
-}
-
-uint32_t mock_core_t::get_focused_layer()
-{
-    return 0;
-}
-
-void mock_core_t::unfocus_layer(int request)
-{}
-
 void mock_core_t::add_view(
     std::unique_ptr<wf::view_interface_t> view)
 {}

--- a/test/mock-core.cpp
+++ b/test/mock-core.cpp
@@ -129,7 +129,7 @@ std::vector<wayfire_view> mock_core_t::get_all_views()
     return {};
 }
 
-void mock_core_t::set_active_view(wayfire_view new_focus)
+void mock_core_t::set_active_node(wf::scene::node_ptr)
 {}
 
 void mock_core_t::focus_view(wayfire_view v)

--- a/test/mock-core.hpp
+++ b/test/mock-core.hpp
@@ -40,7 +40,7 @@ class mock_core_t : public wf::compositor_core_impl_t
 
     void add_view(std::unique_ptr<wf::view_interface_t> view) override;
     std::vector<wayfire_view> get_all_views() override;
-    void set_active_view(wayfire_view v) override;
+    void set_active_node(wf::scene::node_ptr node) override;
     void focus_view(wayfire_view win) override;
     void move_view_to_output(wayfire_view v, wf::output_t *new_output,
         bool reconfigure) override;

--- a/test/mock-core.hpp
+++ b/test/mock-core.hpp
@@ -47,9 +47,6 @@ class mock_core_t : public wf::compositor_core_impl_t
 
     void focus_output(wf::output_t *o) override;
     wf::output_t *get_active_output() override;
-    int focus_layer(uint32_t layer, int request) override;
-    void unfocus_layer(int request) override;
-    uint32_t get_focused_layer() override;
     std::string get_xwayland_display() override;
     pid_t run(std::string command) override;
     void shutdown() override;


### PR DESCRIPTION
This PR refactors core's input handling to be independent of views. Instead, all keyboard input is now routed and decided via scenegraph operations. With this change, it is now possible to implement much more flexible input grabs via custom nodes. A helper for plugins has been added to `wayfire/plugins/common/input-grab.hpp`. The scale plugin has been updated to use it.
