### PR TITLE
DRAFT scale: include all views visible on workspace

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -762,10 +762,10 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
 
             auto vg = view->get_wm_geometry();
             auto og = output->get_relative_geometry();
+            wf::region_t vr{vg};
             wf::region_t wr{og};
-            wf::point_t center{vg.x + vg.width / 2, vg.y + vg.height / 2};
 
-            if (wr.contains_point(center))
+            if (!(wr & vr).empty())
             {
                 views.push_back(view);
             }


### PR DESCRIPTION
Intuitively, "scale" should include all views that are visible in (overlap with) the current workspace, not only those that are mostly inside of it.