### PR TITLE
fix 1890

### DIFF
--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -17,6 +17,7 @@
 xcb_atom_t wf::xw::_NET_WM_WINDOW_TYPE_NORMAL;
 xcb_atom_t wf::xw::_NET_WM_WINDOW_TYPE_DIALOG;
 xcb_atom_t wf::xw::_NET_WM_WINDOW_TYPE_SPLASH;
+xcb_atom_t wf::xw::_NET_WM_WINDOW_TYPE_UTILITY;
 xcb_atom_t wf::xw::_NET_WM_WINDOW_TYPE_DND;
 
 namespace wf
@@ -89,7 +90,8 @@ class xwayland_view_controller_t
 
         /** Example: Android Studio dialogs */
         if (xw->parent && !this->is_dialog() &&
-            !wf::xw::has_type(xw, wf::xw::_NET_WM_WINDOW_TYPE_NORMAL))
+            !wf::xw::has_type(xw, wf::xw::_NET_WM_WINDOW_TYPE_NORMAL) &&
+            !wf::xw::has_type(xw, wf::xw::_NET_WM_WINDOW_TYPE_UTILITY))
         {
             return true;
         }

--- a/src/view/xwayland/xwayland-helpers.cpp
+++ b/src/view/xwayland/xwayland-helpers.cpp
@@ -28,10 +28,11 @@ bool wf::xw::load_basic_atoms(const char *server_name)
         return false;
     }
 
-    _NET_WM_WINDOW_TYPE_NORMAL = load_atom(connection, "_NET_WM_WINDOW_TYPE_NORMAL").value_or(-1);
-    _NET_WM_WINDOW_TYPE_DIALOG = load_atom(connection, "_NET_WM_WINDOW_TYPE_DIALOG").value_or(-1);
-    _NET_WM_WINDOW_TYPE_SPLASH = load_atom(connection, "_NET_WM_WINDOW_TYPE_SPLASH").value_or(-1);
-    _NET_WM_WINDOW_TYPE_DND    = load_atom(connection, "_NET_WM_WINDOW_TYPE_DND").value_or(-1);
+    _NET_WM_WINDOW_TYPE_NORMAL  = load_atom(connection, "_NET_WM_WINDOW_TYPE_NORMAL").value_or(-1);
+    _NET_WM_WINDOW_TYPE_DIALOG  = load_atom(connection, "_NET_WM_WINDOW_TYPE_DIALOG").value_or(-1);
+    _NET_WM_WINDOW_TYPE_SPLASH  = load_atom(connection, "_NET_WM_WINDOW_TYPE_SPLASH").value_or(-1);
+    _NET_WM_WINDOW_TYPE_UTILITY = load_atom(connection, "_NET_WM_WINDOW_TYPE_UTILITY").value_or(-1);
+    _NET_WM_WINDOW_TYPE_DND     = load_atom(connection, "_NET_WM_WINDOW_TYPE_DND").value_or(-1);
     xcb_disconnect(connection);
     return true;
 }

--- a/src/view/xwayland/xwayland-helpers.hpp
+++ b/src/view/xwayland/xwayland-helpers.hpp
@@ -23,6 +23,7 @@ enum class view_type
 extern xcb_atom_t _NET_WM_WINDOW_TYPE_NORMAL;
 extern xcb_atom_t _NET_WM_WINDOW_TYPE_DIALOG;
 extern xcb_atom_t _NET_WM_WINDOW_TYPE_SPLASH;
+extern xcb_atom_t _NET_WM_WINDOW_TYPE_UTILITY;
 extern xcb_atom_t _NET_WM_WINDOW_TYPE_DND;
 
 std::optional<xcb_atom_t> load_atom(xcb_connection_t *connection, const std::string& name);

--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -410,7 +410,6 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
 
     void map(wlr_surface *surface)
     {
-        priv->keyboard_focus_enabled = wlr_xwayland_or_surface_wants_focus(xw);
         priv->set_mapped(true);
         on_surface_commit.connect(&surface->events.commit);
 


### PR DESCRIPTION
- xwayland: treat UTILITY windows as toplevels
- xwayland-toplevel-view: allows receive focus

Fixes #1890
