### PR TITLE
Restore the cursor shape to default when activating scale or expo

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1316,6 +1316,9 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
             return false;
         }
 
+        // hack because otherwise the cursor keeps its previous shape
+        wf::get_core().set_cursor("default");
+
         initial_workspace  = output->workspace->get_current_workspace();
         initial_focus_view = output->get_active_view();
         current_focus_view = initial_focus_view ?: views.front();

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -279,6 +279,9 @@ class wayfire_expo : public wf::per_output_plugin_instance_t, public wf::keyboar
             return false;
         }
 
+        // hack because otherwise the cursor keeps its previous shape
+        wf::get_core().set_cursor("default");
+
         input_grab->grab_input(wf::scene::layer::OVERLAY);
         state.active = true;
         state.button_pressed  = false;


### PR DESCRIPTION
Without that, when switching to expo/scale view, the cursor keeps its shape (or remains hidden if it was hidden before switching)
#1756 