### PR TITLE
Visibility & surface frame done improvements

### DIFF
--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -541,9 +541,9 @@ class core_drag_t : public signal::provider_t
             move_wobbly(v.view, to.x, to.y);
             if (!view_held_in_place)
             {
-                v.view->damage();
+                v.view->get_transformed_node()->begin_transform_update();
                 v.transformer->grab_position = to;
-                v.view->damage();
+                v.view->get_transformed_node()->end_transform_update();
             }
         }
 

--- a/plugins/grid/wayfire/plugins/crossfade.hpp
+++ b/plugins/grid/wayfire/plugins/crossfade.hpp
@@ -276,7 +276,7 @@ class grid_animation_t : public wf::custom_data_t
         }
 
         auto tr = view->get_transformed_node()->get_transformer<crossfade_node_t>();
-        view->damage();
+        view->get_transformed_node()->begin_transform_update();
         tr->displayed_geometry = animation;
 
         auto geometry = view->get_geometry();
@@ -289,7 +289,7 @@ class grid_animation_t : public wf::custom_data_t
             (geometry.y + geometry.height / 2.0);
 
         tr->overlay_alpha = animation.progress();
-        view->damage();
+        view->get_transformed_node()->end_transform_update();
     };
 
     void destroy()

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -679,7 +679,7 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
             if (view_data.fade_animation.running() ||
                 view_data.animation.scale_animation.running())
             {
-                view->damage();
+                view->get_transformed_node()->begin_transform_update();
                 view_data.transformer->scale_x =
                     view_data.animation.scale_animation.scale_x;
                 view_data.transformer->scale_y =
@@ -699,7 +699,7 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
                     wf::scene::set_node_enabled(view->get_transformed_node(), false);
                 }
 
-                view->damage();
+                view->get_transformed_node()->end_transform_update();
             }
         }
     }

--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -112,8 +112,9 @@ class wayfire_fast_switcher : public wf::per_output_plugin_instance_t, public wf
     {
         auto tr = wf::ensure_named_transformer<wf::scene::view_2d_transformer_t>(
             view, wf::TRANSFORMER_2D, transformer_name, view);
+        view->get_transformed_node()->begin_transform_update();
         tr->alpha = alpha;
-        view->damage();
+        view->get_transformed_node()->end_transform_update();
     }
 
     void set_view_highlighted(wayfire_toplevel_view view, bool selected)

--- a/plugins/single_plugins/wrot.cpp
+++ b/plugins/single_plugins/wrot.cpp
@@ -114,8 +114,8 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
     {
         auto tr = wf::ensure_named_transformer<wf::scene::view_2d_transformer_t>(
             current_view, wf::TRANSFORMER_2D, transformer_2d, current_view);
-        current_view->damage();
 
+        current_view->get_transformed_node()->begin_transform_update();
         auto g = current_view->get_geometry();
 
         double cx = g.x + g.width / 2.0;
@@ -126,6 +126,7 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
 
         if (vlen(x2, y2) <= reset_radius)
         {
+            current_view->get_transformed_node()->end_transform_update();
             current_view->get_transformed_node()->rem_transformer(transformer_2d);
             return;
         }
@@ -134,8 +135,7 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
         tr->angle -= std::asin(cross(x1, y1, x2, y2) / vlen(x1, y1) / vlen(x2,
             y2));
 
-        current_view->damage();
-
+        current_view->get_transformed_node()->end_transform_update();
         last_position = {1.0 * x, 1.0 * y};
     }
 
@@ -149,15 +149,14 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
         auto tr = wf::ensure_named_transformer<wf::scene::view_3d_transformer_t>(
             current_view, wf::TRANSFORMER_3D, transformer_3d, current_view);
 
-        current_view->damage();
+        current_view->get_transformed_node()->begin_transform_update();
         float dx     = x - last_position.x;
         float dy     = y - last_position.y;
         float ascale = glm::radians(sensitivity / 60.0f);
         float dir    = invert ? -1.f : 1.f;
         tr->rotation = glm::rotate<float>(tr->rotation, vlen(dx, dy) * ascale,
             {dir *dy, dir * dx, 0});
-        current_view->damage();
-
+        current_view->get_transformed_node()->end_transform_update();
         last_position = {(double)x, (double)y};
     }
 
@@ -250,10 +249,10 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
                 if (std::abs(dot) < 0.05)
                 {
                     /* rotate 2.5 degrees around an axis perpendicular to x */
-                    current_view->damage();
+                    current_view->get_transformed_node()->begin_transform_update();
                     tr->rotation = glm::rotate<float>(tr->rotation, glm::radians(
                         dot < 0 ? -2.5f : 2.5f), {x.y, -x.x, 0});
-                    current_view->damage();
+                    current_view->get_transformed_node()->end_transform_update();
                 }
             }
         }

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -692,12 +692,13 @@ class wobbly_transformer_node_t : public wf::scene::floating_inner_node_t
 
         if (now > last_frame)
         {
+            view->get_transformed_node()->begin_transform_update();
             wobbly_prepare_paint(model.get(), now - last_frame);
             /* Update wobbly geometry */
             last_frame = now;
             wobbly_add_geometry(model.get());
             wobbly_done_paint(model.get());
-            view->damage();
+            view->get_transformed_node()->end_transform_update();
         }
 
         if (state->is_wobbly_done())

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -94,7 +94,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'09'22;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'09'25;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/unstable/wlr-surface-node.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-node.hpp
@@ -65,7 +65,7 @@ class wlr_surface_node_t : public node_t, public zero_copy_texturable_node_t
 
     wlr_surface *get_surface() const;
     void apply_state(surface_state_t&& state);
-    void send_frame_done();
+    void send_frame_done(bool delay_until_vblank);
 
   private:
     std::unique_ptr<pointer_interaction_t> ptr_interaction;

--- a/src/api/wayfire/view-transform.hpp
+++ b/src/api/wayfire/view-transform.hpp
@@ -238,6 +238,18 @@ class transform_manager_node_t : public wf::scene::floating_inner_node_t
     {}
 
     /**
+     * Marks a section of the code which updates one or more transformers added to this transform manager.
+     * Doing so will ensure that the proper damage is propagated upwards in the scenegraph.
+     */
+    void begin_transform_update();
+
+    /**
+     * Marks the end of a section of the code which updates one or more transformers added to this transform
+     * manager. Doing so will ensure that the proper damage is propagated upwards in the scenegraph.
+     */
+    void end_transform_update();
+
+    /**
      * Add a new transformer in the transformer chain.
      *
      * @param transformer The transformer to be added.

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -75,7 +75,7 @@ class view_interface_t : public wf::signal::provider_t, public wf::object_base_t
      * Get the root of the view itself, including its main surface, subsurfaces
      * and transformers, but not dialogs.
      */
-    std::shared_ptr<scene::transform_manager_node_t> get_transformed_node() const;
+    const std::shared_ptr<scene::transform_manager_node_t>& get_transformed_node() const;
 
     /**
      * Get the node which contains the main view (+subsurfaces) only.

--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -431,5 +431,16 @@ void view_3d_transformer_t::gen_render_instances(
         instances.push_back(std::move(uptr));
     }
 }
+
+void transform_manager_node_t::begin_transform_update()
+{
+    wf::scene::damage_node(this, get_bounding_box());
+}
+
+void transform_manager_node_t::end_transform_update()
+{
+    wf::scene::damage_node(this, get_bounding_box());
+    wf::scene::update(shared_from_this(), wf::scene::update_flag::GEOMETRY);
+}
 } // namespace scene
 }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -204,7 +204,7 @@ const wf::scene::floating_inner_ptr& wf::view_interface_t::get_root_node() const
     return priv->root_node;
 }
 
-std::shared_ptr<wf::scene::transform_manager_node_t> wf::view_interface_t::get_transformed_node() const
+const std::shared_ptr<wf::scene::transform_manager_node_t>& wf::view_interface_t::get_transformed_node() const
 {
     return priv->transformed_node;
 }

--- a/src/view/xdg-shell/xdg-toplevel.cpp
+++ b/src/view/xdg-shell/xdg-toplevel.cpp
@@ -89,7 +89,7 @@ void wf::xdg_toplevel_t::commit()
     if (wait_for_client)
     {
         // Send frame done to let the client know it update its state as fast as possible.
-        main_surface->send_frame_done();
+        main_surface->send_frame_done(true);
     } else
     {
         emit_ready();
@@ -145,7 +145,7 @@ void wf::xdg_toplevel_t::handle_surface_commit()
         {
             // Desired state not reached => wait for the desired state to be reached. In the meantime, send a
             // frame done so that the client can redraw faster.
-            main_surface->send_frame_done();
+            main_surface->send_frame_done(true);
             return;
         }
 

--- a/src/view/xwayland/xwayland-toplevel.cpp
+++ b/src/view/xwayland/xwayland-toplevel.cpp
@@ -128,7 +128,7 @@ void wf::xw::xwayland_toplevel_t::commit()
     if (wait_for_client && main_surface)
     {
         // Send frame done to let the client know it can resize
-        main_surface->send_frame_done();
+        main_surface->send_frame_done(true);
     } else
     {
         emit_ready();
@@ -215,7 +215,7 @@ void wf::xw::xwayland_toplevel_t::handle_surface_commit()
         {
             // Desired state not reached => wait for the desired state to be reached. In the meantime, send a
             // frame done so that the client can redraw faster.
-            main_surface->send_frame_done();
+            main_surface->send_frame_done(true);
             return;
         }
 


### PR DESCRIPTION
When we have a pending transaction, we want to make sure we send a frame done to the client, so that it can resize. However, if it is already visible on an output, we should not send additional frame done events. Instead, we should wait until the 'normal' frame done events are sent as part of the rendering loop.
