### PR TITLE
simple-tile: Fix no response to input after move/resize a tiled window.

### DIFF
--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -219,23 +219,22 @@ class tile_plugin_t : public wf::per_output_plugin_instance_t, public wf::pointe
     }
 
     template<class Controller>
-    bool start_controller()
+    void start_controller()
     {
         /* No action possible in this case */
         if (has_fullscreen_view() || !has_tiled_focus())
         {
-            return false;
+            return;
         }
 
         if (!output->activate_plugin(&grab_interface))
         {
-            return false;
+            return;
         }
 
-        input_grab->grab_input(wf::scene::layer::OVERLAY);
+        input_grab->grab_input(wf::scene::layer::OVERLAY, true);
         auto vp = output->workspace->get_current_workspace();
         controller = std::make_unique<Controller>(roots[vp.x][vp.y], get_global_input_coordinates());
-        return true;
     }
 
     void stop_controller(bool force_stop)
@@ -524,12 +523,14 @@ class tile_plugin_t : public wf::per_output_plugin_instance_t, public wf::pointe
 
     wf::button_callback on_move_view = [=] (auto)
     {
-        return start_controller<tile::move_view_controller_t>();
+        start_controller<tile::move_view_controller_t>();
+        return false;
     };
 
     wf::button_callback on_resize_view = [=] (auto)
     {
-        return start_controller<tile::resize_view_controller_t>();
+        start_controller<tile::resize_view_controller_t>();
+        return false;
     };
 
     void handle_pointer_button(const wlr_pointer_button_event& event) override

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -245,6 +245,8 @@ class tile_plugin_t : public wf::per_output_plugin_instance_t, public wf::pointe
             return;
         }
 
+        input_grab->ungrab_input();
+
         // Deactivate plugin, so that others can react to the events
         output->deactivate_plugin(&grab_interface);
         if (!force_stop)


### PR DESCRIPTION
After resizing a tiled window with the key binding `button_resize`, wayfire does not response to any input. To avoid this, We need to ungrab the input when deactivating the plugin.
I'm not sure if this is related to #1725, which seems to have a similar behavior.

In addition, the plugin never receives the  `WLR_BUTTON_RELEASED` event corresponding to the `WLR_BUTTON_PRESSED` event in the key binding. We have to mark the key binding as unhandled so that there's a record of the `WLR_BUTTON_PRESSED` event, then grab input with `retain_pressed_state` set to true.
I've also seen similar issue in `wrot`. I guess it could be fixed like this.