### PR TITLE
Refactor view initialization and ownership

### DIFF
--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -1,6 +1,7 @@
 #include "wayfire/debug.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/plugins/common/input-grab.hpp"
+#include "wayfire/nonstd/tracking-allocator.hpp"
 #include "wayfire/scene-input.hpp"
 #include "wayfire/signal-provider.hpp"
 #include "wayfire/view-helpers.hpp"
@@ -44,7 +45,7 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
 
     struct
     {
-        nonstd::observer_ptr<wf::preview_indication_view_t> preview;
+        std::shared_ptr<wf::preview_indication_t> preview;
         wf::grid::slot_t slot_id = wf::grid::SLOT_NONE;
     } slot;
 
@@ -484,15 +485,10 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
                 return;
             }
 
-            auto input   = get_input_coords();
-            auto preview =
-                new wf::preview_indication_view_t({input.x, input.y, 1, 1}, "move");
-            wf::get_core().add_view(
-                std::unique_ptr<wf::view_interface_t>(preview));
-            preview->set_output(output);
-
-            preview->set_target_geometry(slot_geometry, 1);
-            slot.preview = nonstd::make_observer(preview);
+            auto input = get_input_coords();
+            slot.preview = std::make_shared<wf::preview_indication_t>(
+                wf::geometry_t{input.x, input.y, 1, 1}, output, "move");
+            slot.preview->set_target_geometry(slot_geometry, 1);
         }
 
         update_workspace_switch_timeout(new_slot_id);

--- a/plugins/single_plugins/wsets.cpp
+++ b/plugins/single_plugins/wsets.cpp
@@ -220,7 +220,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
 
         if (!available_sets.count(index))
         {
-            available_sets[index] = std::make_shared<wf::workspace_set_t>(index);
+            available_sets[index] = wf::workspace_set_t::create(index);
         }
 
         if (wo->wset() != available_sets[index])
@@ -232,7 +232,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
                 if (old_output->wset() == available_sets[index])
                 {
                     // Create new empty wset for the output
-                    old_output->set_workspace_set(std::make_shared<wf::workspace_set_t>());
+                    old_output->set_workspace_set(wf::workspace_set_t::create());
                     available_sets[old_output->wset()->get_index()] = old_output->wset();
                     show_workspace_set_overlay(old_output);
                 }
@@ -262,7 +262,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
 
         if (!available_sets.count(index))
         {
-            available_sets[index] = std::make_shared<wf::workspace_set_t>(index);
+            available_sets[index] = wf::workspace_set_t::create(index);
         }
 
         auto target_wset     = available_sets[index];

--- a/plugins/tile/tree-controller.cpp
+++ b/plugins/tile/tree-controller.cpp
@@ -1,6 +1,7 @@
 #include "tree-controller.hpp"
 
 #include <set>
+#include <wayfire/nonstd/tracking-allocator.hpp>
 #include <algorithm>
 #include <wayfire/core.hpp>
 #include <wayfire/output.hpp>
@@ -242,11 +243,7 @@ void move_view_controller_t::ensure_preview(wf::point_t start)
         return;
     }
 
-    auto view =
-        std::make_unique<wf::preview_indication_view_t>(start, "simple-tile");
-    this->preview = {view};
-    wf::get_core().add_view(std::move(view));
-    this->preview->set_output(output);
+    preview = std::make_shared<wf::preview_indication_t>(start, output, "simple-tile");
 }
 
 void move_view_controller_t::input_motion(wf::point_t input)

--- a/plugins/tile/tree-controller.hpp
+++ b/plugins/tile/tree-controller.hpp
@@ -7,7 +7,7 @@
 /* Contains functions which are related to manipulating the tiling tree */
 namespace wf
 {
-class preview_indication_view_t;
+class preview_indication_t;
 namespace tile
 {
 /**
@@ -91,7 +91,7 @@ class move_view_controller_t : public tile_controller_t
     wf::output_t *output;
     wf::point_t current_input;
 
-    nonstd::observer_ptr<wf::preview_indication_view_t> preview;
+    std::shared_ptr<wf::preview_indication_t> preview;
     /**
      * Create preview if it doesn't exist
      *

--- a/src/api/wayfire/compositor-view.hpp
+++ b/src/api/wayfire/compositor-view.hpp
@@ -22,14 +22,20 @@ class color_rect_view_t : public wf::view_interface_t
     bool _is_mapped;
     class color_rect_node_t;
 
-  public:
     /**
      * Create a colored rect view. The map signal is not fired by default.
      * The creator of the colored view should also add it to the desired layer.
      */
     color_rect_view_t();
+    friend class wf::tracking_allocator_t<view_interface_t>;
 
-    virtual void initialize() override;
+  public:
+    /**
+     * Create and initialize a new color rect view.
+     * The view will be automatically mapped, and if specified, put on the given output and layer.
+     */
+    static std::shared_ptr<color_rect_view_t> create(view_role_t role,
+        wf::output_t *start_output = nullptr, std::optional<wf::scene::layer> layer = {});
 
     /**
      * Emit the unmap signal and then drop the internal reference.
@@ -42,6 +48,24 @@ class color_rect_view_t : public wf::view_interface_t
     virtual void set_border_color(wf::color_t border);
     /** Set the border width. */
     virtual void set_border(int width);
+
+    /** Get the view color. Color's alpha is not premultiplied */
+    wf::color_t get_color()
+    {
+        return _color;
+    }
+
+    /** Get the view border color. Color's alpha is not premultiplied */
+    wf::color_t get_border_color()
+    {
+        return _border_color;
+    }
+
+    /** Get the border width. */
+    int get_border()
+    {
+        return border;
+    }
 
     /** Set the view geometry. */
     virtual void set_geometry(wf::geometry_t geometry);

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -250,17 +250,12 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
         nonstd::observer_ptr<wf::touch::gesture_t> gesture) = 0;
 
     /**
-     * Add a view to the compositor's view list. The view will be freed when
-     * its keep_count drops to zero, hence a plugin using this doesn't have to
-     * erase the view manually (instead it should just drop the keep_count)
-     */
-    virtual void add_view(std::unique_ptr<wf::view_interface_t> view) = 0;
-
-    /**
+     * @deprecated. Use tracking_allocator_t<view_interface_t>::get_all()
+     *
      * @return A list of all views core manages, regardless of their output,
      *  properties, etc.
      */
-    virtual std::vector<wayfire_view> get_all_views() = 0;
+    std::vector<wayfire_view> get_all_views();
 
     /**
      * Focus the given output. The currently focused output is used to determine

--- a/src/api/wayfire/dassert.hpp
+++ b/src/api/wayfire/dassert.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <wayfire/util/log.hpp>
+
+namespace wf
+{
+/**
+ * Print the current stacktrace at runtime.
+ *
+ * @param fast_mode If fast_mode is true, the stacktrace will be generated
+ *   using the fastest possible method. However, this means that not all
+ *   information will be printed (for ex., line numbers may be missing).
+ */
+void print_trace(bool fast_mode);
+
+/**
+ * Assert that the condition is true.
+ * Optionally print a message.
+ * Print backtrace when the assertion fails and exit.
+ */
+inline void dassert(bool condition, std::string message = "")
+{
+    if (!condition)
+    {
+        LOGE(message);
+        print_trace(false);
+        std::exit(0);
+    }
+}
+}
+
+#define DASSERT(condition) \
+    wf::dassert(condition, "Assertion failed at " __FILE__ ":" __LINE__)

--- a/src/api/wayfire/debug.hpp
+++ b/src/api/wayfire/debug.hpp
@@ -6,6 +6,7 @@
 #endif
 
 #define nonull(x) ((x) ? (x) : ("nil"))
+#include <wayfire/dassert.hpp>
 #include <wayfire/util/log.hpp>
 #include <wayfire/scene.hpp>
 #include <wayfire/core.hpp>
@@ -14,42 +15,10 @@
 namespace wf
 {
 /**
- * Print the current stacktrace at runtime.
- *
- * @param fast_mode If fast_mode is true, the stacktrace will be generated
- *   using the fastest possible method. However, this means that not all
- *   information will be printed (for ex., line numbers may be missing).
- */
-void print_trace(bool fast_mode);
-
-/**
  * Dump a scenegraph to the log.
  */
 void dump_scene(scene::node_ptr root = wf::get_core().scene());
 
-/**
- * Assert that the condition is true.
- * Optionally print a message.
- * Print backtrace when the assertion fails and exit.
- */
-inline void dassert(bool condition, std::string message = "")
-{
-    if (!condition)
-    {
-        LOGE(message);
-        print_trace(false);
-        std::exit(0);
-    }
-}
-}
-
-#define DASSERT(condition) \
-    wf::dassert(condition, "Assertion failed at " __FILE__ ":" __LINE__)
-
-/* ------------------------ Logging categories -------------------------------*/
-
-namespace wf
-{
 namespace log
 {
 /**

--- a/src/api/wayfire/nonstd/observer_ptr.h
+++ b/src/api/wayfire/nonstd/observer_ptr.h
@@ -155,6 +155,10 @@ public:
     nop_constexpr14 observer_ptr(const std::unique_ptr<W2>& other)
     : ptr(other.get()) {}
 
+    template< class W2 >
+    nop_constexpr14 observer_ptr(const std::shared_ptr<W2>& other)
+    : ptr(other.get()) {}
+
     nop_constexpr14 pointer get() const nop_noexcept
     {
         return ptr;

--- a/src/api/wayfire/nonstd/tracking-allocator.hpp
+++ b/src/api/wayfire/nonstd/tracking-allocator.hpp
@@ -1,0 +1,55 @@
+#pragma once
+#include <memory>
+#include <functional>
+#include <wayfire/dassert.hpp>
+#include <wayfire/nonstd/observer_ptr.h>
+
+namespace wf
+{
+/**
+ * The tracking allocator is a factory singleton for allocating objects of a certain type.
+ * The objects are allocated via shared pointers, and the tracking allocator keeps a list of all allocated
+ * objects, accessible by plugins.
+ */
+template<class ObjectType>
+class tracking_allocator_t
+{
+  public:
+    /**
+     * Get the single global instance of the tracking allocator.
+     */
+    static tracking_allocator_t<ObjectType>& get()
+    {
+        static tracking_allocator_t<ObjectType> allocator;
+        return allocator;
+    }
+
+    template<class ConcreteObjectType, class... Args>
+    std::shared_ptr<ConcreteObjectType> allocate(Args... args)
+    {
+        static_assert(std::is_base_of_v<ObjectType, ConcreteObjectType>);
+        auto ptr = std::shared_ptr<ConcreteObjectType>(
+            new ConcreteObjectType(std::forward<Args>(args)...),
+            std::bind(&tracking_allocator_t<ObjectType>::deallocate_object, this, std::placeholders::_1));
+
+        allocated_objects.push_back(ptr.get());
+        return ptr;
+    }
+
+    const std::vector<nonstd::observer_ptr<ObjectType>>& get_all()
+    {
+        return allocated_objects;
+    }
+
+  private:
+    std::vector<nonstd::observer_ptr<ObjectType>> allocated_objects;
+    void deallocate_object(ObjectType *obj)
+    {
+        auto it = std::find(allocated_objects.begin(), allocated_objects.end(),
+            nonstd::observer_ptr<ObjectType>{obj});
+        wf::dassert(it != allocated_objects.end(), "Object is not allocated?");
+        allocated_objects.erase(it);
+        delete obj;
+    }
+};
+}

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -94,7 +94,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'07'14;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'07'28;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -359,15 +359,6 @@ struct fullscreen_layer_focused_signal
  * View signals
  * -------------------------------------------------------------------------- */
 /**
- * on: core
- * when: A view is created.
- */
-struct view_added_signal
-{
-    wayfire_view view;
-};
-
-/**
  * on: view, output, core
  * when: After the view becomes mapped. This signal must also be emitted from all compositor views.
  */

--- a/src/api/wayfire/toplevel-view.hpp
+++ b/src/api/wayfire/toplevel-view.hpp
@@ -187,16 +187,15 @@ class toplevel_view_interface_t : public wf::view_interface_t
 
     virtual ~toplevel_view_interface_t();
 
-  protected:
-    /**
-     * When a view is being destroyed, all associated objects like subsurfaces,
-     * transformers and custom data are destroyed.
-     *
-     * In general, we want to make sure that these associated objects are freed
-     * before the actual view object destruction starts. Thus, deinitialize()
-     * is called from core just before destroying the view.
-     */
-    void deinitialize() override;
+    std::shared_ptr<toplevel_view_interface_t> shared_from_this()
+    {
+        return std::dynamic_pointer_cast<toplevel_view_interface_t>(view_interface_t::shared_from_this());
+    }
+
+    std::weak_ptr<toplevel_view_interface_t> weak_from_this()
+    {
+        return shared_from_this();
+    }
 };
 
 inline wayfire_toplevel_view toplevel_cast(wayfire_view view)
@@ -206,6 +205,5 @@ inline wayfire_toplevel_view toplevel_cast(wayfire_view view)
 
 // Find the view which has the given toplevel, if such a view exists.
 // The view might not exist if it was destroyed, but a plugin holds on to a stale toplevel pointer.
-wayfire_toplevel_view find_view_for_toplevel(
-    std::shared_ptr<wf::toplevel_t> toplevel);
+wayfire_toplevel_view find_view_for_toplevel(std::shared_ptr<wf::toplevel_t> toplevel);
 }

--- a/src/api/wayfire/workspace-set.hpp
+++ b/src/api/wayfire/workspace-set.hpp
@@ -8,6 +8,7 @@
 #include <functional>
 #include <memory>
 #include <vector>
+#include <wayfire/nonstd/observer_ptr.h>
 #include <wayfire/toplevel-view.hpp>
 
 namespace wf
@@ -66,13 +67,14 @@ class workspace_set_t : public wf::signal::provider_t, public wf::object_base_t,
      * @param index The index of the new workspace set. It will be used if available, otherwise, a the lowest
      *   available index will be selected (starting from 1).
      */
-    workspace_set_t(int64_t index = -1);
+    static std::shared_ptr<workspace_set_t> create(int64_t index = -1);
     ~workspace_set_t();
 
     /**
      * Generate a list of all workspace sets currently allocated.
      */
-    static std::vector<workspace_set_t*> get_all();
+    static std::vector<nonstd::observer_ptr<workspace_set_t>> get_all();
+
 
     /**
      * Get the index of the workspace set. The index is assigned on creation and always the lowest unused
@@ -216,6 +218,9 @@ class workspace_set_t : public wf::signal::provider_t, public wf::object_base_t,
     struct impl;
     std::unique_ptr<impl> pimpl;
     friend class output_impl_t;
+
+    friend class wf::tracking_allocator_t<workspace_set_t>;
+    workspace_set_t(int64_t index = -1);
 
     /**
      * Change the visibility of the workspace set. On each output, only one workspace set will be visible

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -38,18 +38,6 @@ class compositor_core_impl_t : public compositor_core_t
      */
     virtual void post_init();
 
-    /**
-     * Remove a view from the compositor list. This is called when the view's
-     * keep_count reaches zero for the first time after its creation.
-     */
-    virtual void erase_view(wayfire_view view);
-
-    /**
-     * Find a view by its stringified ID.
-     * @return nullptr if no such view exists.
-     */
-    virtual wayfire_view find_view(const std::string& id);
-
     static compositor_core_impl_t& get();
 
     wlr_seat *get_current_seat() override;
@@ -75,8 +63,6 @@ class compositor_core_impl_t : public compositor_core_t
     override;
     virtual wlr_cursor *get_wlr_cursor() override;
 
-    void add_view(std::unique_ptr<wf::view_interface_t> view) override;
-    std::vector<wayfire_view> get_all_views() override;
     void focus_output(wf::output_t *o) override;
     wf::output_t *get_active_output() override;
     std::string get_xwayland_display() override;
@@ -94,9 +80,6 @@ class compositor_core_impl_t : public compositor_core_t
     wf::wl_listener_wrapper idle_inhibitor_created;
 
     wf::output_t *active_output = nullptr;
-    std::vector<std::unique_ptr<wf::view_interface_t>> views;
-    std::unordered_map<std::string, wayfire_view> id_to_view;
-
     std::shared_ptr<scene::root_node_t> scene_root;
 
     compositor_state_t state = compositor_state_t::UNKNOWN;

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -2,6 +2,7 @@
 #include "wayfire/core.hpp"
 #include "wayfire/output-layout.hpp"
 #include "wayfire/view-helpers.hpp"
+#include "wayfire/view.hpp"
 #include "wayfire/workspace-set.hpp"
 #include "wayfire/render-manager.hpp"
 #include "wayfire/signal-definitions.hpp"
@@ -157,14 +158,13 @@ void transfer_views(wf::output_t *from, wf::output_t *to)
     // Step 2: Ensure none of the remaining views have an invalid output.
     // Note that all views in workspace sets will have their output reassigned automatically by the
     // workspace-set impl.
-    std::vector<wayfire_view> non_ws_views;
+    std::vector<std::shared_ptr<wf::view_interface_t>> non_ws_views;
     for (auto& view : wf::get_core().get_all_views())
     {
         if ((view->get_output() == from) && (!toplevel_cast(view) || !toplevel_cast(view)->get_wset()))
         {
-            non_ws_views.push_back(view);
             // Take a ref, so that the view doesn't get destroyed while we're doing operations on the views
-            view->take_ref();
+            non_ws_views.push_back(view->shared_from_this());
         }
     }
 
@@ -180,12 +180,6 @@ void transfer_views(wf::output_t *from, wf::output_t *to)
             // typically: xwayland OR views
             view->set_output(to);
         }
-    }
-
-    // Drop refs we have taken
-    for (auto& view : non_ws_views)
-    {
-        view->unref();
     }
 }
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -80,7 +80,7 @@ wf::output_impl_t::output_impl_t(wlr_output *handle,
     update_node_limits();
 
     workarea = std::make_unique<output_workarea_manager_t>(this);
-    this->set_workspace_set(std::make_shared<workspace_set_t>());
+    this->set_workspace_set(workspace_set_t::create());
 
     render = std::make_unique<render_manager>(this);
     promotion_manager = std::make_unique<promotion_manager_t>(this);

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -17,6 +17,7 @@
 #include "../view/view-impl.hpp"
 #include "wayfire/debug.hpp"
 #include "wayfire/geometry.hpp"
+#include "wayfire/nonstd/tracking-allocator.hpp"
 #include "wayfire/option-wrapper.hpp"
 #include "wayfire/scene-input.hpp"
 #include "wayfire/scene.hpp"
@@ -274,9 +275,10 @@ struct workspace_set_t::impl
         }
     };
 
-    wf::signal::connection_t<view_destruct_signal> on_view_destruct = [=] (view_destruct_signal *ev)
+    wf::signal::connection_t<wf::destruct_signal<view_interface_t>> on_view_destruct =
+        [=] (wf::destruct_signal<view_interface_t> *ev)
     {
-        remove_view(toplevel_cast(ev->view));
+        remove_view(toplevel_cast(ev->object));
     };
 
     bool visible = false;

--- a/src/view/compositor-view.cpp
+++ b/src/view/compositor-view.cpp
@@ -126,6 +126,7 @@ std::shared_ptr<wf::color_rect_view_t> wf::color_rect_view_t::create(view_role_t
         }
     }
 
+    emit_view_map_signal(self, true);
     return self;
 }
 

--- a/src/view/layer-shell/layer-shell-node.hpp
+++ b/src/view/layer-shell/layer-shell-node.hpp
@@ -29,8 +29,7 @@ class layer_shell_node_t : public wf::scene::translation_node_t,
     wf::region_t get_opaque_region() const override;
 
   protected:
-    wayfire_view view;
+    std::weak_ptr<wf::view_interface_t> _view;
     std::unique_ptr<keyboard_interaction_t> kb_interaction;
-    wf::signal::connection_t<view_destruct_signal> on_view_destroy;
 };
 }

--- a/src/view/toplevel-node.hpp
+++ b/src/view/toplevel-node.hpp
@@ -30,8 +30,7 @@ class toplevel_view_node_t : public wf::scene::translation_node_t,
     wf::region_t get_opaque_region() const override;
 
   protected:
-    wayfire_toplevel_view view;
+    std::weak_ptr<toplevel_view_interface_t> _view;
     std::unique_ptr<keyboard_interaction_t> kb_interaction;
-    wf::signal::connection_t<view_destruct_signal> on_view_destroy;
 };
 }

--- a/src/view/toplevel-view.cpp
+++ b/src/view/toplevel-view.cpp
@@ -260,17 +260,6 @@ bool wf::toplevel_view_interface_t::should_be_decorated()
     return false;
 }
 
-void wf::toplevel_view_interface_t::deinitialize()
-{
-    auto children = this->children;
-    for (auto ch : children)
-    {
-        ch->set_toplevel_parent(nullptr);
-    }
-
-    view_interface_t::deinitialize();
-}
-
 wf::toplevel_view_interface_t::~toplevel_view_interface_t()
 {
     /* Note: at this point, it is invalid to call most functions */

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -9,6 +9,7 @@
 
 #include "surface-impl.hpp"
 #include "wayfire/core.hpp"
+#include "wayfire/nonstd/tracking-allocator.hpp"
 #include "wayfire/signal-provider.hpp"
 #include "wayfire/unstable/wlr-surface-node.hpp"
 #include "wayfire/output.hpp"
@@ -27,11 +28,7 @@ class view_interface_t::view_priv_impl
 {
   public:
     wlr_surface *wsurface = nullptr;
-
-    /** Reference count to the view */
-    int ref_cnt = 0;
-
-    size_t last_view_cnt = 0;
+    size_t last_view_cnt  = 0;
 
     bool keyboard_focus_enabled = true;
     uint32_t allowed_actions    = VIEW_ALLOW_ALL;
@@ -49,8 +46,8 @@ class view_interface_t::view_priv_impl
     void set_mapped_surface_contents(std::shared_ptr<scene::wlr_surface_node_t> content);
     void unset_mapped_surface_contents();
     std::weak_ptr<wf::workspace_set_t> current_wset;
-
     std::shared_ptr<toplevel_t> toplevel;
+    wf::signal::connection_t<destruct_signal<view_interface_t>> pre_free;
 };
 
 /**

--- a/src/view/view-keyboard-interaction.hpp
+++ b/src/view/view-keyboard-interaction.hpp
@@ -13,29 +13,32 @@
  */
 class view_keyboard_interaction_t : public wf::keyboard_interaction_t
 {
-    wayfire_view view;
+    std::weak_ptr<wf::view_interface_t> view;
 
   public:
     view_keyboard_interaction_t(wayfire_view _view)
     {
-        this->view = _view;
+        this->view = _view->weak_from_this();
     }
 
     void handle_keyboard_enter(wf::seat_t *seat) override
     {
-        if (view->get_wlr_surface())
+        if (auto ptr = view.lock())
         {
-            auto pressed_keys = seat->get_pressed_keys();
+            if (ptr->get_wlr_surface())
+            {
+                auto pressed_keys = seat->get_pressed_keys();
 
-            auto kbd = wlr_seat_get_keyboard(seat->seat);
-            wlr_seat_keyboard_notify_enter(seat->seat, view->get_wlr_surface(),
-                pressed_keys.data(), pressed_keys.size(), kbd ? &kbd->modifiers : NULL);
+                auto kbd = wlr_seat_get_keyboard(seat->seat);
+                wlr_seat_keyboard_notify_enter(seat->seat, ptr->get_wlr_surface(),
+                    pressed_keys.data(), pressed_keys.size(), kbd ? &kbd->modifiers : NULL);
+            }
         }
     }
 
     void handle_keyboard_leave(wf::seat_t *seat) override
     {
-        if (view->get_wlr_surface())
+        if (auto ptr = view.lock())
         {
             wlr_seat_keyboard_notify_clear_focus(seat->seat);
         }

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -26,12 +26,12 @@ class wayfire_xdg_popup : public wf::view_interface_t
     wlr_xdg_popup *popup;
     void unconstrain();
     void update_position();
+    wayfire_xdg_popup(wlr_xdg_popup *popup);
+    friend class wf::tracking_allocator_t<view_interface_t>;
 
   public:
-    wayfire_xdg_popup(wlr_xdg_popup *popup);
     ~wayfire_xdg_popup();
-
-    void initialize() override;
+    static std::shared_ptr<wayfire_xdg_popup> create(wlr_xdg_popup *popup);
 
     wayfire_view popup_parent;
     void map();

--- a/src/view/xdg-shell/xdg-toplevel-view.hpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.hpp
@@ -17,7 +17,7 @@ namespace wf
 class xdg_toplevel_view_t : public wf::toplevel_view_interface_t
 {
   public:
-    xdg_toplevel_view_t(wlr_xdg_toplevel *tlvl);
+    static std::shared_ptr<xdg_toplevel_view_t> create(wlr_xdg_toplevel *toplevel);
 
     void request_native_size() override;
     void close() override;
@@ -29,11 +29,11 @@ class xdg_toplevel_view_t : public wf::toplevel_view_interface_t
     std::string get_title() override;
     bool should_be_decorated() override;
     bool is_mapped() const override;
-    void initialize() override;
-
     void set_decoration_mode(bool use_csd);
 
   private:
+    friend class wf::tracking_allocator_t<view_interface_t>;
+    xdg_toplevel_view_t(wlr_xdg_toplevel *tlvl);
     bool has_client_decoration = true;
     bool _is_mapped = false;
     wf::wl_listener_wrapper on_map, on_unmap, on_destroy, on_new_popup,

--- a/src/view/xdg-shell/xdg-toplevel-view.hpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.hpp
@@ -63,4 +63,6 @@ class xdg_toplevel_view_t : public wf::toplevel_view_interface_t
     void handle_app_id_changed(std::string new_app_id);
     void handle_toplevel_state_changed(toplevel_state_t old_state);
 };
+
+void default_handle_new_xdg_toplevel(wlr_xdg_toplevel *toplevel);
 }

--- a/src/view/xwayland/xwayland-helpers.cpp
+++ b/src/view/xwayland/xwayland-helpers.cpp
@@ -36,4 +36,17 @@ bool wf::xw::load_basic_atoms(const char *server_name)
     return true;
 }
 
+bool wf::xw::has_type(wlr_xwayland_surface *xw, xcb_atom_t type)
+{
+    for (size_t i = 0; i < xw->window_type_len; i++)
+    {
+        if (xw->window_type[i] == type)
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 #endif

--- a/src/view/xwayland/xwayland-helpers.hpp
+++ b/src/view/xwayland/xwayland-helpers.hpp
@@ -7,6 +7,7 @@
 #if WF_HAS_XWAYLAND
 
     #include <xcb/xcb.h>
+    #include <wayfire/nonstd/wlroots-full.hpp>
 
 namespace wf
 {
@@ -26,6 +27,7 @@ extern xcb_atom_t _NET_WM_WINDOW_TYPE_DND;
 
 std::optional<xcb_atom_t> load_atom(xcb_connection_t *connection, const std::string& name);
 bool load_basic_atoms(const char *server_name);
+bool has_type(wlr_xwayland_surface *xw, xcb_atom_t type);
 }
 }
 

--- a/src/view/xwayland/xwayland-unmanaged-view.hpp
+++ b/src/view/xwayland/xwayland-unmanaged-view.hpp
@@ -210,8 +210,6 @@ class wayfire_unmanaged_xwayland_view : public wf::view_interface_t, public wayf
         on_unmap.disconnect();
         on_set_geometry.disconnect();
         wayfire_xwayland_view_base::destroy();
-        /* Drop the internal reference */
-        unref();
     }
 
     wf::xw::view_type get_current_impl_type() const override

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,2 +1,3 @@
 subdir('geometry')
 subdir('txn')
+subdir('misc')

--- a/test/misc/meson.build
+++ b/test/misc/meson.build
@@ -1,0 +1,6 @@
+tracking_allocator = executable(
+    'tracking_allocator',
+    'tracking-allocator.cpp',
+    dependencies: libwayfire,
+    install: false)
+test('Tracking factory test', tracking_allocator)

--- a/test/misc/meson.build
+++ b/test/misc/meson.build
@@ -4,3 +4,10 @@ tracking_allocator = executable(
     dependencies: libwayfire,
     install: false)
 test('Tracking factory test', tracking_allocator)
+
+safe_list = executable(
+    'safe_list',
+    'safe-list-test.cpp',
+    include_directories: wayfire_api_inc,
+    install: false)
+test('Safe list test', safe_list)

--- a/test/misc/safe-list-test.cpp
+++ b/test/misc/safe-list-test.cpp
@@ -1,4 +1,3 @@
-#include "wayfire/nonstd/tracking-allocator.hpp"
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 

--- a/test/misc/safe-list-test.cpp
+++ b/test/misc/safe-list-test.cpp
@@ -1,0 +1,97 @@
+#include "wayfire/nonstd/tracking-allocator.hpp"
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/nonstd/safe-list.hpp>
+
+TEST_CASE("Safe-list basics")
+{
+    wf::safe_list_t<int> list;
+
+    list.push_back(5);
+    list.push_back(6);
+    REQUIRE(list.size() == 2);
+
+    list.for_each([x = 0] (int i) mutable
+    {
+        if (x == 0)
+        {
+            REQUIRE(i == 5);
+        }
+
+        if (x == 1)
+        {
+            REQUIRE(i == 6);
+        }
+
+        REQUIRE(x <= 1);
+        x++;
+    });
+
+    list.remove_if([] (int i) { return i == 5; });
+    REQUIRE(list.size() == 1);
+
+    list.for_each([x = 0] (int i) mutable
+    {
+        if (x == 0)
+        {
+            REQUIRE(i == 6);
+        }
+
+        REQUIRE(x <= 0);
+        x++;
+    });
+}
+
+TEST_CASE("safe-list remove self")
+{
+    using cb = std::function<void ()>;
+    wf::safe_list_t<cb*> list;
+
+    cb self;
+    list.push_back(&self);
+    list.for_each_reverse([&] (cb *c)
+    {
+        REQUIRE(c == &self);
+        list.remove_all(c);
+    });
+}
+
+TEST_CASE("safe-list remove next")
+{
+    using cb = std::function<void ()>;
+    wf::safe_list_t<cb*> list;
+
+    cb self, next;
+    list.push_back(&self);
+    list.push_back(&next);
+
+    int calls = 0;
+    list.for_each([&] (cb *c)
+    {
+        calls++;
+        REQUIRE(calls <= 1);
+        REQUIRE(c == &self);
+        list.remove_all(&next);
+        REQUIRE(list.back() == &self);
+    });
+}
+
+TEST_CASE("safe-list push next")
+{
+    using cb = std::function<void ()>;
+    wf::safe_list_t<cb*> list;
+
+    cb self, next;
+    list.push_back(&self);
+
+    int calls = 0;
+    list.for_each([&] (cb *c)
+    {
+        calls++;
+        REQUIRE(calls <= 1);
+        list.push_back(&next);
+    });
+
+    REQUIRE(list.size() == 2);
+}

--- a/test/misc/tracking-allocator.cpp
+++ b/test/misc/tracking-allocator.cpp
@@ -1,0 +1,44 @@
+#include "wayfire/nonstd/tracking-allocator.hpp"
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+class base_t
+{
+  public:
+    static int destroyed;
+    virtual ~base_t()
+    {
+        ++destroyed;
+    }
+};
+
+class derived_t : public base_t
+{
+  public:
+    derived_t(int useless)
+    {
+        (void)useless;
+    }
+
+    virtual ~derived_t() = default;
+};
+
+int base_t::destroyed = 0;
+
+
+TEST_CASE("Misc factory works")
+{
+    auto& allocator = wf::tracking_allocator_t<base_t>::get();
+    REQUIRE(&allocator == &wf::tracking_allocator_t<base_t>::get());
+    REQUIRE((void*)&allocator != (void*)&wf::tracking_allocator_t<derived_t>::get());
+
+    auto obj_a = allocator.allocate<base_t>();
+    REQUIRE(allocator.get_all().size() == 1);
+
+    {
+        auto obj_b = allocator.allocate<derived_t>(5);
+        REQUIRE(allocator.get_all().size() == 2);
+    }
+
+    REQUIRE(allocator.get_all().size() == 1);
+}


### PR DESCRIPTION
This PR refactors the way that views are initialized and how to take ownership of them (they are now managed with `shared_ptr` and `weak_ptr`, as well as raw pointers for backwards compatibility)

The PR contains breaking changes, but in reality very few plugins should be affected:

- If for some reason you used to use `view->take_ref`, now you can just use `shared_from_this` to get a shared pointer which keeps the view valid as long as the shared_ptr is alive.
- If you are implementing a custom view type, view allocation has been changed a bit:
  - Core no longer keeps ownership of the view, so you would need to keep a shared_ptr as long as you use the view.
  - Allocating a view should happen via `view_interface_t::create<ConcreteType>(params)`. View constructors should do very little, instead actual initialization happens in static factory methods or some other similar construct. For example here is a snippet of how layer shell views do it:
  ```cpp
    auto self = wf::view_interface_t::create<wayfire_layer_shell_view>(lsurface);
    self->surface_root_node = std::make_shared<wf::layer_shell_node_t>(self);
    self->set_surface_root_node(self->surface_root_node);

    /* If we already have an output set, then assign it before core assigns us
     * an output */
    if (lsurface->output)
    {
        auto wo = wf::get_core().output_layout->find_output(lsurface->output);
        self->set_output(wo);
    } else
    {
        self->set_output(wf::get_core().get_active_output());
    }
    // .. further code
  ```

- Workspace sets should now be allocated via `workspace_set_t::create()`

Fixes #1369 