### PR TITLE
default-config-backend: Use IN_CLOSE_WRITE instead of IN_MODIFY

### DIFF
--- a/src/default-config-backend.cpp
+++ b/src/default-config-backend.cpp
@@ -20,7 +20,7 @@ static int wd_cfg_file;
 static void readd_watch(int fd)
 {
     inotify_add_watch(fd, config_dir.c_str(), IN_CREATE);
-    wd_cfg_file = inotify_add_watch(fd, config_file.c_str(), IN_MODIFY);
+    wd_cfg_file = inotify_add_watch(fd, config_file.c_str(), IN_CLOSE_WRITE);
 }
 
 static void reload_config(int fd)


### PR DESCRIPTION
The man page states "IN_MODIFY - File was modified", which seems to make sense for monitoring the config file. However, some users have reported strange crashes during or after modifying the config file, apparently due to the file being partially written when it is read. The man page also shows "IN_CLOSE_WRITE - File opened for writing was closed". This sounds like a better fit and prevents the potential crashes. Fixes #1722.