### PR TITLE
[RFC] Move window rules to IPC scripts

### DIFF
--- a/ipc-scripts/inactive-alpha.py
+++ b/ipc-scripts/inactive-alpha.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python3
+#
+# This script demonstrates how Wayfire's IPC can be used to set the opacity of inactive views.
+
+import os
+from wayfire_socket import *
+
+addr = os.getenv('WAYFIRE_SOCKET')
+sock = WayfireSocket(addr)
+sock.watch()
+
+last_focused_toplevel = -1
+while True:
+    msg = sock.read_message()
+    # The view-mapped event is emitted when a new window has been opened.
+    if "event" in msg and msg["event"] == "view-focused":
+        view = msg["view"]
+        print(view)
+        new_focus = view["id"] if view and view["type"] == "toplevel" else -1
+        if last_focused_toplevel != new_focus:
+            if last_focused_toplevel != -1 and new_focus != -1:
+                sock.set_view_alpha(last_focused_toplevel, 0.8)
+
+            if new_focus != -1:
+                sock.set_view_alpha(new_focus, 1.0)
+
+            last_focused_toplevel = new_focus

--- a/ipc-scripts/ipc-rules-demo.py
+++ b/ipc-scripts/ipc-rules-demo.py
@@ -1,0 +1,37 @@
+#!/usr/bin/python3
+#
+# This is a simple script which demonstrates how to use the Wayfire IPC socket with the wayfire_socket.py helper.
+# To use this, make sure that the ipc plugin is first in the plugin list, so that the WAYFIRE_SOCKET environment
+# variable propagates to all processes, including autostarted processes.
+# To use this script, the ipc-rules plugin should also be enabled, as it provides some of the basic events and commands
+# required for IPC interaction.
+#
+# Lastly, this script can be run from a terminal for testing purposes, or started as an autostart entry.
+# It is safe to kill/restart the process at any point in time.
+
+import os
+from wayfire_socket import *
+
+addr = os.getenv('WAYFIRE_SOCKET')
+sock = WayfireSocket(addr)
+sock.watch()
+
+while True:
+    msg = sock.read_message()
+    # The view-mapped event is emitted when a new window has been opened.
+    if "event" in msg and msg["event"] == "view-mapped":
+        view = msg["view"]
+        if view["app-id"] == "gedit":
+            output_data = sock.query_output(view["output"])
+            workarea = output_data["workarea"]
+
+            # We want gedit to take a certain position (200,200) and a quarter of the output
+            x = 200
+            y = 200
+            w = workarea['width'] // 2
+            h = workarea['height'] // 2
+
+            sock.configure_view(view["id"], x, y, w, h)
+            # sock.assign_slot(view["id"], "slot_br")
+            sock.set_always_on_top(view["id"], True)
+            sock.set_view_alpha(view["id"], 0.5)

--- a/ipc-scripts/wayfire_socket.py
+++ b/ipc-scripts/wayfire_socket.py
@@ -1,0 +1,80 @@
+import socket
+import json as js
+
+def get_msg_template(method: str):
+    # Create generic message template
+    message = {}
+    message["method"] = method
+    message["data"] = {}
+    return message
+
+def geometry_to_json(x: int, y: int, w: int, h: int):
+    geometry = {}
+    geometry["x"] = x
+    geometry["y"] = y
+    geometry["width"] = w
+    geometry["height"] = h
+    return geometry
+
+class WayfireSocket:
+    def __init__(self, socket_name):
+        self.client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.client.connect(socket_name)
+
+    def read_exact(self, n):
+        response = bytes()
+        while n > 0:
+            read_this_time = self.client.recv(n)
+            if not read_this_time:
+                raise Exception("Failed to read anything from the socket!")
+            n -= len(read_this_time)
+            response += read_this_time
+
+        return response
+
+    def read_message(self):
+        rlen = int.from_bytes(self.read_exact(4), byteorder="little")
+        response_message = self.read_exact(rlen)
+        return js.loads(response_message)
+
+    def send_json(self, msg):
+        data = js.dumps(msg).encode('utf8')
+        header = len(data).to_bytes(4, byteorder="little")
+        self.client.send(header)
+        self.client.send(data)
+        return self.read_message()
+
+    def watch(self):
+        message = get_msg_template("window-rules/events/watch")
+        return self.send_json(message)
+
+    def query_output(self, output_id: int):
+        message = get_msg_template("window-rules/output-info")
+        message["data"]["id"] = output_id
+        return self.send_json(message)
+
+    def configure_view(self, view_id: int, x: int, y: int, w: int, h: int):
+        message = get_msg_template("window-rules/configure-view")
+        message["data"]["id"] = view_id
+        message["data"]["geometry"] = geometry_to_json(x, y, w, h)
+        print(message)
+        return self.send_json(message)
+
+    def assign_slot(self, view_id: int, slot: str):
+        message = get_msg_template("grid/" + slot)
+        message["data"]["view_id"] = view_id
+        return self.send_json(message)
+
+    def set_always_on_top(self, view_id: int, always_on_top: bool):
+        message = get_msg_template("wm-actions/set-always-on-top")
+        message["data"]["view_id"] = view_id
+        message["data"]["state"] = always_on_top
+        return self.send_json(message)
+
+    def set_view_alpha(self, view_id: int, alpha: float):
+        message = get_msg_template("wf/alpha/set-view-alpha")
+        message["method"] = "wf/alpha/set-view-alpha"
+        message["data"] = {}
+        message["data"]["view-id"] = view_id
+        message["data"]["alpha"] = alpha
+        return self.send_json(message)

--- a/plugins/grid/grid.cpp
+++ b/plugins/grid/grid.cpp
@@ -17,6 +17,7 @@
 
 #include <wayfire/plugins/wobbly/wobbly-signal.hpp>
 #include <wayfire/view-transform.hpp>
+#include "plugins/ipc/ipc-activator.hpp"
 
 const std::string grid_view_id = "grid-view";
 
@@ -49,118 +50,75 @@ nonstd::observer_ptr<wf::grid::grid_animation_t> ensure_grid_view(wayfire_toplev
     return view->get_data<wf::grid::grid_animation_t>();
 }
 
-/*
- * 7 8 9
- * 4 5 6
- * 1 2 3
- */
-static uint32_t get_tiled_edges_for_slot(uint32_t slot)
+class wayfire_grid : public wf::plugin_interface_t, public wf::per_output_tracker_mixin_t<>
 {
-    if (slot == 0)
-    {
-        return 0;
-    }
-
-    uint32_t edges = wf::TILED_EDGES_ALL;
-    if (slot % 3 == 0)
-    {
-        edges &= ~WLR_EDGE_LEFT;
-    }
-
-    if (slot % 3 == 1)
-    {
-        edges &= ~WLR_EDGE_RIGHT;
-    }
-
-    if (slot <= 3)
-    {
-        edges &= ~WLR_EDGE_TOP;
-    }
-
-    if (slot >= 7)
-    {
-        edges &= ~WLR_EDGE_BOTTOM;
-    }
-
-    return edges;
-}
-
-static uint32_t get_slot_from_tiled_edges(uint32_t edges)
-{
-    for (int slot = 0; slot <= 9; slot++)
-    {
-        if (get_tiled_edges_for_slot(slot) == edges)
-        {
-            return slot;
-        }
-    }
-
-    return 0;
-}
-
-class wayfire_grid : public wf::per_output_plugin_instance_t
-{
-    std::vector<std::string> slots =
-    {"unused", "bl", "b", "br", "l", "c", "r", "tl", "t", "tr"};
-    wf::activator_callback bindings[10];
-    wf::option_wrapper_t<wf::activatorbinding_t> keys[10];
-    wf::option_wrapper_t<wf::activatorbinding_t> restore_opt{"grid/restore"};
+    std::vector<std::string> slots = {"unused", "bl", "b", "br", "l", "c", "r", "tl", "t", "tr"};
+    wf::ipc_activator_t bindings[10];
+    wf::ipc_activator_t restore{"grid/restore"};
 
     wf::plugin_activation_data_t grab_interface{
         .name = "grid",
         .capabilities = wf::CAPABILITY_MANAGE_DESKTOP,
     };
 
-    wf::activator_callback restore = [=] (auto)
+    wf::ipc_activator_t::handler_t handle_restore = [=] (wf::output_t *wo, wayfire_view view)
     {
-        if (!output->can_activate_plugin(&grab_interface))
+        if (!wo->can_activate_plugin(&grab_interface))
         {
             return false;
         }
 
-        auto view = toplevel_cast(output->get_active_view());
+        auto toplevel = toplevel_cast(view);
         if (!view)
         {
             return false;
         }
 
-        wf::get_core().default_wm->tile_request(view, 0);
+        wf::get_core().default_wm->tile_request(toplevel, 0);
         return true;
     };
 
   public:
     void init() override
     {
+        init_output_tracking();
+        restore.set_handler(handle_restore);
         for (int i = 1; i < 10; i++)
         {
-            keys[i].load_option("grid/slot_" + slots[i]);
-            bindings[i] = [=] (auto)
+            bindings[i].load_from_xml_option("grid/slot_" + slots[i]);
+            bindings[i].set_handler([=] (wf::output_t *wo, wayfire_view view)
             {
-                auto view = toplevel_cast(output->get_active_view());
-                if (!view || (view->role != wf::VIEW_ROLE_TOPLEVEL))
+                if (!wo->can_activate_plugin(wf::CAPABILITY_MANAGE_DESKTOP))
                 {
                     return false;
                 }
 
-                if (!output->can_activate_plugin(wf::CAPABILITY_MANAGE_DESKTOP))
+                if (auto toplevel = toplevel_cast(view))
                 {
-                    return false;
+                    handle_slot(toplevel, i);
+                    return true;
                 }
 
-                handle_slot(view, i);
-                return true;
-            };
-
-            output->add_activator(keys[i], &bindings[i]);
+                return false;
+            });
         }
+    }
 
-        output->add_activator(restore_opt, &restore);
-
+    void handle_new_output(wf::output_t *output) override
+    {
         output->connect(&on_workarea_changed);
-        output->connect(&on_snap_signal);
-        output->connect(&on_snap_query);
         output->connect(&on_maximize_signal);
         output->connect(&on_fullscreen_signal);
+    }
+
+    void handle_output_removed(wf::output_t *output) override
+    {
+        // no-op
+    }
+
+    void fini() override
+    {
+        fini_output_tracking();
     }
 
     bool can_adjust_view(wayfire_toplevel_view view)
@@ -177,47 +135,15 @@ class wayfire_grid : public wf::per_output_plugin_instance_t
         }
 
         view->get_data_safe<wf_grid_slot_data>()->slot = slot;
+        auto slot_geometry = wf::grid::get_slot_dimensions(view->get_output(), slot) + delta;
         ensure_grid_view(view)->adjust_target_geometry(
-            get_slot_dimensions(slot) + delta,
-            get_tiled_edges_for_slot(slot));
-    }
-
-    /*
-     * 7 8 9
-     * 4 5 6
-     * 1 2 3
-     * */
-    wf::geometry_t get_slot_dimensions(int n)
-    {
-        auto area = output->workarea->get_workarea();
-        int w2    = area.width / 2;
-        int h2    = area.height / 2;
-
-        if (n % 3 == 1)
-        {
-            area.width = w2;
-        }
-
-        if (n % 3 == 0)
-        {
-            area.width = w2, area.x += w2;
-        }
-
-        if (n >= 7)
-        {
-            area.height = h2;
-        } else if (n <= 3)
-        {
-            area.height = h2, area.y += h2;
-        }
-
-        return area;
+            slot_geometry, wf::grid::get_tiled_edges_for_slot(slot));
     }
 
     wf::signal::connection_t<wf::workarea_changed_signal> on_workarea_changed =
         [=] (wf::workarea_changed_signal *ev)
     {
-        for (auto& view : output->wset()->get_views(wf::WSET_MAPPED_ONLY))
+        for (auto& view : ev->output->wset()->get_views(wf::WSET_MAPPED_ONLY))
         {
             auto data = view->get_data_safe<wf_grid_slot_data>();
 
@@ -237,33 +163,20 @@ class wayfire_grid : public wf::per_output_plugin_instance_t
             /* Workarea changed, and we have a view which is tiled into some slot.
              * We need to make sure it remains in its slot. So we calculate the
              * viewport of the view, and tile it there */
-            auto output_geometry = output->get_relative_geometry();
+            auto output_geometry = ev->output->get_relative_geometry();
 
             int vx = std::floor(1.0 * wm.x / output_geometry.width);
             int vy = std::floor(1.0 * wm.y / output_geometry.height);
 
-            handle_slot(view, data->slot,
-                {vx *output_geometry.width, vy * output_geometry.height});
+            handle_slot(view, data->slot, {vx *output_geometry.width, vy * output_geometry.height});
         }
     };
 
-    wf::signal::connection_t<wf::grid::grid_query_geometry_signal> on_snap_query =
-        [=] (wf::grid::grid_query_geometry_signal *query)
+    wf::geometry_t adjust_for_workspace(std::shared_ptr<wf::workspace_set_t> wset,
+        wf::geometry_t geometry, wf::point_t workspace)
     {
-        query->out_geometry = get_slot_dimensions(query->slot);
-    };
-
-    wf::signal::connection_t<wf::grid::grid_snap_view_signal> on_snap_signal =
-        [=] (wf::grid::grid_snap_view_signal *data)
-    {
-        handle_slot(data->view, data->slot);
-    };
-
-    wf::geometry_t adjust_for_workspace(wf::geometry_t geometry,
-        wf::point_t workspace)
-    {
-        auto delta_ws = workspace - output->wset()->get_current_workspace();
-        auto scr_size = output->get_screen_size();
+        auto delta_ws = workspace - wset->get_current_workspace();
+        auto scr_size = wset->get_last_output_geometry().value();
         geometry.x += delta_ws.x * scr_size.width;
         geometry.y += delta_ws.y * scr_size.height;
         return geometry;
@@ -272,49 +185,39 @@ class wayfire_grid : public wf::per_output_plugin_instance_t
     wf::signal::connection_t<wf::view_tile_request_signal> on_maximize_signal =
         [=] (wf::view_tile_request_signal *data)
     {
-        if (data->carried_out || (data->desired_size.width <= 0) ||
-            !can_adjust_view(data->view))
+        if (data->carried_out || (data->desired_size.width <= 0) || !data->view->get_output() ||
+            !data->view->get_wset() || !can_adjust_view(data->view))
         {
             return;
         }
 
         data->carried_out = true;
-        uint32_t slot = get_slot_from_tiled_edges(data->edges);
+        uint32_t slot = wf::grid::get_slot_from_tiled_edges(data->edges);
         if (slot > 0)
         {
-            data->desired_size = get_slot_dimensions(slot);
+            data->desired_size = wf::grid::get_slot_dimensions(data->view->get_output(), slot);
         }
 
         data->view->get_data_safe<wf_grid_slot_data>()->slot = slot;
         ensure_grid_view(data->view)->adjust_target_geometry(
-            adjust_for_workspace(data->desired_size, data->workspace),
-            get_tiled_edges_for_slot(slot));
+            adjust_for_workspace(data->view->get_wset(), data->desired_size, data->workspace),
+            wf::grid::get_tiled_edges_for_slot(slot));
     };
 
     wf::signal::connection_t<wf::view_fullscreen_request_signal> on_fullscreen_signal =
         [=] (wf::view_fullscreen_request_signal *data)
     {
         static const std::string fs_data_name = "grid-saved-fs";
-        if (data->carried_out || (data->desired_size.width <= 0) ||
-            !can_adjust_view(data->view))
+        if (data->carried_out || (data->desired_size.width <= 0) || !data->view->get_output() ||
+            !data->view->get_wset() || !can_adjust_view(data->view))
         {
             return;
         }
 
         data->carried_out = true;
         ensure_grid_view(data->view)->adjust_target_geometry(
-            adjust_for_workspace(data->desired_size, data->workspace), -1);
+            adjust_for_workspace(data->view->get_wset(), data->desired_size, data->workspace), -1);
     };
-
-    void fini() override
-    {
-        for (int i = 1; i < 10; i++)
-        {
-            output->rem_binding(&bindings[i]);
-        }
-
-        output->rem_binding(&restore);
-    }
 };
 
-DECLARE_WAYFIRE_PLUGIN(wf::per_output_plugin_t<wayfire_grid>);
+DECLARE_WAYFIRE_PLUGIN(wayfire_grid);

--- a/plugins/grid/meson.build
+++ b/plugins/grid/meson.build
@@ -1,6 +1,6 @@
 grid_inc = include_directories('.')
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, wobbly_inc, grid_inc]
-all_deps = [wlroots, pixman, wfconfig, wftouch, cairo]
+all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, json]
 
 shared_module('grid', ['grid.cpp'],
         include_directories: all_include_dirs,

--- a/plugins/ipc/ipc-activator.hpp
+++ b/plugins/ipc/ipc-activator.hpp
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <wayfire/bindings-repository.hpp>
+#include <wayfire/config/types.hpp>
+#include "ipc-helpers.hpp"
+#include "plugins/ipc/ipc-method-repository.hpp"
+#include "wayfire/bindings.hpp"
+#include "wayfire/core.hpp"
+#include "wayfire/option-wrapper.hpp"
+#include "wayfire/output.hpp"
+#include "wayfire/plugins/common/shared-core-data.hpp"
+
+namespace wf
+{
+/**
+ * The IPC activator class is a helper class which combines an IPC method with a normal activator binding.
+ */
+
+class ipc_activator_t
+{
+  public:
+    ipc_activator_t()
+    {}
+
+    ipc_activator_t(std::string name)
+    {
+        load_from_xml_option(name);
+    }
+
+    void load_from_xml_option(std::string name)
+    {
+        activator.load_option(name);
+        wf::get_core().bindings->add_activator(activator, &activator_cb);
+        repo->register_method(name, ipc_cb);
+        this->name = name;
+    }
+
+    ~ipc_activator_t()
+    {
+        wf::get_core().bindings->rem_binding(&activator_cb);
+        repo->unregister_method(name);
+    }
+
+    /**
+     * The handler is given over an optional output and a view to execute the action for.
+     * Note that the output is always set (if not explicitly given, then it is set to the currently focused
+     * output), however the view might be nullptr if not indicated in the IPC call or in the case of
+     * activators, no suitable view could be found for the cursor/keyboard focus.
+     */
+    using handler_t = std::function<bool (wf::output_t*, wayfire_view)>;
+    void set_handler(handler_t hnd)
+    {
+        this->hnd = hnd;
+    }
+
+  private:
+    wf::option_wrapper_t<activatorbinding_t> activator;
+    shared_data::ref_ptr_t<ipc::method_repository_t> repo;
+    std::string name;
+    handler_t hnd;
+
+    activator_callback activator_cb = [=] (const wf::activator_data_t& data) -> bool
+    {
+        if (hnd)
+        {
+            return hnd(choose_output(), choose_view(data.source));
+        }
+
+        return false;
+    };
+
+    ipc::method_callback ipc_cb = [=] (const nlohmann::json& data)
+    {
+        WFJSON_OPTIONAL_FIELD(data, "output_id", number_integer);
+        WFJSON_OPTIONAL_FIELD(data, "view_id", number_integer);
+
+        wf::output_t *wo = wf::get_core().get_active_output();
+        if (data.contains("output_id"))
+        {
+            wo = ipc::find_output_by_id(data["output_id"]);
+            if (!wo)
+            {
+                return ipc::json_error("output id not found!");
+            }
+        }
+
+        wayfire_view view;
+        if (data.contains("view_id"))
+        {
+            view = ipc::find_view_by_id(data["view_id"]);
+            if (!view)
+            {
+                return ipc::json_error("view id not found!");
+            }
+        }
+
+        if (hnd)
+        {
+            hnd(wo, view);
+        }
+
+        return ipc::json_ok();
+    };
+
+    wf::output_t *choose_output()
+    {
+        return wf::get_core().get_active_output();
+    }
+
+    wayfire_view choose_view(wf::activator_source_t source)
+    {
+        wayfire_view view;
+        if (source == wf::activator_source_t::BUTTONBINDING)
+        {
+            view = wf::get_core().get_cursor_focus_view();
+        } else
+        {
+            view = wf::get_core().get_active_output()->get_active_view();
+        }
+
+        return view;
+    }
+};
+}

--- a/plugins/ipc/ipc-method-repository.hpp
+++ b/plugins/ipc/ipc-method-repository.hpp
@@ -84,5 +84,11 @@ inline nlohmann::json json_error(std::string msg)
     { \
         return wf::ipc::json_error("Field \"" field "\" does not have the correct type " #type); \
     }
+
+#define WFJSON_OPTIONAL_FIELD(data, field, type) \
+    if (data.count(field) && !data[field].is_ ## type()) \
+    { \
+        return wf::ipc::json_error("Field \"" field "\" does not have the correct type " #type); \
+    }
 }
 }

--- a/plugins/ipc/meson.build
+++ b/plugins/ipc/meson.build
@@ -30,4 +30,4 @@ demoipc = shared_module('demo-ipc',
     install: true,
     install_dir: conf_data.get('PLUGIN_PATH'))
 
-install_headers(['ipc-method-repository.hpp', 'ipc.hpp', 'ipc-helpers.hpp'], subdir: 'wayfire/plugins/ipc')
+install_headers(['ipc-method-repository.hpp', 'ipc.hpp', 'ipc-helpers.hpp', 'ipc-activator.hpp'], subdir: 'wayfire/plugins/ipc')

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -1,0 +1,253 @@
+#include <wayfire/plugin.hpp>
+#include <wayfire/per-output-plugin.hpp>
+#include <wayfire/view.hpp>
+#include <wayfire/output.hpp>
+#include <wayfire/toplevel-view.hpp>
+#include <set>
+
+#include "plugins/ipc/ipc-helpers.hpp"
+#include "plugins/ipc/ipc.hpp"
+#include "plugins/ipc/ipc-method-repository.hpp"
+#include "wayfire/core.hpp"
+#include "wayfire/object.hpp"
+#include "wayfire/plugins/common/shared-core-data.hpp"
+#include "wayfire/signal-definitions.hpp"
+#include "wayfire/signal-provider.hpp"
+#include "wayfire/view-helpers.hpp"
+#include "wayfire/workarea.hpp"
+#include "wayfire/workspace-set.hpp"
+#include "config.h"
+#include <wayfire/nonstd/wlroots-full.hpp>
+
+class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker_mixin_t<>
+{
+  public:
+    void init() override
+    {
+        method_repository->register_method("window-rules/events/watch", on_client_watch);
+        method_repository->register_method("window-rules/view-info", get_view_info);
+        method_repository->register_method("window-rules/output-info", get_output_info);
+        method_repository->register_method("window-rules/configure-view", configure_view);
+        ipc_server->connect(&on_client_disconnected);
+        wf::get_core().connect(&on_view_mapped);
+        wf::get_core().connect(&on_kbfocus_changed);
+        init_output_tracking();
+    }
+
+    void fini() override
+    {
+        method_repository->unregister_method("window-rules/events/watch");
+        method_repository->unregister_method("window-rules/view-info");
+        method_repository->unregister_method("window-rules/output-info");
+        method_repository->unregister_method("window-rules/configure-view");
+        fini_output_tracking();
+    }
+
+    void handle_new_output(wf::output_t *output) override
+    {
+        output->connect(&_tiled);
+        output->connect(&_minimized);
+        output->connect(&_fullscreened);
+    }
+
+    void handle_output_removed(wf::output_t *output) override
+    {
+        // no-op
+    }
+
+    wf::ipc::method_callback get_view_info = [=] (nlohmann::json data)
+    {
+        WFJSON_EXPECT_FIELD(data, "id", number_integer);
+        if (auto view = wf::ipc::find_view_by_id(data["id"]))
+        {
+            auto response = wf::ipc::json_ok();
+            response["info"] = view_to_json(view);
+            return response;
+        }
+
+        return wf::ipc::json_error("no such view");
+    };
+
+    wf::ipc::method_callback get_output_info = [=] (nlohmann::json data)
+    {
+        WFJSON_EXPECT_FIELD(data, "id", number_integer);
+        auto wo = wf::ipc::find_output_by_id(data["id"]);
+        if (!wo)
+        {
+            return wf::ipc::json_error("output not found");
+        }
+
+        auto response = wf::ipc::json_ok();
+        response["name"]     = wo->to_string();
+        response["geometry"] = wf::ipc::geometry_to_json(wo->get_layout_geometry());
+        response["workarea"] = wf::ipc::geometry_to_json(wo->workarea->get_workarea());
+        response["workspace"]["x"] = wo->wset()->get_current_workspace().x;
+        response["workspace"]["y"] = wo->wset()->get_current_workspace().y;
+        response["workspace"]["grid_width"]  = wo->wset()->get_workspace_grid_size().width;
+        response["workspace"]["grid_height"] = wo->wset()->get_workspace_grid_size().height;
+        return response;
+    };
+
+    wf::ipc::method_callback configure_view = [=] (nlohmann::json data)
+    {
+        WFJSON_EXPECT_FIELD(data, "id", number_integer);
+        WFJSON_OPTIONAL_FIELD(data, "output_id", number_integer);
+        WFJSON_OPTIONAL_FIELD(data, "geometry", object);
+
+        auto view = wf::ipc::find_view_by_id(data["id"]);
+        if (!view)
+        {
+            return wf::ipc::json_error("view not found");
+        }
+
+        auto toplevel = wf::toplevel_cast(view);
+        if (!toplevel)
+        {
+            return wf::ipc::json_error("view is not toplevel");
+        }
+
+        if (data.contains("output_id"))
+        {
+            auto wo = wf::ipc::find_output_by_id(data["output_id"]);
+            if (!wo)
+            {
+                return wf::ipc::json_error("output not found");
+            }
+
+            wf::move_view_to_output(toplevel, wo, !data.contains("geometry"));
+        }
+
+        if (data.contains("geometry"))
+        {
+            auto geometry = wf::ipc::geometry_from_json(data["geometry"]);
+            if (!geometry)
+            {
+                return wf::ipc::json_error("invalid geometry");
+            }
+
+            toplevel->set_geometry(*geometry);
+        }
+
+        return wf::ipc::json_ok();
+    };
+
+  private:
+    wf::shared_data::ref_ptr_t<wf::ipc::method_repository_t> method_repository;
+    wf::shared_data::ref_ptr_t<wf::ipc::server_t> ipc_server;
+
+    // Track a list of clients which have requested watch
+    std::set<wf::ipc::client_t*> clients;
+
+    wf::ipc::method_callback on_client_watch = [=] (nlohmann::json data)
+    {
+        clients.insert(ipc_server->get_current_request_client());
+        return wf::ipc::json_ok();
+    };
+
+    wf::signal::connection_t<wf::ipc::client_disconnected_signal> on_client_disconnected =
+        [=] (wf::ipc::client_disconnected_signal *ev)
+    {
+        clients.erase(ev->client);
+    };
+
+    void send_view_to_subscribes(wayfire_view view, std::string event_name)
+    {
+        nlohmann::json event;
+        event["event"] = event_name;
+        event["view"]  = view_to_json(view);
+        for (auto& client : clients)
+        {
+            client->send_json(event);
+        }
+    }
+
+    wf::signal::connection_t<wf::view_mapped_signal> on_view_mapped = [=] (wf::view_mapped_signal *ev)
+    {
+        send_view_to_subscribes(ev->view, "view-mapped");
+    };
+
+    wf::signal::connection_t<wf::keyboard_focus_changed_signal> on_kbfocus_changed =
+        [=] (wf::keyboard_focus_changed_signal *ev)
+    {
+        send_view_to_subscribes(wf::node_to_view(ev->new_focus), "view-focused");
+    };
+
+    // Maximized rule handler.
+    wf::signal::connection_t<wf::view_tiled_signal> _tiled = [=] (wf::view_tiled_signal *ev)
+    {
+        send_view_to_subscribes(ev->view, "view-tiled");
+    };
+
+    // Minimized rule handler.
+    wf::signal::connection_t<wf::view_minimized_signal> _minimized = [=] (wf::view_minimized_signal *ev)
+    {
+        send_view_to_subscribes(ev->view, "view-minimized");
+    };
+
+    // Fullscreened rule handler.
+    wf::signal::connection_t<wf::view_fullscreen_signal> _fullscreened = [=] (wf::view_fullscreen_signal *ev)
+    {
+        send_view_to_subscribes(ev->view, "view-fullscreen");
+    };
+
+    std::string get_view_type(wayfire_view view)
+    {
+        if (view->role == wf::VIEW_ROLE_TOPLEVEL)
+        {
+            return "toplevel";
+        }
+
+        if (view->role == wf::VIEW_ROLE_UNMANAGED)
+        {
+#if WF_HAS_XWAYLAND
+            auto surf = view->get_wlr_surface();
+            if (surf && wlr_surface_is_xwayland_surface(surf))
+            {
+                return "x-or";
+            }
+
+#endif
+
+            return "unmanaged";
+        }
+
+        auto layer = wf::get_view_layer(view);
+        if ((layer == wf::scene::layer::BACKGROUND) || (layer == wf::scene::layer::BOTTOM))
+        {
+            return "background";
+        } else if (layer == wf::scene::layer::TOP)
+        {
+            return "panel";
+        } else if (layer == wf::scene::layer::OVERLAY)
+        {
+            return "overlay";
+        }
+
+        return "unknown";
+    }
+
+    nlohmann::json view_to_json(wayfire_view view)
+    {
+        if (!view)
+        {
+            return nullptr;
+        }
+
+        nlohmann::json description;
+        description["id"]     = view->get_id();
+        description["app-id"] = view->get_app_id();
+        description["title"]  = view->get_title();
+        auto toplevel = wf::toplevel_cast(view);
+        description["geometry"] =
+            wf::ipc::geometry_to_json(toplevel ? toplevel->get_pending_geometry() : view->get_bounding_box());
+        description["output"] = view->get_output() ? view->get_output()->get_id() : -1;
+        description["tiled-edges"] = toplevel ? toplevel->pending_tiled_edges() : 0;
+        description["fullscreen"]  = toplevel ? toplevel->pending_fullscreen() : false;
+        description["minimized"]   = toplevel ? toplevel->minimized : false;
+        description["focusable"]   = view->is_focusable();
+        description["type"] = get_view_type(view);
+        return description;
+    }
+};
+
+DECLARE_WAYFIRE_PLUGIN(ipc_rules_t);

--- a/plugins/single_plugins/meson.build
+++ b/plugins/single_plugins/meson.build
@@ -2,7 +2,7 @@ plugins = [
   'move', 'resize', 'command', 'autostart', 'vswipe', 'wrot', 'expo',
   'switcher', 'fast-switcher', 'oswitch', 'place', 'invert',
   'fisheye', 'zoom', 'alpha', 'idle', 'extra-gestures', 'preserve-output',
-  'wsets'
+  'wsets', 'ipc-rules'
 ]
 
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, vswitch_inc, wobbly_inc, grid_inc]

--- a/plugins/single_plugins/meson.build
+++ b/plugins/single_plugins/meson.build
@@ -6,7 +6,7 @@ plugins = [
 ]
 
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, vswitch_inc, wobbly_inc, grid_inc]
-all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, pango, pangocairo]
+all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, pango, pangocairo, json]
 
 foreach plugin : plugins
   shared_module(plugin, plugin + '.cpp',

--- a/plugins/window-rules/view-action-interface.cpp
+++ b/plugins/window-rules/view-action-interface.cpp
@@ -1,5 +1,6 @@
 #include "view-action-interface.hpp"
 
+#include "wayfire/core.hpp"
 #include "wayfire/output.hpp"
 #include "wayfire/toplevel-view.hpp"
 #include "wayfire/view.hpp"
@@ -120,36 +121,34 @@ bool view_action_interface_t::execute(const std::string & name,
 
         auto location = wf::get_string(args.at(0));
 
-        wf::grid::grid_snap_view_signal data;
-        data.view = _view;
-
+        grid::slot_t slot;
         if (location == "top")
         {
-            data.slot = grid::SLOT_TOP;
+            slot = grid::SLOT_TOP;
         } else if (location == "top_right")
         {
-            data.slot = grid::SLOT_TR;
+            slot = grid::SLOT_TR;
         } else if (location == "right")
         {
-            data.slot = grid::SLOT_RIGHT;
+            slot = grid::SLOT_RIGHT;
         } else if (location == "bottom_right")
         {
-            data.slot = grid::SLOT_BR;
+            slot = grid::SLOT_BR;
         } else if (location == "bottom")
         {
-            data.slot = grid::SLOT_BOTTOM;
+            slot = grid::SLOT_BOTTOM;
         } else if (location == "bottom_left")
         {
-            data.slot = grid::SLOT_BL;
+            slot = grid::SLOT_BL;
         } else if (location == "left")
         {
-            data.slot = grid::SLOT_LEFT;
+            slot = grid::SLOT_LEFT;
         } else if (location == "top_left")
         {
-            data.slot = grid::SLOT_TL;
+            slot = grid::SLOT_TL;
         } else if (location == "center")
         {
-            data.slot = grid::SLOT_CENTER;
+            slot = grid::SLOT_CENTER;
         } else
         {
             LOGE(
@@ -160,9 +159,7 @@ bool view_action_interface_t::execute(const std::string & name,
         }
 
         LOGI("View action interface: Snap to ", location, ".");
-
-        output->emit(&data);
-
+        wf::get_core().default_wm->tile_request(_view, grid::get_tiled_edges_for_slot(slot));
         return false;
     } else if (name == "start_on_output")
     {

--- a/plugins/wm-actions/meson.build
+++ b/plugins/wm-actions/meson.build
@@ -1,6 +1,6 @@
 wm_actions = shared_module('wm-actions',
                            ['wm-actions.cpp'],
                            include_directories: [wayfire_api_inc, wayfire_conf_inc],
-                           dependencies: [wlroots, pixman, wfconfig],
+                           dependencies: [wlroots, pixman, wfconfig, json],
                            install: true,
                            install_dir: join_paths(get_option('libdir'), 'wayfire'))

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -341,6 +341,7 @@ struct workspace_grid_changed_signal
  */
 struct workarea_changed_signal
 {
+    wf::output_t *output;
     wf::geometry_t old_workarea;
     wf::geometry_t new_workarea;
 };

--- a/src/output/workarea.cpp
+++ b/src/output/workarea.cpp
@@ -108,6 +108,7 @@ void wf::output_workarea_manager_t::reflow_reserved_areas()
     }
 
     wf::workarea_changed_signal data;
+    data.output = priv->output;
     data.old_workarea = old_workarea;
     data.new_workarea = priv->current_workarea;
 


### PR DESCRIPTION
Window-rules are currently limited to whatever we implement in core, and use a weird custom syntax.

It is possible to move window-rules to an IPC script, as this PR demonstrates. The question is, do people prefer the old or the new approach? Let me know what you think.
Here are some of my arguments why the one or the other:

Pros of the old approach:

- The custom syntax window-rules lets us have the configuration in one file, `wayfire.ini`.
- The custom syntax rules are applied immediately, with IPC there is a slight delay until the changes are applied (a frame or two at most).
- You don't need to know Python or a similar language (but you have to learn quirky custom syntax ...)

Pros of the IPC approach:

- Different plugins can add different IPC commands, so we do not need window-rules to support everything
- Using a language of the user's choice (IPC can be used from every language) allows much more complex and flexible configuration
- No quirky syntax
- IPC in general will have a few more areas of application aside from simple window-rules, e.g. one can implement something like `swaymsg` but for Wayfire.

All in all, I think IPC is a better choice for the future, what do others think? Is there a need for the old window-rules?

Here is a demo in Python how to use the IPC:

```py
#!/usr/bin/python3

import os
from wayfire_socket import *

addr = os.getenv('WAYFIRE_SOCKET')
sock = WayfireSocket(addr)

print(sock.watch())

while True:
    msg = sock.read_message()
    print(msg)

    if "event" in msg and msg["event"] == "view-mapped":
        view = msg["view"]
        if view["app-id"] == "gedit":
            output_data = sock.query_output(view["output"])
            workarea = output_data["workarea"]

            x = 200
            y = 200
            w = workarea['width'] // 2
            h = workarea['height'] // 2

            print(sock.configure_view(view["id"], x, y, w, h))
            # print(sock.assign_slot(view["id"], "slot_br"))
            print(sock.set_always_on_top(view["id"], True))
            print(sock.set_view_alpha(view["id"], 0.5))
```

and here is `wayfire_socket.py` (which the user does not have to write themselves, we can figure out some way to distribute this with pip or similar):

<details>

```py
import socket
import json as js

def get_msg_template(method: str):
    # Create generic message template
    message = {}
    message["method"] = method
    message["data"] = {}
    return message

def geometry_to_json(x: int, y: int, w: int, h: int):
    geometry = {}
    geometry["x"] = x
    geometry["y"] = y
    geometry["width"] = w
    geometry["height"] = h
    return geometry

class WayfireSocket:
    def __init__(self, socket_name):
        self.client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
        self.client.connect(socket_name)

    def read_exact(self, n):
        response = bytes()
        while n > 0:
            read_this_time = self.client.recv(n)
            if not read_this_time:
                raise Exception("Failed to read anything from the socket!")
            n -= len(read_this_time)
            response += read_this_time

        return response

    def read_message(self):
        rlen = int.from_bytes(self.read_exact(4), byteorder="little")
        response_message = self.read_exact(rlen)
        return js.loads(response_message)

    def send_json(self, msg):
        data = js.dumps(msg).encode('utf8')
        header = len(data).to_bytes(4, byteorder="little")
        self.client.send(header)
        self.client.send(data)
        return self.read_message()

    def watch(self):
        message = get_msg_template("window-rules/events/watch")
        return self.send_json(message)

    def query_output(self, output_id: int):
        message = get_msg_template("window-rules/output-info")
        message["data"]["id"] = output_id
        return self.send_json(message)

    def configure_view(self, view_id: int, x: int, y: int, w: int, h: int):
        message = get_msg_template("window-rules/configure-view")
        message["data"]["id"] = view_id
        message["data"]["geometry"] = geometry_to_json(x, y, w, h)
        print(message)
        return self.send_json(message)

    def assign_slot(self, view_id: int, slot: str):
        message = get_msg_template("grid/" + slot)
        message["data"]["view_id"] = view_id
        return self.send_json(message)

    def set_always_on_top(self, view_id: int, always_on_top: bool):
        message = get_msg_template("wm-actions/set-always-on-top")
        message["data"]["view_id"] = view_id
        message["data"]["state"] = always_on_top
        return self.send_json(message)

    def set_view_alpha(self, view_id: int, alpha: float):
        message = get_msg_template("wf/alpha/set-view-alpha")
        message["method"] = "wf/alpha/set-view-alpha"
        message["data"] = {}
        message["data"]["view-id"] = view_id
        message["data"]["alpha"] = alpha
        return self.send_json(message)
```
</details>
