### PR TITLE
Do not send a view-disappeared signal when a minimized view is restored

### DIFF
--- a/src/view/toplevel-view.cpp
+++ b/src/view/toplevel-view.cpp
@@ -211,9 +211,12 @@ void wf::toplevel_view_interface_t::set_minimized(bool minim)
     if (get_output())
     {
         get_output()->emit(&data);
-        view_disappeared_signal data;
-        data.view = self();
-        get_output()->emit(&data);
+        if (minim)
+        {
+            view_disappeared_signal data;
+            data.view = self();
+            get_output()->emit(&data);
+        }
     }
 }
 


### PR DESCRIPTION
See the discussion in #1274 
I did some quick testing and a search for where this signal is used, but let me know if I could do some more tests for regressions.