### PR TITLE
ShowDesktop: Minimize current workspace views

### DIFF
--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -435,6 +435,8 @@ class output_viewport_manager_t
 
         views.erase(it, views.end());
 
+        std::reverse(views.begin(), views.end());
+
         return views;
     }
 


### PR DESCRIPTION
@soreau 's patch to minimize current workspace views in wm-actions plugin's show desktop.