### PR TITLE
Move ensure_pointer() call to oswitch

### DIFF
--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -21,6 +21,7 @@ class wayfire_oswitch : public wf::plugin_interface_t
         idle_next_output.run_once([=] ()
         {
             wf::get_core().seat->focus_output(next);
+            next->ensure_pointer(true);
         });
 
         return true;
@@ -43,6 +44,7 @@ class wayfire_oswitch : public wf::plugin_interface_t
         idle_next_output.run_once([=] ()
         {
             wf::get_core().seat->focus_output(next);
+            next->ensure_pointer(true);
         });
 
         return true;

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -58,8 +58,6 @@ void wf::seat_t::focus_output(wf::output_t *wo)
     if (wo)
     {
         LOGC(KBD, "focus output: ", wo->handle->name);
-        /* Move to the middle of the output if this is the first output */
-        wo->ensure_pointer((priv->active_output == nullptr));
 
         refocus();
 


### PR DESCRIPTION
When a view is opened on another output than the focused one, i.e. with window-rules plugin, focus_output() was calling ensure_pointer() which was moving the pointer to the center of the output where the view was opened. Here we move the call to oswitch so this only happens when the user would want it to.

Fixes #2013.