### PR TITLE
wm-actions: allow show desktop to be called from IPC (and other plugins)

### DIFF
--- a/plugins/wm-actions/meson.build
+++ b/plugins/wm-actions/meson.build
@@ -1,6 +1,6 @@
 wm_actions = shared_module('wm-actions',
                            ['wm-actions.cpp'],
-                           include_directories: [wayfire_api_inc, wayfire_conf_inc],
+                           include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc],
                            dependencies: [wlroots, pixman, wfconfig, json],
                            install: true,
                            install_dir: join_paths(get_option('libdir'), 'wayfire'))


### PR DESCRIPTION
Adding some more functionality in line with #1811 