### PR TITLE
Backport graphics tablet fix to 0.7.x

### DIFF
--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -479,7 +479,7 @@ void wf::tablet_pad_t::update_focus(wlr_surface *focus_surface)
     {
         wlr_tablet_v2_tablet_pad_notify_enter(pad_v2,
             attached_to->tablet_v2, focus_surface);
-    } else
+    } else if (old_focus)
     {
         wlr_tablet_v2_tablet_pad_notify_leave(pad_v2, old_focus);
     }


### PR DESCRIPTION
Straightforward backport of #1555 to the `0.7.x` branch. I'd appreciate if you could make a new release including this change, so that this change can hopefully make it into Debian bookworm.