### PR TITLE
[breaking] Rewrite preserve-output

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1050,6 +1050,8 @@ class output_layout_t::impl
         state.source = OUTPUT_IMAGE_SOURCE_NONE;
         noop_output->apply_state(state);
         wlr_output_layout_remove(output_layout, noop_output->handle);
+        // Trigger repositioning of all outputs
+        apply_configuration(get_current_configuration());
     }
 
     void add_output(wlr_output *output)
@@ -1382,15 +1384,6 @@ class output_layout_t::impl
             {
                 ++count_enabled;
                 wlr_output_layout_add_auto(output_layout, handle);
-
-                /* Get the correct position */
-                wlr_box box;
-                wlr_output_layout_get_box(output_layout, handle, &box);
-                if (wlr_box_empty(&box))
-                {
-                    LOGE("failed to get layout box");
-                }
-
                 lo->apply_state(state);
             }
         }

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1409,6 +1409,21 @@ class output_layout_t::impl
             }
         }
 
+        /* Fifth: emit configuration-changed again for dynamically-positioned outputs, because their position
+         * might have changed. */
+        for (auto& entry : config)
+        {
+            auto& handle = entry.first;
+            auto& state  = entry.second;
+            auto& lo     = this->outputs[handle];
+
+            if (state.source & OUTPUT_IMAGE_SOURCE_SELF &&
+                entry.second.position.is_automatic_position())
+            {
+                lo->emit_configuration_changed(wf::OUTPUT_POSITION_CHANGE);
+            }
+        }
+
         wf::output_layout_configuration_changed_signal ev;
         get_core().output_layout->emit(&ev);
 


### PR DESCRIPTION
This PR changes the way the `preserve-output` plugin works, and is thus a breaking change for all users that use it.

The original intention of this plugin was to gracefully handle the case where a monitor reports itself as turned off while DPMS is active. Without `preserve-output`, Wayfire would move all windows off that monitor, causing a messed up state (windows lose their workspaces, positions, etc). The `preserve-output` plugin used to move the windows to a different output, and then to restore them when the idling monitor is reconnected.

With workspace sets, we have a much more powerful way of doing that, because we can simply detach the workspace set from a monitor before it is removed, and then restore it when the monitor is online again. That however means that the views from that monitor will remain on their original workspace set, which is not visible to the user, except if a plugin like `wsets` is used (that is, until the monitor is re-enabled).
