### PR TITLE
api: make input focus global state

### DIFF
--- a/plugins/common/wayfire/plugins/common/input-grab.hpp
+++ b/plugins/common/wayfire/plugins/common/input-grab.hpp
@@ -8,6 +8,7 @@
 #include <wayfire/debug.hpp>
 #include <memory>
 #include <string>
+#include <wayfire/seat.hpp>
 namespace wf
 {
 namespace scene
@@ -146,8 +147,7 @@ class input_grab_t
         children.insert(idx, grab_node);
         root->set_children_list(children);
         wf::get_core().transfer_grab(grab_node);
-        scene::update(root, scene::update_flag::CHILDREN_LIST);
-        output->refocus();
+        scene::update(root, scene::update_flag::CHILDREN_LIST | scene::update_flag::REFOCUS);
 
         // Set cursor to default.
         wf::get_core().set_cursor("default");
@@ -160,10 +160,8 @@ class input_grab_t
     {
         if (grab_node->parent())
         {
-            wf::scene::remove_child(grab_node);
+            wf::scene::remove_child(grab_node, scene::update_flag::REFOCUS);
         }
-
-        output->refocus();
     }
 };
 }

--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -9,6 +9,7 @@
 #include "wayfire/scene-operations.hpp"
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
+#include "wayfire/seat.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include <memory>
 #include <wayfire/nonstd/reverse.hpp>
@@ -669,7 +670,7 @@ class core_drag_t : public signal::provider_t
 
             current_output    = output;
             data.focus_output = output;
-            wf::get_core().focus_output(output);
+            wf::get_core().seat->focus_output(output);
             emit(&data);
 
             if (output)
@@ -774,7 +775,7 @@ inline void adjust_view_on_output(drag_done_signal *ev)
         ev->focused_output->wset()->move_to_workspace(v, target_ws);
     }
 
-    ev->focused_output->focus_view(focus_view, true);
+    wf::get_core().default_wm->focus_raise_view(focus_view);
 }
 
 /**

--- a/plugins/ipc/ipc-activator.hpp
+++ b/plugins/ipc/ipc-activator.hpp
@@ -9,6 +9,7 @@
 #include "wayfire/option-wrapper.hpp"
 #include "wayfire/output.hpp"
 #include "wayfire/plugins/common/shared-core-data.hpp"
+#include "wayfire/seat.hpp"
 
 namespace wf
 {
@@ -74,7 +75,7 @@ class ipc_activator_t
         WFJSON_OPTIONAL_FIELD(data, "output_id", number_integer);
         WFJSON_OPTIONAL_FIELD(data, "view_id", number_integer);
 
-        wf::output_t *wo = wf::get_core().get_active_output();
+        wf::output_t *wo = wf::get_core().seat->get_active_output();
         if (data.contains("output_id"))
         {
             wo = ipc::find_output_by_id(data["output_id"]);
@@ -104,7 +105,7 @@ class ipc_activator_t
 
     wf::output_t *choose_output()
     {
-        return wf::get_core().get_active_output();
+        return wf::get_core().seat->get_active_output();
     }
 
     wayfire_view choose_view(wf::activator_source_t source)
@@ -115,7 +116,7 @@ class ipc_activator_t
             view = wf::get_core().get_cursor_focus_view();
         } else
         {
-            view = wf::get_core().get_active_output()->get_active_view();
+            view = wf::get_core().seat->get_active_view();
         }
 
         return view;

--- a/plugins/scale/scale-title-filter.cpp
+++ b/plugins/scale/scale-title-filter.cpp
@@ -10,6 +10,7 @@
 #include <wayfire/plugins/scale-signal.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/toplevel-view.hpp>
+#include <wayfire/seat.hpp>
 
 #include <linux/input-event-codes.h>
 
@@ -218,7 +219,7 @@ class scale_title_filter : public wf::per_output_plugin_instance_t
             return;
         }
 
-        if (output != wf::get_core().get_active_output())
+        if (output != wf::get_core().seat->get_active_output())
         {
             return;
         }

--- a/plugins/single_plugins/fast-switcher.cpp
+++ b/plugins/single_plugins/fast-switcher.cpp
@@ -11,6 +11,7 @@
 #include <wayfire/util/log.hpp>
 #include <wayfire/seat.hpp>
 #include <wayfire/toplevel-view.hpp>
+#include <wayfire/window-manager.hpp>
 
 /*
  * This plugin provides abilities to switch between views.
@@ -74,7 +75,7 @@ class wayfire_fast_switcher : public wf::per_output_plugin_instance_t, public wf
             wf::view_bring_to_front(views[i]);
         } else
         {
-            output->focus_view(views[i], true);
+            wf::get_core().default_wm->focus_raise_view(views[i]);
         }
     }
 

--- a/plugins/single_plugins/idle.cpp
+++ b/plugins/single_plugins/idle.cpp
@@ -194,7 +194,7 @@ class wayfire_idle_plugin : public wf::per_output_plugin_instance_t
         output->connect(&fullscreen_state_changed);
         disable_on_fullscreen.set_callback(disable_on_fullscreen_changed);
 
-        if (auto toplevel = toplevel_cast(output->get_active_view()))
+        if (auto toplevel = toplevel_cast(wf::get_active_view_for_output(output)))
         {
             /* Currently, the fullscreen count would always be 0 or 1,
              * since fullscreen-layer-focused is only emitted on changes between 0

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -3,6 +3,7 @@
 #include <wayfire/view.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/toplevel-view.hpp>
+#include <wayfire/seat.hpp>
 #include <set>
 
 #include "plugins/ipc/ipc-helpers.hpp"
@@ -75,7 +76,7 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
 
     wf::ipc::method_callback get_focused_view = [=] (nlohmann::json data)
     {
-        if (auto view = wf::get_core().get_active_output()->get_active_view())
+        if (auto view = wf::get_core().seat->get_active_view())
         {
             auto response = wf::ipc::json_ok();
             response["info"] = view_to_json(view);

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -331,7 +331,7 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
         if (join_views)
         {
             // ensure that the originally grabbed view will be focused
-            output->focus_view(grabbed_view);
+            wf::get_core().seat->focus_view(grabbed_view);
         }
 
         drag_helper->start_drag(view, grab_position, opts);

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -5,6 +5,7 @@
 #include <wayfire/view.hpp>
 #include <wayfire/output-layout.hpp>
 #include <wayfire/bindings-repository.hpp>
+#include <wayfire/seat.hpp>
 
 class wayfire_oswitch : public wf::plugin_interface_t
 {
@@ -15,11 +16,11 @@ class wayfire_oswitch : public wf::plugin_interface_t
         /* when we switch the output, the oswitch keybinding
          * may be activated for the next output, which we don't want,
          * so we postpone the switch */
-        auto current_output = wf::get_core().get_active_output();
+        auto current_output = wf::get_core().seat->get_active_output();
         auto next = wf::get_core().output_layout->get_next_output(current_output);
         idle_next_output.run_once([=] ()
         {
-            wf::get_core().focus_output(next);
+            wf::get_core().seat->focus_output(next);
         });
 
         return true;
@@ -27,9 +28,10 @@ class wayfire_oswitch : public wf::plugin_interface_t
 
     wf::activator_callback switch_output_with_window = [=] (auto)
     {
-        auto current_output = wf::get_core().get_active_output();
+        auto current_output = wf::get_core().seat->get_active_output();
         auto next = wf::get_core().output_layout->get_next_output(current_output);
-        auto view = wf::toplevel_cast(current_output->get_active_view());
+        auto view = wf::toplevel_cast(wf::get_active_view_for_output(current_output));
+        LOGI("Found view ", view);
         if (!view)
         {
             switch_output(wf::activator_data_t{});
@@ -40,7 +42,7 @@ class wayfire_oswitch : public wf::plugin_interface_t
         move_view_to_output(view, next, true);
         idle_next_output.run_once([=] ()
         {
-            wf::get_core().focus_output(next);
+            wf::get_core().seat->focus_output(next);
         });
 
         return true;

--- a/plugins/single_plugins/preserve-output.cpp
+++ b/plugins/single_plugins/preserve-output.cpp
@@ -3,6 +3,7 @@
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/output.hpp>
+#include <wayfire/seat.hpp>
 #include <wayfire/output-layout.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <chrono>
@@ -47,7 +48,7 @@ class preserve_output_t : public wf::plugin_interface_t
         auto ident = make_output_identifier(output);
         auto& data = saved_outputs[ident];
 
-        data.was_focused = (output == wf::get_core().get_active_output());
+        data.was_focused = (output == wf::get_core().seat->get_active_output());
         data.destroy_timestamp = std::chrono::steady_clock::now();
         data.workspace_set     = output->wset();
 
@@ -84,7 +85,7 @@ class preserve_output_t : public wf::plugin_interface_t
         output->set_workspace_set(data.workspace_set);
         if (data.was_focused && !focused_output_expired(data))
         {
-            wf::get_core().focus_output(output);
+            wf::get_core().seat->focus_output(output);
         }
 
         saved_outputs.erase(ident);

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -5,6 +5,7 @@
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
 #include "wayfire/view-helpers.hpp"
+#include <wayfire/window-manager.hpp>
 #include <memory>
 #include <wayfire/per-output-plugin.hpp>
 #include <wayfire/opengl.hpp>
@@ -598,7 +599,7 @@ class WayfireSwitcher : public wf::per_output_plugin_instance_t, public wf::keyb
         /* Potentially restore view[0] if it was maximized */
         if (views.size())
         {
-            output->focus_view(views[0].view, true);
+            wf::get_core().default_wm->focus_raise_view(views[0].view);
         }
     }
 

--- a/plugins/single_plugins/vswipe.cpp
+++ b/plugins/single_plugins/vswipe.cpp
@@ -205,7 +205,7 @@ class vswipe : public wf::per_output_plugin_instance_t
         }
 
         input_grab->grab_input(wf::scene::layer::OVERLAY);
-        wf::get_core().focus_output(output);
+        wf::get_core().seat->focus_output(output);
 
         auto ws = output->wset()->get_current_workspace();
         wall->set_background_color(background_color);

--- a/plugins/single_plugins/wrot.cpp
+++ b/plugins/single_plugins/wrot.cpp
@@ -9,6 +9,7 @@
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/plugins/common/util.hpp>
+#include <wayfire/window-manager.hpp>
 #include <linux/input.h>
 
 #include <glm/gtc/matrix_transform.hpp>
@@ -74,7 +75,7 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
             return false;
         }
 
-        output->focus_view(current_view, true);
+        wf::get_core().default_wm->focus_raise_view(current_view);
         current_view->connect(&current_view_unmapped);
         input_grab->grab_input(wf::scene::layer::OVERLAY);
 
@@ -91,7 +92,7 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
 
     wf::key_callback reset_one = [this] (auto)
     {
-        auto view = output->get_active_view();
+        auto view = wf::get_active_view_for_output(output);
         if (view)
         {
             view->get_transformed_node()->rem_transformer(transformer_2d);
@@ -188,7 +189,7 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
                 return false;
             }
 
-            output->focus_view(current_view, true);
+            wf::get_core().default_wm->focus_raise_view(current_view);
             current_view->connect(&current_view_unmapped);
             input_grab->grab_input(wf::scene::layer::OVERLAY);
 

--- a/plugins/single_plugins/wsets.cpp
+++ b/plugins/single_plugins/wsets.cpp
@@ -1,6 +1,7 @@
 #include "wayfire/bindings.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/object.hpp"
+#include "wayfire/seat.hpp"
 #include "wayfire/option-wrapper.hpp"
 #include "wayfire/scene-operations.hpp"
 #include "wayfire/signal-provider.hpp"
@@ -125,7 +126,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
 
             select_callback.push_back([=] (auto)
             {
-                auto wo = wf::get_core().get_active_output();
+                auto wo = wf::get_core().seat->get_active_output();
                 if (!wo->can_activate_plugin(wf::CAPABILITY_MANAGE_COMPOSITOR))
                 {
                     return false;
@@ -149,7 +150,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
 
             send_callback.push_back([=] (auto)
             {
-                auto wo = wf::get_core().get_active_output();
+                auto wo = wf::get_core().seat->get_active_output();
                 if (!wo->can_activate_plugin(wf::CAPABILITY_MANAGE_COMPOSITOR))
                 {
                     return false;
@@ -236,7 +237,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
 
     void select_workspace(int index)
     {
-        auto wo = wf::get_core().get_active_output();
+        auto wo = wf::get_core().seat->get_active_output();
         if (!wo)
         {
             return;
@@ -268,13 +269,13 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
 
     void send_window_to(int index)
     {
-        auto wo = wf::get_core().get_active_output();
+        auto wo = wf::get_core().seat->get_active_output();
         if (!wo)
         {
             return;
         }
 
-        auto view = toplevel_cast(wo->get_active_view());
+        auto view = toplevel_cast(wf::get_active_view_for_output(wo));
         if (!view)
         {
             return;
@@ -298,10 +299,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
         target_wset->add_view(view);
         wf::emit_view_moved_to_wset(view, old_wset, target_wset);
 
-        if (target_wset->get_attached_output())
-        {
-            target_wset->get_attached_output()->refocus();
-        }
+        wf::get_core().seat->refocus();
     }
 
     wf::signal::connection_t<wf::output_added_signal> on_new_output = [=] (wf::output_added_signal *ev)

--- a/plugins/vswitch/vswitch.cpp
+++ b/plugins/vswitch/vswitch.cpp
@@ -1,8 +1,9 @@
+#include "wayfire/core.hpp"
 #include <wayfire/plugins/vswitch.hpp>
 #include <wayfire/per-output-plugin.hpp>
 #include <linux/input.h>
 #include <wayfire/util/log.hpp>
-
+#include <wayfire/seat.hpp>
 
 class vswitch : public wf::per_output_plugin_instance_t
 {
@@ -85,7 +86,7 @@ class vswitch : public wf::per_output_plugin_instance_t
                     data.from = output->wset()->get_current_workspace();
                     data.to   = data.from + delta;
                     output->emit(&data);
-                    output->refocus();
+                    wf::get_core().seat->refocus();
 
                     return true;
                 }

--- a/plugins/vswitch/wayfire/plugins/vswitch.hpp
+++ b/plugins/vswitch/wayfire/plugins/vswitch.hpp
@@ -1,9 +1,12 @@
 #pragma once
 
+#include "wayfire/seat.hpp"
+#include "wayfire/core.hpp"
 #include "wayfire/render-manager.hpp"
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
 #include "wayfire/toplevel-view.hpp"
+#include "wayfire/view-helpers.hpp"
 #include <memory>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/plugins/common/geometry-animation.hpp>
@@ -278,7 +281,7 @@ class workspace_switch_t
         output->emit(&data);
 
         set_overlay_view(nullptr);
-        output->refocus();
+        wf::get_core().seat->refocus();
     }
 };
 
@@ -480,12 +483,7 @@ class control_bindings_t
     /** Find the view to switch workspace with */
     virtual wayfire_toplevel_view get_target_view()
     {
-        auto view = toplevel_cast(output->get_active_view());
-        while (view && view->parent)
-        {
-            view = view->parent;
-        }
-
+        auto view = find_topmost_parent(toplevel_cast(wf::get_core().seat->get_active_view()));
         if (!view || (view->role != wf::VIEW_ROLE_TOPLEVEL))
         {
             return nullptr;

--- a/plugins/window-rules/view-action-interface.cpp
+++ b/plugins/window-rules/view-action-interface.cpp
@@ -232,16 +232,12 @@ void view_action_interface_t::_unmaximize()
 
 void view_action_interface_t::_minimize()
 {
-    _view->set_minimized(true);
+    wf::get_core().default_wm->minimize_request(_view, true);
 }
 
 void view_action_interface_t::_unminimize()
 {
-    _view->set_minimized(false);
-    if (_view->get_output())
-    {
-        _view->get_output()->focus_view(_view, true);
-    }
+    wf::get_core().default_wm->minimize_request(_view, false);
 }
 
 void view_action_interface_t::_make_sticky()

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -14,6 +14,7 @@
 #include "wayfire/signal-provider.hpp"
 #include "wayfire/toplevel-view.hpp"
 #include "wayfire/window-manager.hpp"
+#include "wayfire/seat.hpp"
 #include "wm-actions-signals.hpp"
 
 class always_on_top_root_node_t : public wf::scene::output_node_t
@@ -93,7 +94,7 @@ class wayfire_wm_actions_output_t : public wf::per_output_plugin_instance_t
             view = wf::get_core().get_cursor_focus_view();
         } else
         {
-            view = output->get_active_view();
+            view = wf::get_core().seat->get_active_view();
         }
 
         return wf::toplevel_cast(view);
@@ -325,7 +326,7 @@ class wayfire_wm_actions_output_t : public wf::per_output_plugin_instance_t
                     wf::WSET_CURRENT_WORKSPACE | wf::WSET_MAPPED_ONLY |
                     wf::WSET_EXCLUDE_MINIMIZED | wf::WSET_SORT_STACKING);
 
-                view->get_output()->focus_view(views[0], false);
+                wf::get_core().seat->focus_view(views[0]);
             }
 
             return true;

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -257,17 +257,6 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
      */
     std::vector<wayfire_view> get_all_views();
 
-    /**
-     * Focus the given output. The currently focused output is used to determine
-     * which plugins receive various events (including bindings)
-     */
-    virtual void focus_output(wf::output_t *o) = 0;
-
-    /**
-     * Get the currently focused "active" output
-     */
-    virtual wf::output_t *get_active_output() = 0;
-
     /** The wayland socket name of Wayfire */
     std::string wayland_display;
 

--- a/src/api/wayfire/output.hpp
+++ b/src/api/wayfire/output.hpp
@@ -167,55 +167,10 @@ class output_t : public wf::object_base_t, public wf::signal::provider_t
     virtual bool is_plugin_active(std::string owner_name) const = 0;
 
     /**
-     * Get the most recently focused view on this output.
-     *
-     * Note that the view might not be actually focused, as focus can be overridden
-     * by core, layer-shell views or plugins.
-     */
-    virtual wayfire_view get_active_view() const = 0;
-
-    /**
-     * Set the view as the output's active view.
-     *
-     * This operation will change the view's last_focus_timestamp and its activated
-     * status. In addition, an attempt to focus the view on the current seat will
-     * be made. Note, however, that the last operation may fail if layer-shell
-     * views, plugin grabs or something similar overrides the focus request.
-     *
-     * @param raise If set to true, the view will additionally be raised to the
-     *   top of its layer.
-     */
-    virtual void focus_view(wayfire_view v, bool raise = false) = 0;
-
-    /**
-     * Try to focus the given scenegraph node. This may not work if another node
-     * requests a higher focus_importance.
-     *
-     * Note that the focus_view function should be used for view nodes, as
-     * focusing views typically involves more operations. Calling this function
-     * does not change the active view on the output, even if the newly focused
-     * node is a view node!
-     *
-     * The new_focus' last focus timestamp will be updated.
-     */
-    virtual void focus_node(wf::scene::node_ptr new_focus) = 0;
-
-    /**
-     * Get the last focus timestamp which was given out by this output.
-     */
-    virtual uint64_t get_last_focus_timestamp() const = 0;
-
-    /**
      * Switch the workspace so that view becomes visible.
      * @return true if workspace switch really occurred
      */
     bool ensure_visible(wayfire_view view);
-
-    /**
-     * Trigger a refocus operation on the output.
-     * See scene::node_t::keyboard_refocus() for details.
-     */
-    virtual void refocus() = 0;
 
     /**
      * the add_* functions are used by plugins to register bindings. They pass
@@ -244,6 +199,12 @@ class output_t : public wf::object_base_t, public wf::signal::provider_t
     /* outputs are instantiated internally by core */
     output_t();
 };
+
+/**
+ * Find the active view on the given output. It is the same as wf::get_core().seat->get_active_view() if the
+ * output is currently focused, otherwise NULL.
+ */
+wayfire_view get_active_view_for_output(wf::output_t *output);
 }
 
 #endif /* end of include guard: OUTPUT_HPP */

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -94,7 +94,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'09'25;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'09'28;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/scene-operations.hpp
+++ b/src/api/wayfire/scene-operations.hpp
@@ -14,7 +14,7 @@ namespace scene
 /**
  * Remove a child node from a parent node and update the parent.
  */
-inline void remove_child(node_ptr child)
+inline void remove_child(node_ptr child, uint32_t add_flags = 0)
 {
     if (!child->parent())
     {
@@ -28,7 +28,7 @@ inline void remove_child(node_ptr child)
     children.erase(std::remove(children.begin(), children.end(), child),
         children.end());
     parent->set_children_list(children);
-    update(parent->shared_from_this(), update_flag::CHILDREN_LIST);
+    update(parent->shared_from_this(), update_flag::CHILDREN_LIST | add_flags);
 }
 
 inline void add_front(floating_inner_ptr parent, node_ptr child)
@@ -59,17 +59,23 @@ inline void readd_back(floating_inner_ptr parent, node_ptr child)
     add_back(parent, child);
 }
 
-inline void raise_to_front(node_ptr child)
+inline bool raise_to_front(node_ptr child)
 {
     auto dyn_parent = dynamic_cast<floating_inner_node_t*>(child->parent());
     wf::dassert(dyn_parent, "Raise to front in a non-floating container!");
 
     auto children = dyn_parent->get_children();
+    if (children.front() == child)
+    {
+        return false;
+    }
+
     children.erase(std::remove(children.begin(), children.end(), child),
         children.end());
     children.insert(children.begin(), child);
     dyn_parent->set_children_list(children);
     update(dyn_parent->shared_from_this(), update_flag::CHILDREN_LIST);
+    return true;
 }
 }
 }

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -448,6 +448,10 @@ enum update_flag
      * of the view, but also things like opaque regions.
      */
     GEOMETRY      = (1 << 3),
+    /**
+     * A keyboard refocus might be necessary (for example, node removed, keyboard input state changed, etc.).
+     */
+    REFOCUS       = (1 << 4),
 };
 }
 

--- a/src/api/wayfire/seat.hpp
+++ b/src/api/wayfire/seat.hpp
@@ -4,6 +4,7 @@
 #include <wayfire/scene.hpp>
 #include <wayfire/nonstd/wlroots.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
+#include <wayfire/view.hpp>
 
 namespace wf
 {
@@ -42,10 +43,54 @@ class seat_t
     uint32_t modifier_from_keycode(uint32_t keycode);
 
     /**
-     * Set the keyboard focus node. Note that this changes only the focus state
-     * and does not reorder nodes or anything like this.
+     * Try to focus the given scenegraph node. This may not work if another node requests a higher focus
+     * importance.
+     *
+     * Note that the focus_view function should be used for view nodes, as focusing views typically involves
+     * more operations. Calling this function does not change the active view, even if the newly focused node
+     * is a view node!
+     *
+     * The new_focus' last focus timestamp will be updated.
      */
     void set_active_node(wf::scene::node_ptr node);
+
+    /**
+     * Try to focus the given view. This may not work if another view or a node requests a higher focus
+     * importance.
+     */
+    void focus_view(wayfire_view v);
+
+    /**
+     * Get the view which is currently marked as active. In general, this is the last view for which
+     * @focus_view() was called, or for ex. when refocusing after a view disappears, the next view which
+     * received focus.
+     *
+     * Usually, the active view has keyboard focus as well. In some cases (for ex. grabs), however, another
+     * node might have the actual keyboard focus.
+     */
+    wayfire_view get_active_view() const;
+
+    /**
+     * Get the last focus timestamp which was given out by a set_active_node request.
+     */
+    uint64_t get_last_focus_timestamp() const;
+
+    /**
+     * Trigger a refocus operation.
+     * See scene::node_t::keyboard_refocus() for details.
+     */
+    void refocus();
+
+    /**
+     * Focus the given output. The currently focused output is used to determine
+     * which plugins receive various events (including bindings)
+     */
+    void focus_output(wf::output_t *o);
+
+    /**
+     * Get the currently focused "active" output
+     */
+    wf::output_t *get_active_output();
 
     /**
      * Create and initialize a new seat.

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -687,27 +687,6 @@ struct view_disappeared_signal
 
 /**
  * on: output
- * when: Before the output focus changes.
- */
-struct pre_focus_view_signal
-{
-    wayfire_view view;
-    /* Set by the listener to indicate whether or not to give the view focus */
-    bool can_focus = true;
-};
-
-/**
- * on: output
- * when: As soon as the output focus changes.
- * argument: The newly focused view.
- */
-struct focus_view_signal
-{
-    wayfire_view view;
-};
-
-/**
- * on: output
  * when: Whenever an interactive move is requested on the view. See also
  *   view_interface_t::move_request()
  */

--- a/src/api/wayfire/view-helpers.hpp
+++ b/src/api/wayfire/view-helpers.hpp
@@ -36,6 +36,12 @@ std::vector<wayfire_view> collect_views_from_output(
     wf::output_t *output, std::initializer_list<wf::scene::layer> layers);
 
 /**
+ * Find the topmost parent in the chain of views.
+ */
+wayfire_view find_topmost_parent(wayfire_view v);
+wayfire_toplevel_view find_topmost_parent(wayfire_toplevel_view v);
+
+/**
  * A few simple functions which help in view implementations.
  */
 namespace view_implementation

--- a/src/api/wayfire/window-manager.hpp
+++ b/src/api/wayfire/window-manager.hpp
@@ -44,8 +44,18 @@ class window_manager_t
 
     /**
      * Try to focus the view and its output.
+     * This will first emit a focus_request signal for the view, and if it is not handled by any plugin, the
+     * default focus actions will be taken (i.e @focus_raise_view(allow_switch_ws=true) will be called).
      */
-    virtual void focus_request(wayfire_toplevel_view view, bool self_request = false);
+    virtual void focus_request(wayfire_view view, bool self_request = false);
+
+    /**
+     * Focus the view and take any actions necessary to make it visible:
+     * - Unminimize minized views
+     * - Switch to the view's workspace, if @allow_switch_ws is set.
+     * - Raise the view to the top of the stack.
+     */
+    virtual void focus_raise_view(wayfire_view view, bool allow_switch_ws = false);
 
     /** Request that the view is (un)minimized */
     virtual void minimize_request(wayfire_toplevel_view view, bool minimized);

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -63,8 +63,6 @@ class compositor_core_impl_t : public compositor_core_t
     override;
     virtual wlr_cursor *get_wlr_cursor() override;
 
-    void focus_output(wf::output_t *o) override;
-    wf::output_t *get_active_output() override;
     std::string get_xwayland_display() override;
     pid_t run(std::string command) override;
     void shutdown() override;
@@ -78,8 +76,6 @@ class compositor_core_impl_t : public compositor_core_t
     wf::wl_listener_wrapper input_inhibit_deactivated;
     wf::wl_listener_wrapper pointer_constraint_added;
     wf::wl_listener_wrapper idle_inhibitor_created;
-
-    wf::output_t *active_output = nullptr;
     std::shared_ptr<scene::root_node_t> scene_root;
 
     compositor_state_t state = compositor_state_t::UNKNOWN;

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -449,11 +449,11 @@ struct output_layout_output_t
         /* Focus the first output, but do not change the focus on subsequently
          * added outputs. We also change the focus if the noop output was
          * focused */
-        wlr_output *focused = get_core().get_active_output() ?
-            get_core().get_active_output()->handle : nullptr;
+        wlr_output *focused = get_core().seat->get_active_output() ?
+            get_core().seat->get_active_output()->handle : nullptr;
         if (!focused || (focused->data == WF_NOOP_OUTPUT_MAGIC))
         {
-            get_core().focus_output(wo);
+            get_core().seat->focus_output(wo);
         }
 
         output_added_signal data;
@@ -479,18 +479,18 @@ struct output_layout_output_t
         wo->cancel_active_plugins();
 
         bool shutdown = is_shutting_down();
-        if ((get_core().get_active_output() == wo) && !shutdown)
+        if ((get_core().seat->get_active_output() == wo) && !shutdown)
         {
-            get_core().focus_output(
+            get_core().seat->focus_output(
                 get_core().output_layout->get_next_output(wo));
         } else if (shutdown)
         {
-            get_core().focus_output(nullptr);
+            get_core().seat->focus_output(nullptr);
         }
 
         /* It doesn't make sense to transfer to another output if we're
          * going to shut down the compositor */
-        transfer_views(wo, shutdown ? nullptr : get_core().get_active_output());
+        transfer_views(wo, shutdown ? nullptr : get_core().seat->get_active_output());
 
         wf::output_removed_signal data2;
         data2.output = wo;

--- a/src/core/plugin-loader.cpp
+++ b/src/core/plugin-loader.cpp
@@ -224,7 +224,7 @@ static wf::loaded_plugin_t create_plugin()
 void wf::plugin_manager_t::load_static_plugins()
 {
     loaded_plugins["_exit"]  = create_plugin<wf::per_output_plugin_t<wayfire_exit>>();
-    loaded_plugins["_focus"] = create_plugin<wf::per_output_plugin_t<wayfire_focus>>();
+    loaded_plugins["_focus"] = create_plugin<wayfire_focus>();
     loaded_plugins["_close"] = create_plugin<wf::per_output_plugin_t<wayfire_close>>();
 }
 

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -195,6 +195,6 @@ void wf::input_manager_t::set_exclusive_focus(wl_client *client)
      * focus to the topmost view */
     if (!client)
     {
-        wf::get_core().get_active_output()->refocus();
+        wf::get_core().seat->refocus();
     }
 }

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -218,9 +218,8 @@ void wf::pointer_t::handle_pointer_button(wlr_pointer_button_event *ev,
             /* Focus only the first click, since then we also start an implicit
              * grab, and we don't want to suddenly change the output */
             auto gc     = seat->priv->cursor->get_cursor_position();
-            auto output =
-                wf::get_core().output_layout->get_output_at(gc.x, gc.y);
-            wf::get_core().focus_output(output);
+            auto output = wf::get_core().output_layout->get_output_at(gc.x, gc.y);
+            seat->focus_output(output);
         }
 
         handled_in_binding |= wf::get_core().bindings->handle_button(

--- a/src/core/seat/seat-impl.hpp
+++ b/src/core/seat/seat-impl.hpp
@@ -9,6 +9,9 @@
 #include "wayfire/output.hpp"
 #include "wayfire/input-device.hpp"
 #include "wayfire/scene-input.hpp"
+#include "wayfire/scene.hpp"
+#include "wayfire/signal-provider.hpp"
+#include "wayfire/toplevel-view.hpp"
 #include "wayfire/util.hpp"
 
 namespace wf
@@ -99,6 +102,13 @@ struct seat_t::impl
 
     wf::wl_listener_wrapper on_wlr_keyboard_grab_end;
     wf::wl_listener_wrapper on_wlr_pointer_grab_end;
+
+    uint64_t last_timestamp     = 0;
+    wf::output_t *active_output = nullptr;
+    std::weak_ptr<wf::toplevel_view_interface_t> _last_active_toplevel;
+    std::weak_ptr<wf::view_interface_t> _last_active_view;
+    wf::signal::connection_t<scene::root_node_update_signal> on_root_node_updated;
+    void update_active_view(wf::scene::node_ptr new_focus);
 };
 }
 

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -203,7 +203,7 @@ void wf::touch_interface_t::handle_touch_down(int32_t id, uint32_t time,
 
     if (id == 0)
     {
-        wf::get_core().focus_output(
+        wf::get_core().seat->focus_output(
             wf::get_core().output_layout->get_output_at(point.x, point.y));
     }
 
@@ -409,7 +409,7 @@ class multi_action_t : public gesture_action_t
 
 static uint32_t find_swipe_edges(wf::touch::point_t point)
 {
-    auto output   = wf::get_core().get_active_output();
+    auto output   = wf::get_core().seat->get_active_output();
     auto geometry = output->get_layout_geometry();
 
     uint32_t edge_directions = 0;

--- a/src/core/wm.hpp
+++ b/src/core/wm.hpp
@@ -10,11 +10,6 @@
 #include "wayfire/touch/touch.hpp"
 #include "wayfire/option-wrapper.hpp"
 
-struct wm_focus_request_signal
-{
-    wf::scene::node_ptr node;
-};
-
 class wayfire_close : public wf::per_output_plugin_instance_t
 {
     wf::activator_callback callback;
@@ -29,11 +24,9 @@ class wayfire_close : public wf::per_output_plugin_instance_t
     void fini() override;
 };
 
-class wayfire_focus : public wf::per_output_plugin_instance_t
+class wayfire_focus : public wf::plugin_interface_t
 {
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_button_event>> on_pointer_button;
-    wf::signal::connection_t<wm_focus_request_signal> on_wm_focus_request;
-
     std::unique_ptr<wf::touch::gesture_t> tap_gesture;
 
     // @return True if the focus has changed

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -23,7 +23,6 @@ class output_impl_t : public output_t
 
     std::shared_ptr<workspace_set_t> current_wset;
     std::unique_ptr<promotion_manager_t> promotion_manager;
-    uint64_t last_timestamp = 0;
 
     std::map<key_callback*, key_callback> key_map;
     std::map<axis_callback*, axis_callback> axis_map;
@@ -32,38 +31,17 @@ class output_impl_t : public output_t
 
   private:
     std::unordered_multiset<wf::plugin_activation_data_t*> active_plugins;
-
-    wf::signal::connection_t<view_disappeared_signal> on_view_disappeared;
     wf::signal::connection_t<output_configuration_changed_signal> on_configuration_changed;
-    void handle_view_removed(wayfire_view view);
     void update_node_limits();
 
     bool inhibited = false;
 
-    enum focus_view_flags_t
-    {
-        /* Raise the view which is being focused */
-        FOCUS_VIEW_RAISE = (1 << 0),
-    };
-
-    /**
-     * Set the given view as the active view.
-     */
-    void update_active_view(wayfire_view view);
-
-    /** @param flags bitmask of @focus_view_flags_t */
-    void focus_view(wayfire_view view, uint32_t flags);
-
     wf::dimensions_t effective_size;
-
-    void do_update_focus(wf::scene::node_t *node);
 
   public:
     output_impl_t(wlr_output *output, const wf::dimensions_t& effective_size);
 
     virtual ~output_impl_t();
-    wayfire_view active_view = nullptr;
-    wayfire_toplevel_view last_active_toplevel = nullptr;
 
     /**
      * Implementations of the public APIs
@@ -78,7 +56,6 @@ class output_impl_t : public output_t
     bool deactivate_plugin(wf::plugin_activation_data_t *owner) override;
     void cancel_active_plugins() override;
     bool is_plugin_active(std::string owner_name) const override;
-    void focus_view(wayfire_view v, bool raise) override;
     wf::dimensions_t get_screen_size() const override;
 
     void add_key(option_sptr_t<keybinding_t> key, wf::key_callback*) override;
@@ -86,11 +63,6 @@ class output_impl_t : public output_t
     void add_button(option_sptr_t<buttonbinding_t> button, wf::button_callback*) override;
     void add_activator(option_sptr_t<activatorbinding_t> activator, wf::activator_callback*) override;
     void rem_binding(void *callback) override;
-
-    wayfire_view get_active_view() const override;
-    void focus_node(wf::scene::node_ptr new_focus) override;
-    void refocus() override;
-    uint64_t get_last_focus_timestamp() const override;
 
     /**
      * Set the output as inhibited, so that no plugins can be activated

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -11,6 +11,8 @@
 #include <algorithm>
 #include <wayfire/nonstd/reverse.hpp>
 #include <wayfire/util/log.hpp>
+#include <wayfire/window-manager.hpp>
+#include <wayfire/seat.hpp>
 
 #include <wayfire/scene-operations.hpp>
 
@@ -627,7 +629,7 @@ struct workspace_set_t::impl
             if (output)
             {
                 output->emit(&vdata);
-                output->focus_view(v, true);
+                wf::get_core().default_wm->focus_raise_view(v, false);
             }
         }
 
@@ -635,7 +637,7 @@ struct workspace_set_t::impl
         if (output)
         {
             // Finally, do a refocus to update the keyboard focus
-            output->refocus();
+            wf::get_core().seat->refocus();
             output->emit(&data);
         }
 

--- a/src/view/layer-shell/layer-shell-node.cpp
+++ b/src/view/layer-shell/layer-shell-node.cpp
@@ -67,11 +67,11 @@ wf::keyboard_focus_node_t wf::layer_shell_node_t::keyboard_refocus(wf::output_t 
         return wf::keyboard_focus_node_t{};
     }
 
-    const uint64_t output_last_ts = view->get_output()->get_last_focus_timestamp();
-    const uint64_t our_ts = keyboard_interaction().last_focus_timestamp;
+    const uint64_t last_ts = wf::get_core().seat->get_last_focus_timestamp();
+    const uint64_t our_ts  = keyboard_interaction().last_focus_timestamp;
 
     auto cur_focus = wf::get_core_impl().seat->priv->keyboard_focus.get();
-    bool has_focus = (cur_focus == this) || (our_ts == output_last_ts);
+    bool has_focus = (cur_focus == this) || (our_ts == last_ts);
     if (has_focus)
     {
         return wf::keyboard_focus_node_t{this, focus_importance::REGULAR};

--- a/src/view/toplevel-view.cpp
+++ b/src/view/toplevel-view.cpp
@@ -7,8 +7,10 @@
 #include <wayfire/workarea.hpp>
 #include <wayfire/window-manager.hpp>
 #include <wayfire/txn/transaction-manager.hpp>
+#include <wayfire/seat.hpp>
 #include "view-impl.hpp"
 #include "wayfire/core.hpp"
+#include "wayfire/scene.hpp"
 #include "wayfire/view.hpp"
 
 static void reposition_relative_to_parent(wayfire_toplevel_view view)
@@ -87,9 +89,9 @@ static wayfire_toplevel_view find_toplevel_parent(wayfire_toplevel_view view)
 static void check_refocus_parent(wayfire_toplevel_view view)
 {
     view = find_toplevel_parent(view);
-    if (view->get_output() && (view->get_output()->get_active_view() == view))
+    if (wf::get_core().seat->get_active_view() == view)
     {
-        view->get_output()->focus_view(view, false);
+        wf::get_core().seat->focus_view(view);
     }
 }
 
@@ -216,6 +218,7 @@ void wf::toplevel_view_interface_t::set_minimized(bool minim)
             view_disappeared_signal data;
             data.view = self();
             get_output()->emit(&data);
+            wf::scene::update(get_root_node(), scene::update_flag::REFOCUS);
         }
     }
 }

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -58,6 +58,7 @@ void wf::view_interface_t::set_output(wf::output_t *new_output)
         view_disappeared_signal data_disappeared;
         data_disappeared.view = self();
         data.output->emit(&data_disappeared);
+        wf::scene::update(get_root_node(), scene::update_flag::REFOCUS);
     }
 }
 

--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -10,6 +10,8 @@
 #include "wayfire/debug.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/nonstd/tracking-allocator.hpp"
+#include "wayfire/scene.hpp"
+#include "wayfire/seat.hpp"
 #include "wayfire/util.hpp"
 #include "wayfire/view.hpp"
 #include <wayfire/output-layout.hpp>
@@ -154,7 +156,7 @@ std::shared_ptr<wf::xdg_toplevel_view_t> wf::xdg_toplevel_view_t::create(wlr_xdg
     self->set_surface_root_node(self->surface_root_node);
 
     // Set the output early, so that we can emit the signals on the output
-    self->set_output(wf::get_core().get_active_output());
+    self->set_output(wf::get_core().seat->get_active_output());
 
     self->handle_title_changed(nonull(toplevel->title));
     self->handle_app_id_changed(nonull(toplevel->app_id));
@@ -261,7 +263,7 @@ void wf::xdg_toplevel_view_t::map()
             get_output()->wset()->add_view({this});
         }
 
-        get_output()->focus_view(self(), true);
+        wf::get_core().default_wm->focus_request(self());
     }
 
     damage();
@@ -279,6 +281,7 @@ void wf::xdg_toplevel_view_t::unmap()
 
     emit_view_unmap();
     priv->set_mapped(false);
+    wf::scene::update(get_surface_root_node(), wf::scene::update_flag::INPUT_STATE);
 }
 
 void wf::xdg_toplevel_view_t::handle_toplevel_state_changed(wf::toplevel_state_t old_state)

--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -5,6 +5,7 @@
 #include "wayfire/core.hpp"
 #include "wayfire/debug.hpp"
 #include "wayfire/geometry.hpp"
+#include "wayfire/seat.hpp"
 #include "wayfire/scene-render.hpp"
 #include "wayfire/signal-provider.hpp"
 #include "wayfire/toplevel-view.hpp"
@@ -280,7 +281,7 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
         self->set_surface_root_node(self->surface_root_node);
 
         // Set the output early, so that we can emit the signals on the output
-        self->set_output(wf::get_core().get_active_output());
+        self->set_output(wf::get_core().seat->get_active_output());
         self->_initialize();
 
         self->update_decorated();
@@ -406,7 +407,7 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
             get_output()->wset()->add_view({this});
         }
 
-        get_output()->focus_view(self(), true);
+        wf::get_core().default_wm->focus_request(self());
 
         damage();
         emit_view_map();
@@ -425,6 +426,7 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
 
         emit_view_unmap();
         priv->set_mapped(false);
+        wf::scene::update(get_surface_root_node(), wf::scene::update_flag::INPUT_STATE);
     }
 
     void commit()

--- a/src/view/xwayland/xwayland-unmanaged-view.hpp
+++ b/src/view/xwayland/xwayland-unmanaged-view.hpp
@@ -9,6 +9,7 @@
 #include "xwayland-view-base.hpp"
 #include <wayfire/render-manager.hpp>
 #include <wayfire/scene-operations.hpp>
+#include <wayfire/window-manager.hpp>
 #include "../core/core-impl.hpp"
 #include "../core/seat/seat-impl.hpp"
 #include "../view-keyboard-interaction.hpp"
@@ -39,10 +40,10 @@ class xwayland_unmanaged_view_node_t : public wf::scene::translation_node_t, pub
             return wf::keyboard_focus_node_t{};
         }
 
-        const uint64_t output_last_ts = view->get_output()->get_last_focus_timestamp();
-        const uint64_t our_ts = keyboard_interaction().last_focus_timestamp;
+        const uint64_t last_ts = wf::get_core().seat->get_last_focus_timestamp();
+        const uint64_t our_ts  = keyboard_interaction().last_focus_timestamp;
         auto cur_focus = wf::get_core_impl().seat->priv->keyboard_focus.get();
-        bool has_focus = (cur_focus == this) || (our_ts == output_last_ts);
+        bool has_focus = (cur_focus == this) || (our_ts == last_ts);
         if (has_focus)
         {
             return wf::keyboard_focus_node_t{this, focus_importance::REGULAR};
@@ -181,7 +182,7 @@ class wayfire_unmanaged_xwayland_view : public wf::view_interface_t, public wayf
 
         if (priv->keyboard_focus_enabled)
         {
-            get_output()->focus_view(self(), true);
+            wf::get_core().default_wm->focus_request(self());
         }
 
         damage();


### PR DESCRIPTION
The keyboard input focus has always been a global state (to be precise, per-seat, but Wayfire has only one seat anyway). However, previously the focused view has been managed per-output, which makes little sense and does not reflect reality, nor the desired behavior. This commit moves all keyboard-focus functionality out of `wf::output_t` and into `wf::seat_t`.

Fixes #1892
