### PR TITLE
foreign-toplevel: Cleanup remaining leftovers from moving to a plugin

### DIFF
--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -119,7 +119,6 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
         wlr_input_inhibit_manager *input_inhibit;
         wlr_idle *idle;
         wlr_idle_inhibit_manager_v1 *idle_inhibit;
-        wlr_foreign_toplevel_manager_v1 *toplevel_manager;
         wlr_pointer_gestures_v1 *pointer_gestures;
         wlr_relative_pointer_manager_v1 *relative_pointer;
         wlr_pointer_constraints_v1 *pointer_constraints;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -277,7 +277,6 @@ void wf::compositor_core_impl_t::init()
         &protocols.idle_inhibit->events.new_inhibitor);
 
     protocols.idle = wlr_idle_create(display);
-    protocols.toplevel_manager = wlr_foreign_toplevel_manager_v1_create(display);
     protocols.pointer_gestures = wlr_pointer_gestures_v1_create(display);
     protocols.relative_pointer = wlr_relative_pointer_manager_v1_create(display);
 


### PR DESCRIPTION
Wayfire was advertising the protocol twice which breaks apps like waybar.

Fixes #1739.