### PR TITLE
Remove attach and detach signals

### DIFF
--- a/plugins/blur/blur.hpp
+++ b/plugins/blur/blur.hpp
@@ -107,8 +107,6 @@ class wf_blur_base
     wf::option_wrapper_t<int> degrade_opt, iterations_opt;
     wf::config::option_base_t::updated_callback_t options_changed;
 
-    wf::output_t *output;
-
     /* renders the in texture to the out framebuffer.
      * assumes a properly bound and initialized GL program */
     void render_iteration(wf::region_t blur_region,
@@ -126,7 +124,7 @@ class wf_blur_base
     virtual int blur_fb0(const wf::region_t& blur_region, int width, int height) = 0;
 
   public:
-    wf_blur_base(wf::output_t *output, std::string name);
+    wf_blur_base(std::string name);
     virtual ~wf_blur_base();
 
     virtual int calculate_blur_radius();
@@ -138,10 +136,8 @@ class wf_blur_base
         wlr_box scissor_box, const wf::render_target_t& target_fb);
 };
 
-std::unique_ptr<wf_blur_base> create_box_blur(wf::output_t *output);
-std::unique_ptr<wf_blur_base> create_bokeh_blur(wf::output_t *output);
-std::unique_ptr<wf_blur_base> create_kawase_blur(wf::output_t *output);
-std::unique_ptr<wf_blur_base> create_gaussian_blur(wf::output_t *output);
-
-std::unique_ptr<wf_blur_base> create_blur_from_name(wf::output_t *output,
-    std::string algorithm_name);
+std::unique_ptr<wf_blur_base> create_box_blur();
+std::unique_ptr<wf_blur_base> create_bokeh_blur();
+std::unique_ptr<wf_blur_base> create_kawase_blur();
+std::unique_ptr<wf_blur_base> create_gaussian_blur();
+std::unique_ptr<wf_blur_base> create_blur_from_name(std::string algorithm_name);

--- a/plugins/blur/bokeh.cpp
+++ b/plugins/blur/bokeh.cpp
@@ -57,7 +57,7 @@ void main()
 class wf_bokeh_blur : public wf_blur_base
 {
   public:
-    wf_bokeh_blur(wf::output_t *output) : wf_blur_base(output, "bokeh")
+    wf_bokeh_blur() : wf_blur_base("bokeh")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(bokeh_vertex_shader,
@@ -105,7 +105,7 @@ class wf_bokeh_blur : public wf_blur_base
     }
 };
 
-std::unique_ptr<wf_blur_base> create_bokeh_blur(wf::output_t *output)
+std::unique_ptr<wf_blur_base> create_bokeh_blur()
 {
-    return std::make_unique<wf_bokeh_blur>(output);
+    return std::make_unique<wf_bokeh_blur>();
 }

--- a/plugins/blur/box.cpp
+++ b/plugins/blur/box.cpp
@@ -74,7 +74,7 @@ class wf_box_blur : public wf_blur_base
     void get_id_locations(int i)
     {}
 
-    wf_box_blur(wf::output_t *output) : wf_blur_base(output, "box")
+    wf_box_blur() : wf_blur_base("box")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(
@@ -144,7 +144,7 @@ class wf_box_blur : public wf_blur_base
     }
 };
 
-std::unique_ptr<wf_blur_base> create_box_blur(wf::output_t *output)
+std::unique_ptr<wf_blur_base> create_box_blur()
 {
-    return std::make_unique<wf_box_blur>(output);
+    return std::make_unique<wf_box_blur>();
 }

--- a/plugins/blur/gaussian.cpp
+++ b/plugins/blur/gaussian.cpp
@@ -70,7 +70,7 @@ void main()
 class wf_gaussian_blur : public wf_blur_base
 {
   public:
-    wf_gaussian_blur(wf::output_t *output) : wf_blur_base(output, "gaussian")
+    wf_gaussian_blur() : wf_blur_base("gaussian")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(
@@ -140,7 +140,7 @@ class wf_gaussian_blur : public wf_blur_base
     }
 };
 
-std::unique_ptr<wf_blur_base> create_gaussian_blur(wf::output_t *output)
+std::unique_ptr<wf_blur_base> create_gaussian_blur()
 {
-    return std::make_unique<wf_gaussian_blur>(output);
+    return std::make_unique<wf_gaussian_blur>();
 }

--- a/plugins/blur/kawase.cpp
+++ b/plugins/blur/kawase.cpp
@@ -60,8 +60,7 @@ void main()
 class wf_kawase_blur : public wf_blur_base
 {
   public:
-    wf_kawase_blur(wf::output_t *output) :
-        wf_blur_base(output, "kawase")
+    wf_kawase_blur() : wf_blur_base("kawase")
     {
         OpenGL::render_begin();
         program[0].set_simple(OpenGL::compile_program(kawase_vertex_shader,
@@ -144,7 +143,7 @@ class wf_kawase_blur : public wf_blur_base
     }
 };
 
-std::unique_ptr<wf_blur_base> create_kawase_blur(wf::output_t *output)
+std::unique_ptr<wf_blur_base> create_kawase_blur()
 {
-    return std::make_unique<wf_kawase_blur>(output);
+    return std::make_unique<wf_kawase_blur>();
 }

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1101,9 +1101,8 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
         layout_slots(get_views());
     }
 
-    /* New view or view moved to output with scale active */
-    wf::signal::connection_t<wf::view_layer_attached_signal> view_attached =
-        [=] (wf::view_layer_attached_signal *ev)
+    wf::signal::connection_t<wf::view_set_output_signal> on_view_set_output =
+        [=] (wf::view_set_output_signal *ev)
     {
         handle_new_view(ev->view);
     };
@@ -1333,7 +1332,7 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
 
         layout_slots(get_views());
 
-        output->connect(&view_attached);
+        output->connect(&on_view_set_output);
         output->connect(&on_view_mapped);
         output->connect(&workspace_changed);
         output->connect(&view_detached);
@@ -1355,8 +1354,8 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
         set_hook();
         view_focused.disconnect();
         on_view_mapped.disconnect();
+        on_view_set_output.disconnect();
         view_unmapped.disconnect();
-        view_attached.disconnect();
         view_minimized.disconnect();
         workspace_changed.disconnect();
         view_geometry_changed.disconnect();
@@ -1404,8 +1403,8 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
         grab->ungrab_input();
         view_focused.disconnect();
         on_view_mapped.disconnect();
+        on_view_set_output.disconnect();
         view_unmapped.disconnect();
-        view_attached.disconnect();
         view_detached.disconnect();
         view_minimized.disconnect();
         workspace_changed.disconnect();

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1130,8 +1130,8 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
     }
 
     /* Destroyed view or view moved to another output */
-    wf::signal::connection_t<wf::view_layer_detached_signal> view_detached =
-        [=] (wf::view_layer_detached_signal *ev)
+    wf::signal::connection_t<wf::view_disappeared_signal> view_disappeared =
+        [=] (wf::view_disappeared_signal *ev)
     {
         handle_view_disappeared(ev->view);
     };
@@ -1166,10 +1166,8 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
     /* View minimized */
     wf::signal::connection_t<wf::view_minimized_signal> view_minimized = [=] (wf::view_minimized_signal *ev)
     {
-        if (ev->view->minimized)
-        {
-            handle_view_disappeared(ev->view);
-        } else if (should_scale_view(ev->view))
+        // Handle view restoration, view minimization is handled by disappeared already.
+        if (!ev->view->minimized)
         {
             layout_slots(get_views());
         }
@@ -1335,7 +1333,7 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
         output->connect(&on_view_set_output);
         output->connect(&on_view_mapped);
         output->connect(&workspace_changed);
-        output->connect(&view_detached);
+        output->connect(&view_disappeared);
         output->connect(&view_minimized);
         output->connect(&view_unmapped);
         output->connect(&view_focused);
@@ -1405,7 +1403,7 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
         on_view_mapped.disconnect();
         on_view_set_output.disconnect();
         view_unmapped.disconnect();
-        view_detached.disconnect();
+        view_disappeared.disconnect();
         view_minimized.disconnect();
         workspace_changed.disconnect();
         view_geometry_changed.disconnect();

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -198,7 +198,7 @@ class WayfireSwitcher : public wf::per_output_plugin_instance_t, public wf::keyb
         output->add_key(
             wf::option_wrapper_t<wf::keybinding_t>{"switcher/prev_view"},
             &prev_view_binding);
-        output->connect(&view_removed);
+        output->connect(&view_disappeared);
 
         input_grab = std::make_unique<wf::input_grab_t>("switcher", output, this, nullptr, nullptr);
         grab_interface.cancel = [=] () {deinit_switcher();};
@@ -240,7 +240,8 @@ class WayfireSwitcher : public wf::per_output_plugin_instance_t, public wf::keyb
         }
     };
 
-    wf::signal::connection_t<wf::view_detached_signal> view_removed = [=] (wf::view_detached_signal *ev)
+    wf::signal::connection_t<wf::view_disappeared_signal> view_disappeared =
+        [=] (wf::view_disappeared_signal *ev)
     {
         handle_view_removed(ev->view);
     };

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -310,6 +310,7 @@ class tile_plugin_t : public wf::per_output_plugin_instance_t, public wf::pointe
         if ((ev->new_output == this->output) && node)
         {
             ev->view->store_data(std::make_unique<wf::view_auto_tile_t>());
+            detach_view(node);
         }
     };
 
@@ -335,15 +336,6 @@ class tile_plugin_t : public wf::per_output_plugin_instance_t, public wf::pointe
             output->workspace->add_view(wview, wf::LAYER_WORKSPACE);
         }
     }
-
-    wf::signal::connection_t<view_detached_signal> on_view_detached = [=] (view_detached_signal *ev)
-    {
-        auto view_node = wf::tile::view_node_t::get_node(ev->view);
-        if (view_node)
-        {
-            detach_view(view_node, false);
-        }
-    };
 
     wf::signal::connection_t<workarea_changed_signal> on_workarea_changed = [=] (auto)
     {
@@ -579,7 +571,6 @@ class tile_plugin_t : public wf::per_output_plugin_instance_t, public wf::pointe
 
         output->connect(&on_view_unmapped);
         output->connect(&on_view_attached);
-        output->connect(&on_view_detached);
         output->connect(&on_workarea_changed);
         output->connect(&on_tile_request);
         output->connect(&on_fullscreen_request);

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -154,8 +154,8 @@ class wayfire_wm_actions_t : public wf::per_output_plugin_instance_t
      * Disables show desktop if the workspace is changed or any view is attached,
      * mapped or unminimized.
      */
-    wf::signal::connection_t<wf::view_layer_attached_signal> view_attached =
-        [=] (wf::view_layer_attached_signal *ev)
+    wf::signal::connection_t<wf::view_set_output_signal> view_set_output =
+        [=] (wf::view_set_output_signal *ev)
     {
         check_disable_showdesktop(ev->view);
     };
@@ -263,7 +263,7 @@ class wayfire_wm_actions_t : public wf::per_output_plugin_instance_t
                 }
             }
 
-            output->connect(&view_attached);
+            output->connect(&view_set_output);
             output->connect(&workspace_changed);
             output->connect(&view_minimized);
             output->connect(&on_view_mapped);
@@ -319,7 +319,7 @@ class wayfire_wm_actions_t : public wf::per_output_plugin_instance_t
 
     void disable_showdesktop()
     {
-        view_attached.disconnect();
+        view_set_output.disconnect();
         workspace_changed.disconnect();
         view_minimized.disconnect();
 

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -94,7 +94,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'01'17;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'05'18;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -660,17 +660,6 @@ struct view_layer_attached_signal
 
 /**
  * on: output
- * when: Emitted when the view's output is about to be changed to another one.
- *   This is the last point where the view is considered to be part of the given
- *   output.
- */
-struct view_detached_signal
-{
-    wayfire_view view;
-};
-
-/**
- * on: output
  * when: Emitted when the view is removed from a layer but is not added to
  *   another.
  */
@@ -713,10 +702,9 @@ struct view_moved_to_output_signal
 
 /**
  * on: output
- * when: This is a signal which combines view-unmapped, view-detached and
- *   view-minimized, and is emitted together with each of these three. Semantic
- *   meaning is that the view is no longer available for focus, interaction with
- *   the user, etc.
+ * when: This signal is a combination of the unmapped and set-output signals. In the latter case, the signal
+ *   is emitted on the view's previous output. The meaning of this signal is that the view is no longer
+ *   available for focus, interaction with the user, etc. on the output where it used to be.
  */
 struct view_disappeared_signal
 {

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -385,7 +385,7 @@ struct view_unmapped_signal
 };
 
 /**
- * on: view, core
+ * on: view, new output, core
  * when: Immediately after the view's output changes. Note that child views may still be on the old output.
  */
 struct view_set_output_signal
@@ -647,16 +647,6 @@ struct view_ping_timeout_signal
 /* ----------------------------------------------------------------------------/
  * View <-> output signals
  * -------------------------------------------------------------------------- */
-
-/**
- * on: output
- * when: Emitted when the view is added to a layer in the output's workspace
- *   manager and it was in no layer previously.
- */
-struct view_layer_attached_signal
-{
-    wayfire_view view;
-};
 
 /**
  * on: output

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -649,22 +649,8 @@ struct view_ping_timeout_signal
  * -------------------------------------------------------------------------- */
 
 /**
- * on: output
- * when: Emitted when the view is removed from a layer but is not added to
- *   another.
- */
-struct view_layer_detached_signal
-{
-    wayfire_view view;
-};
-
-/**
  * on: core
- * when: Immediately before the view is moved to another output. The usual
- *   sequence when moving views to another output is:
- *
- *   pre-moved-to-output -> layer-detach -> detach ->
- *      attach -> layer-attach -> moved-to-output
+ * when: Immediately before the view is moved to another output. view-moved-to-output is emitted afterwards.
  */
 struct view_pre_moved_to_output_signal
 {
@@ -692,9 +678,9 @@ struct view_moved_to_output_signal
 
 /**
  * on: output
- * when: This signal is a combination of the unmapped and set-output signals. In the latter case, the signal
- *   is emitted on the view's previous output. The meaning of this signal is that the view is no longer
- *   available for focus, interaction with the user, etc. on the output where it used to be.
+ * when: This signal is a combination of the unmapped, minimized and set-output signals. In the latter case,
+ *   the signal is emitted on the view's previous output. The meaning of this signal is that the view is no
+ *   longer available for focus, interaction with the user, etc. on the output where it used to be.
  */
 struct view_disappeared_signal
 {

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -650,16 +650,6 @@ struct view_ping_timeout_signal
 
 /**
  * on: output
- * when: As soon as the view's output is set to the given output. This is the
- *   first point where the view is considered to be part of that output.
- */
-struct view_attached_signal
-{
-    wayfire_view view;
-};
-
-/**
- * on: output
  * when: Emitted when the view is added to a layer in the output's workspace
  *   manager and it was in no layer previously.
  */

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -30,7 +30,6 @@ class output_impl_t : public output_t
     std::unordered_multiset<wf::plugin_activation_data_t*> active_plugins;
 
     wf::signal::connection_t<view_disappeared_signal> on_view_disappeared;
-    wf::signal::connection_t<view_detached_signal> on_view_detached;
     void handle_view_removed(wayfire_view view);
 
     bool inhibited = false;

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -70,10 +70,7 @@ wf::output_impl_t::output_impl_t(wlr_output *handle,
     render    = std::make_unique<render_manager>(this);
 
     on_view_disappeared.set_callback([=] (view_disappeared_signal *ev) { handle_view_removed(ev->view); });
-    on_view_detached.set_callback([=] (view_detached_signal *ev) { handle_view_removed(ev->view); });
-
     connect(&on_view_disappeared);
-    connect(&on_view_detached);
 }
 
 std::shared_ptr<wf::scene::output_node_t> wf::output_impl_t::node_for_layer(

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -865,10 +865,6 @@ class workspace_manager::impl
         uint32_t view_layer = layer_manager.get_view_layer(view);
         layer_manager.remove_view(view);
 
-        view_layer_detached_signal data;
-        data.view = view;
-        output->emit(&data);
-
         /* Check if the next focused view is fullscreen. If so, then we need
          * to make sure it is in the fullscreen layer */
         if (view_layer & MIDDLE_LAYERS)

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -841,24 +841,11 @@ class workspace_manager::impl
         }
     }
 
-    void handle_view_first_add(wayfire_view view)
-    {
-        view_layer_attached_signal data;
-        data.view = view;
-        output->emit(&data);
-    }
-
     void add_view_to_layer(wayfire_view view, layer_t layer)
     {
         assert(view->get_output() == output);
-        bool first_add = layer_manager.get_view_layer(view) == 0;
         layer_manager.add_view_to_layer(view, layer);
         update_promoted_views();
-
-        if (first_add)
-        {
-            handle_view_first_add(view);
-        }
     }
 
     void bring_to_front(wayfire_view view)

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -213,12 +213,6 @@ void wf::view_interface_t::set_output(wf::output_t *new_output)
     data.output = get_output();
 
     this->priv->output = new_output;
-    if ((new_output != data.output) && new_output)
-    {
-        view_attached_signal data;
-        data.view = self();
-        get_output()->emit(&data);
-    }
 
     this->emit(&data);
     wf::get_core().emit(&data);

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -210,6 +210,11 @@ void wf::view_interface_t::set_output(wf::output_t *new_output)
     this->priv->output = new_output;
 
     this->emit(&data);
+    if (new_output)
+    {
+        new_output->emit(&data);
+    }
+
     wf::get_core().emit(&data);
 
     for (auto& view : this->children)

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -197,15 +197,10 @@ void wf::view_interface_t::set_output(wf::output_t *new_output)
     {
         /* Emit view-layer-detached first */
         get_output()->workspace->remove_view(self());
-
-        view_detached_signal data_detached;
-        data_detached.view = self();
-
         view_disappeared_signal data_disappeared;
         data_disappeared.view = self();
 
         get_output()->emit(&data_disappeared);
-        get_output()->emit(&data_detached);
     }
 
     view_set_output_signal data;


### PR DESCRIPTION
These signals are used in just a few plugins and do not reflect the way Wayfire's API should be used.
Namely, a view is no longer bound to a single layer on one output (since scenegraph), even though most views are, in practice.

Replacement: use view-mapped, view-unmapped, view-disappeared, view-set-output (which indicates the view's 'primary output'), depending on what the plugin needs to handle.
