### PR TITLE
wm-actions: Fix show desktop restore

### DIFF
--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -323,7 +323,8 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t
         workspace_changed.disconnect();
         view_minimized.disconnect();
 
-        for (auto& view : output->workspace->get_views_in_layer(wf::ALL_LAYERS))
+        for (auto& view : output->workspace->get_views_in_layer(
+            wf::ALL_LAYERS, true))
         {
             if (view->has_data("wm-actions-showdesktop"))
             {


### PR DESCRIPTION
Core changed get_views_in_layer() to take a minimized boolean in 31def7ee.