### PR TITLE
Fix broken scale

### DIFF
--- a/src/api/wayfire/view-transform.hpp
+++ b/src/api/wayfire/view-transform.hpp
@@ -103,6 +103,7 @@ class transformer_render_instance_t : public render_instance_t
         int target_height = scale * bbox.height;
 
         OpenGL::render_begin();
+        inner_content.scale = scale;
         if (inner_content.allocate(target_width, target_height))
         {
             cached_damage |= bbox;


### PR DESCRIPTION
This missing line was causing only the top left quadrant of surfaces to be rendered with scale = 2, for example. Fixes #1750.