### PR TITLE
Improvements related to compilation times

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,8 @@ jobs:
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
-    - run: meson build -Dtests=enabled -Db_pch=true
+    - run: (cd subprojects/wlroots && meson build --prefix=/usr && ninja -C build install)
+    - run: meson build -Dtests=enabled -Db_pch=true -Duse_system_wlroots=enabled --unity on
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_glibc_llvm:
@@ -28,7 +29,8 @@ jobs:
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
-    - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true
+    - run: (cd subprojects/wlroots && env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build --prefix=/usr && ninja -C build install)
+    - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true -Duse_system_wlroots=enabled --unity on
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_code_style:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
-    - run: meson build -Dtests=enabled
+    - run: meson build -Dtests=enabled -Db_pch=true
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_glibc_llvm:
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
-    - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build
+    - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_code_style:

--- a/meson.build
+++ b/meson.build
@@ -31,8 +31,16 @@ pixman         = dependency('pixman-1')
 threads        = dependency('threads')
 xkbcommon      = dependency('xkbcommon')
 libdl          = meson.get_compiler('cpp').find_library('dl')
-wlroots        = dependency('wlroots', version: ['>=0.16.0', '<0.17.0'], required: get_option('use_system_wlroots'))
-wfconfig       = dependency('wf-config', version: ['>=0.8.0', '<0.9.0'], required: get_option('use_system_wfconfig'))
+wlroots        = dependency('wlroots', version: ['>=0.16.0', '<0.17.0'], required: false)
+wfconfig       = dependency('wf-config', version: ['>=0.8.0', '<0.9.0'], required: false)
+
+if get_option('use_system_wlroots').enabled() and not wlroots.found()
+  error('User specified use_system_wlroots=true, but system wlroots not found!')
+endif
+
+if get_option('use_system_wfconfig').enabled() and not wfconfig.found()
+  error('User specified use_system_wfconfig=true, but system wfconfig not found!')
+endif
 
 use_system_wlroots = not get_option('use_system_wlroots').disabled() and wlroots.found()
 if not use_system_wlroots

--- a/plugins/blur/blur.hpp
+++ b/plugins/blur/blur.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "wayfire/geometry.hpp"
 #include <wayfire/core.hpp>
 #include <wayfire/opengl.hpp>

--- a/plugins/cube/shaders.tpp
+++ b/plugins/cube/shaders.tpp
@@ -1,3 +1,5 @@
+#pragma once
+
 static const char* cube_vertex_2_0 =
 R"(#version 100
 attribute mediump vec3 position;

--- a/plugins/scale/scale.hpp
+++ b/plugins/scale/scale.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "wayfire/toplevel-view.hpp"
 #include <wayfire/plugin.hpp>
 #include <wayfire/output.hpp>

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -8,13 +8,9 @@
 
 #include "wayfire/nonstd/tracking-allocator.hpp"
 #include "wayfire/object.hpp"
-#include "wayfire/opengl.hpp"
-#include "wayfire/scene-input.hpp"
-#include "wayfire/scene-render.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/view-transform.hpp"
 #include <wayfire/nonstd/wlroots.hpp>
-#include <wayfire/region.hpp>
 #include <wayfire/signal-provider.hpp>
 #include <wayfire/scene.hpp>
 
@@ -22,7 +18,7 @@ namespace wf
 {
 class view_interface_t;
 class workspace_set_t;
-class decorator_frame_t;
+struct render_target_t;
 }
 
 using wayfire_view = nonstd::observer_ptr<wf::view_interface_t>;

--- a/src/meson.build
+++ b/src/meson.build
@@ -95,7 +95,7 @@ libwayfire_sta = static_library('libwayfire', wayfire_sources,
     dependencies: wayfire_dependencies,
     include_directories: [wayfire_conf_inc, wayfire_api_inc],
     cpp_args: debug_arguments,
-    install: false)
+    install: false, cpp_pch: 'pch/pch.h')
 
 libwayfire = declare_dependency(link_whole: libwayfire_sta,
     include_directories: [wayfire_conf_inc, wayfire_api_inc],

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -1,3 +1,4 @@
+#pragma once
 #include "output/promotion-manager.hpp"
 #include "wayfire/bindings.hpp"
 #include "wayfire/output.hpp"

--- a/src/pch/pch.h
+++ b/src/pch/pch.h
@@ -1,0 +1,26 @@
+#include <functional>
+#include <memory>
+#include <algorithm>
+#include <iostream>
+#include <sstream>
+#include <list>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <map>
+#include <set>
+#include <wayland-server.h>
+#include <wayland-server-protocol.h>
+#include <wayland-server-core.h>
+#include <glm/glm.hpp>
+
+#include <wayfire/view.hpp>
+#include <wayfire/toplevel-view.hpp>
+#include <wayfire/signal-provider.hpp>
+#include <wayfire/object.hpp>
+#include <wayfire/signal-definitions.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
+#include <wayfire/nonstd/observer_ptr.h>
+
+#include "src/core/core-impl.hpp"
+#include "src/view/view-impl.hpp"

--- a/src/view/view-keyboard-interaction.hpp
+++ b/src/view/view-keyboard-interaction.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "view/view-impl.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include "wayfire/signal-provider.hpp"


### PR DESCRIPTION
C++ is infamous for slow compile times when you (over)use templates like Wayfire does.
These changes enable:

- Precompiled headers for core, seems to speed up compilation quite a lot. For plugins, we cannot use pch because meson precompiles headers for each target, and each plugin is a separate target. Also, my experiments show that adding PCH manually to plugins is not super beneficial.
- Unity builds (pass `--unity on` to meson), which also helps.
