### PR TITLE
wlr-surface-node: Don't send frame events to surfaces with a buffer

### DIFF
--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -29,7 +29,7 @@ wf::scene::wlr_surface_node_t::wlr_surface_node_t(wlr_surface *surface) : node_t
 
     this->on_surface_commit.set_callback([=] (void*)
     {
-        if (this->visibility.empty())
+        if (!wlr_surface_has_buffer(this->surface) && this->visibility.empty())
         {
             send_frame_done();
         }


### PR DESCRIPTION
After removing a view from workspace-manager, wayfire was sending frame done events immediately on commit, if it was not visible on any output. In addition, we can check if the surface has a buffer to tell if it's mapped or not.