### PR TITLE
Shortcuts inhibit core xml

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -7,7 +7,7 @@
 		<option name="plugins" type="string">
 			<_short>Plugins</_short>
 			<_long>Loads the specified plugins, space-separated list.</_long>
-			<default>alpha animate autostart command cube decoration expo fast-switcher fisheye foreign-toplevel grid gtk-shell idle invert move oswitch place resize switcher vswitch wayfire-shell window-rules wobbly wrot zoom</default>
+			<default>alpha animate autostart command cube decoration expo fast-switcher fisheye foreign-toplevel grid gtk-shell idle invert move oswitch place resize shortcuts-inhibit switcher vswitch wayfire-shell window-rules wobbly wrot zoom</default>
 		</option>
 		<option name="close_top_view" type="activator">
 			<_short>Close view</_short>

--- a/wayfire.ini
+++ b/wayfire.ini
@@ -64,6 +64,7 @@ plugins = \
   oswitch \
   place \
   resize \
+  shortcuts-inhibit \
   switcher \
   vswitch \
   wayfire-shell \


### PR DESCRIPTION
I think it would be beneficial if shortcuts-inhibit was enabled by default. I've added the plugin to core.xml and the sample wayfire.ini 