### PR TITLE
build: Tell meson to ignore the return value of git commands

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -86,8 +86,8 @@ conf_data = configuration_data()
 version = '"@0@"'.format(meson.project_version())
 git = find_program('git', native: true, required: false)
 if git.found()
-	git_commit = run_command([git, 'rev-parse', '--short', 'HEAD'], check: true)
-	git_branch = run_command([git, 'rev-parse', '--abbrev-ref', 'HEAD'], check: true)
+	git_commit = run_command([git, 'rev-parse', '--short', 'HEAD'], check: false)
+	git_branch = run_command([git, 'rev-parse', '--abbrev-ref', 'HEAD'], check: false)
 	if git_commit.returncode() == 0 and git_branch.returncode() == 0
 		version = '"@0@-@1@ (" __DATE__ ", branch \'@2@\')"'.format(
 			meson.project_version(),


### PR DESCRIPTION
We grab the commit hash and branch name for use in the log, but this does not work when building from a tarball. Tell meson to ignore the return value by setting 'check: false' for git commands.