### PR TITLE
Always define WLR_USE_UNSTABLE

### DIFF
--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -1,5 +1,9 @@
 #pragma once
 
+#ifndef WLR_USE_UNSTABLE
+    #define WLR_USE_UNSTABLE
+#endif
+
 /**
  * This file is used to put all wlroots headers needed in the Wayfire API
  * in an extern "C" block because wlroots headers are not always compatible


### PR DESCRIPTION
Suggested improvement for #1918 

This is the simplest possible solution that will leave WLR_USE_UNSTABLE defined -- if this is not desired, I could change this to conditionally undefine it after the wlroots includes (if it was not originally defined).
