### PR TITLE
xwayland: do not honor request_activate() if the view is not mapped yet

### DIFF
--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -190,7 +190,7 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
         });
         on_request_activate.set_callback([&] (void*)
         {
-            if (!this->activated)
+            if (!this->activated && this->is_mapped())
             {
                 wf::get_core().default_wm->focus_request({this}, true);
             }


### PR DESCRIPTION
We can't really give focus to the view anyway.

Fixes a bug which I'm not sure how to trigger in a test, but otherwise happens if I open a GLFW window which crashes before showing anything.
