### PR TITLE
simple-tile: connect to workarea changed when creating wset

### DIFF
--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -86,6 +86,10 @@ class tile_workspace_set_data_t : public wf::custom_data_t
         wset->connect(&on_wset_attached);
         wset->connect(&on_workspace_grid_changed);
         resize_roots(wset->get_workspace_grid_size());
+        if (wset->get_attached_output())
+        {
+            wset->get_attached_output()->connect(&on_workarea_changed);
+        }
 
         inner_gaps.set_callback(update_gaps);
         outer_horiz_gaps.set_callback(update_gaps);


### PR DESCRIPTION
Otherwise, we only connect once the wset has been attached to another
output, which is too late.

Fixes #1983
