### PR TITLE
Restore the cursor shape to default when activating scale or expo

### DIFF
--- a/plugins/common/wayfire/plugins/common/input-grab.hpp
+++ b/plugins/common/wayfire/plugins/common/input-grab.hpp
@@ -148,6 +148,9 @@ class input_grab_t
         wf::get_core().transfer_grab(grab_node);
         scene::update(root, scene::update_flag::CHILDREN_LIST);
         output->refocus();
+
+        // Set cursor to default.
+        wf::get_core().set_cursor("default");
     }
 
     /**


### PR DESCRIPTION
Resubmit of #1769 with the fix placed at the proper place.
Fixes #1756
