### PR TITLE
Add `xkb_options` to `wayfire.ini`

### DIFF
--- a/wayfire.ini
+++ b/wayfire.ini
@@ -15,6 +15,7 @@
 # [input]
 # xkb_layout = us,fr
 # xkb_variant = dvorak,bepo
+# xkb_options = grp:win_space_toggle
 #
 # See Input options for a complete reference.
 # https://github.com/WayfireWM/wayfire/wiki/Configuration#input


### PR DESCRIPTION
This makes it clearer how to set the key to switch the keyboard layout, I think this should be included in the config because to use multiple layouts you need to set a way to switch between them. This was inspired by the discussion at #1326