### PR TITLE
[Switcher Plugin]: Animate to show next view on trigger

### DIFF
--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -551,6 +551,10 @@ class WayfireSwitcher : public wf::per_output_plugin_instance_t, public wf::keyb
         {
             arrange_view(views[i], SWITCHER_POSITION_RIGHT);
         }
+
+        // We want the next view to be focused right off the bat
+        // But we want it to be animated.
+        handle_switch_request(-1);
     }
 
     void dearrange()


### PR DESCRIPTION
With this PR, the "next view" is shown as the "center view" as soon as the plugin is activated. This removes the need to press `Alt-Tab-Tab` to focus the "next view".