### PR TITLE
Fix 'lazy' code of window rules

### DIFF
--- a/plugins/window-rules/window-rules.cpp
+++ b/plugins/window-rules/window-rules.cpp
@@ -14,6 +14,7 @@
 #include <wayfire/rule/lambda_rule.hpp>
 #include <wayfire/rule/rule.hpp>
 #include <wayfire/util/log.hpp>
+#include <wayfire/option-wrapper.hpp>
 
 #include "lambda-rules-registration.hpp"
 #include "view-action-interface.hpp"
@@ -194,11 +195,13 @@ void wayfire_window_rules_t::setup_rules_from_config()
 {
     _rules.clear();
 
-    // Build rule list.
-    auto section = wf::get_core().config.get_section("window-rules");
-    for (auto opt : section->get_registered_options())
+    wf::option_wrapper_t<wf::config::compound_list_t<std::string>> rule_list_option{"window-rules/rules"};
+    auto rule_list = rule_list_option.value();
+
+    for (const auto& [name, rule_str] : rule_list)
     {
-        _lexer.reset(opt->get_value_str());
+        LOGW("Registering ", rule_str);
+        _lexer.reset(rule_str);
         auto rule = wf::rule_parser_t().parse(_lexer);
         if (rule != nullptr)
         {

--- a/plugins/window-rules/window-rules.cpp
+++ b/plugins/window-rules/window-rules.cpp
@@ -200,7 +200,7 @@ void wayfire_window_rules_t::setup_rules_from_config()
 
     for (const auto& [name, rule_str] : rule_list)
     {
-        LOGW("Registering ", rule_str);
+        LOGD("Registering ", rule_str);
         _lexer.reset(rule_str);
         auto rule = wf::rule_parser_t().parse(_lexer);
         if (rule != nullptr)


### PR DESCRIPTION
This fixes the [problem](https://github.com/WayfireWM/wayfire/pull/1607#issuecomment-1338902195) reported by @lilydjwg. Besides, it also makes window-rules work with hjson config backend.