### PR TITLE
support reposition popups

### DIFF
--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -72,7 +72,7 @@ wayfire_xdg_popup::wayfire_xdg_popup(wlr_xdg_popup *popup) : wf::view_interface_
     {
         wf::view_implementation::emit_ping_timeout_signal(self());
     });
-    on_repostion.set_callback([&] (void*)
+    on_reposition.set_callback([&] (void*)
     {
         unconstrain();
     });
@@ -82,7 +82,7 @@ wayfire_xdg_popup::wayfire_xdg_popup(wlr_xdg_popup *popup) : wf::view_interface_
     on_destroy.connect(&popup->base->events.destroy);
     on_new_popup.connect(&popup->base->events.new_popup);
     on_ping_timeout.connect(&popup->base->events.ping_timeout);
-    on_repostion.connect(&popup->events.reposition);
+    on_reposition.connect(&popup->events.reposition);
 
     popup->base->data = this;
     parent_geometry_changed.set_callback([=] (auto)

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -227,6 +227,7 @@ void wayfire_xdg_popup::destroy()
     on_destroy.disconnect();
     on_new_popup.disconnect();
     on_ping_timeout.disconnect();
+    on_reposition.disconnect();
     popup = nullptr;
 }
 

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -72,12 +72,17 @@ wayfire_xdg_popup::wayfire_xdg_popup(wlr_xdg_popup *popup) : wf::view_interface_
     {
         wf::view_implementation::emit_ping_timeout_signal(self());
     });
+    on_repostion.set_callback([&] (void*)
+    {
+        unconstrain();
+    });
 
     on_map.connect(&popup->base->events.map);
     on_unmap.connect(&popup->base->events.unmap);
     on_destroy.connect(&popup->base->events.destroy);
     on_new_popup.connect(&popup->base->events.new_popup);
     on_ping_timeout.connect(&popup->base->events.ping_timeout);
+    on_repostion.connect(&popup->events.reposition);
 
     popup->base->data = this;
     parent_geometry_changed.set_callback([=] (auto)
@@ -350,7 +355,7 @@ static wlr_xdg_shell *xdg_handle = nullptr;
 void wf::init_xdg_shell()
 {
     static wf::wl_listener_wrapper on_xdg_created;
-    xdg_handle = wlr_xdg_shell_create(wf::get_core().display, 2);
+    xdg_handle = wlr_xdg_shell_create(wf::get_core().display, 3);
 
     if (xdg_handle)
     {

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -16,7 +16,7 @@ class wayfire_xdg_popup : public wf::view_interface_t
 {
   protected:
     wf::wl_listener_wrapper on_destroy, on_new_popup,
-        on_map, on_unmap, on_ping_timeout, on_repostion;
+        on_map, on_unmap, on_ping_timeout, on_reposition;
 
     wf::signal::connection_t<wf::view_geometry_changed_signal> parent_geometry_changed;
     wf::signal::connection_t<wf::view_title_changed_signal> parent_title_changed;

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -16,7 +16,7 @@ class wayfire_xdg_popup : public wf::view_interface_t
 {
   protected:
     wf::wl_listener_wrapper on_destroy, on_new_popup,
-        on_map, on_unmap, on_ping_timeout;
+        on_map, on_unmap, on_ping_timeout, on_repostion;
 
     wf::signal::connection_t<wf::view_geometry_changed_signal> parent_geometry_changed;
     wf::signal::connection_t<wf::view_title_changed_signal> parent_title_changed;


### PR DESCRIPTION
This implements [xdg-shell v3](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3514). GTK 4 can use the reposition functionality to move its popups, which avoids flickering by the fallback way to hide and show popups.

This is especially useful since Wayfire doesn't fully implement the wayland input protocol and input methods resort to client side rendering.

(This patch is adapted from an earlier patch about which I don't remember many details, but it works.)