### PR TITLE
input: add libinput drag lock.

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -203,6 +203,11 @@
 				<_long>Enables or disables natural (inverted) scrolling.</_long>
 				<default>false</default>
 			</option>
+			<option name="drag_lock" type="bool">
+				<_short>Drag lock</_short>
+				<_long>Enables or disables drag lock.</_long>
+				<default>false</default>
+			</option>
 			<option name="touchpad_cursor_speed" type="double">
 				<_short>Touchpad cursor speed</_short>
 				<_long>Changes the touchpad acceleration.</_long>

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -21,6 +21,7 @@ void wf::pointing_device_t::config_t::load()
     touchpad_dwt_enabled.load_option("input/disable_touchpad_while_typing");
     touchpad_dwmouse_enabled.load_option("input/disable_touchpad_while_mouse");
     touchpad_natural_scroll_enabled.load_option("input/natural_scroll");
+    touchpad_drag_lock_enabled.load_option("input/drag_lock");
 
     mouse_accel_profile.load_option("input/mouse_accel_profile");
     touchpad_accel_profile.load_option("input/touchpad_accel_profile");
@@ -127,6 +128,11 @@ void wf::pointing_device_t::update_options()
             config.touchpad_dwmouse_enabled ?
             LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE :
             LIBINPUT_CONFIG_SEND_EVENTS_ENABLED);
+
+        libinput_device_config_tap_set_drag_lock_enabled(dev,
+            config.touchpad_drag_lock_enabled ?
+            LIBINPUT_CONFIG_DRAG_LOCK_ENABLED :
+            LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
 
         if (libinput_device_config_scroll_has_natural_scroll(dev) > 0)
         {

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -29,6 +29,7 @@ struct pointing_device_t : public input_device_impl_t
         wf::option_wrapper_t<bool> touchpad_dwt_enabled;
         wf::option_wrapper_t<bool> touchpad_dwmouse_enabled;
         wf::option_wrapper_t<bool> touchpad_natural_scroll_enabled;
+        wf::option_wrapper_t<bool> touchpad_drag_lock_enabled;
         void load();
     } config;
 };


### PR DESCRIPTION
Limited by the touchpad size, some dragging behavior may be hard to finish, eg selecting long texts. The libinput developers said that they are not going to implement the edge dragging[[1]](https://gitlab.freedesktop.org/libinput/libinput/-/issues/131), but there is another similar function called [drag lock](https://wayland.freedesktop.org/libinput/doc/latest/tapping.html#tapndrag), which is not yet implemented by wayfire.

PS. This is my first pr in github, so please let me know if I make something wrong. : )
Thanks.