### PR TITLE
switcher: disable minimized nodes correctly when exiting

### DIFF
--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -259,7 +259,7 @@ class WayfireSwitcher : public wf::plugin_interface_t
             if (view->has_data("switcher-minimized-showed"))
             {
                 view->erase_data("switcher-minimized-showed");
-                wf::scene::set_node_enabled(view->get_root_node(), true);
+                wf::scene::set_node_enabled(view->get_root_node(), false);
             }
 
             view->pop_transformer(switcher_transformer);


### PR DESCRIPTION
Fixes #1600
