### PR TITLE
workspace-impl: return output size directly if output is attached

### DIFF
--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -757,6 +757,11 @@ uint64_t workspace_set_t::get_index() const
 
 std::optional<wf::geometry_t> workspace_set_t::get_last_output_geometry()
 {
+    if (pimpl->output)
+    {
+        return pimpl->output->get_relative_geometry();
+    }
+
     return pimpl->workspace_geometry;
 }
 


### PR DESCRIPTION
Fixes #1991

The idea is that otherwise we can have race conditions depending on the
order of the output-configuration-changed handlers.
