### PR TITLE
xdg-popup: set keyboard focus surface to not null

### DIFF
--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -316,7 +316,7 @@ wf::geometry_t wayfire_xdg_popup::get_geometry()
 
 wlr_surface*wayfire_xdg_popup::get_keyboard_focus_surface()
 {
-    return nullptr;
+    return priv->wsurface;
 }
 
 /**


### PR DESCRIPTION
Popups may receive keyboard input.

Fixes a regression in google-chrome in Wayland mode.
