### PR TITLE
plugin: bump api/abi version

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -167,7 +167,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2022'11'23;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'01'04;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI


### PR DESCRIPTION
The API/ABI version should be bumped as there were many recent breaking changes.
