### PR TITLE
use native binary for wayland-scanner

### DIFF
--- a/proto/meson.build
+++ b/proto/meson.build
@@ -1,6 +1,6 @@
 wl_protocol_dir = wayland_protos.get_pkgconfig_variable('pkgdatadir')
 
-wayland_scanner = find_program('wayland-scanner')
+wayland_scanner = find_program('wayland-scanner', native: true)
 
 wayland_scanner_server = generator(
 	wayland_scanner,


### PR DESCRIPTION
This is similar to how [swaylock](https://github.com/swaywm/swaylock/blob/ac3b49b6571ceda3f8db11a98bfe320106996280/meson.build#L34) finds the wayland-scanner binary. This gives better support for cross compilation.