### PR TITLE
Add mode option to mirror 

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -456,7 +456,6 @@ struct output_layout_output_t
             tmp.refresh  = mode.get_refresh();
             state.mode   = (tmp.width > 0 && is_mode_supported(tmp) ? tmp : select_default_mode());
             state.mirror_from = mode.get_mirror_from();
-            state.mirror_from = mode.get_mirror_from();
             break;
         }
 

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -451,7 +451,11 @@ struct output_layout_output_t
 
           case output_config::MODE_MIRROR:
             state.source = OUTPUT_IMAGE_SOURCE_MIRROR;
-            state.mode   = select_default_mode();
+            tmp.width    = mode.get_width();
+            tmp.height   = mode.get_height();
+            tmp.refresh  = mode.get_refresh();
+            state.mode   = (tmp.width > 0 && is_mode_supported(tmp) ? tmp : select_default_mode());
+            state.mirror_from = mode.get_mirror_from();
             state.mirror_from = mode.get_mirror_from();
             break;
         }


### PR DESCRIPTION
This follows the wf-config  update needed to support this: https://github.com/WayfireWM/wf-config/pull/59

This adds support for a config option like:

```
[option:DP-2]
mode = mirror DP-1 1920x1080@60000
```

## Reason

Currently Mirroring works like this: 

```
          case output_config::MODE_MIRROR:
            state.source = OUTPUT_IMAGE_SOURCE_MIRROR;
            state.mode   = select_default_mode();
            state.mirror_from = mode.get_mirror_from();
            break;
```

This sets the monitors default mode and mirrors another output. This can have side effects and unexpected behaviour when the mirrors resolution and refresh rate don't match the outputs.  For example, if you mirror a 60hz screen on a 144hz screen the frames don't sync up neatly and it looks strangely jerky, by forcing the output to 120hz or 60hz there are fewer display issues.

There are also times when we might not want to use the default mode. I might prefer my monitor to run at the same resolution of the display being mirrored to scale in the hardware rather than software.

While we could just copy the source's mode here, we might try to copy a monitor that runs at 60hz to a monitor that runs at 59.9hz, not solving the problem. Rather than trying to guess at a best match, let's let the user decide.

