### PR TITLE
output: Implement adaptive sync option

### DIFF
--- a/metadata/output.xml
+++ b/metadata/output.xml
@@ -14,5 +14,8 @@
     <option name="transform" type="string">
       <default>normal</default>
     </option>
+    <option name="vrr" type="bool">
+      <default>false</default>
+    </option>
   </object>
 </wayfire>

--- a/src/api/wayfire/output-layout.hpp
+++ b/src/api/wayfire/output-layout.hpp
@@ -49,6 +49,8 @@ struct output_state_t
     wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
     /* The scale of the output */
     double scale = 1.0;
+    /* Whether or not adaptive sync is enabled */
+    bool vrr = false;
 
     /* Output to take the image from. Valid only if source is mirror */
     std::string mirror_from;

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -600,7 +600,7 @@ struct output_layout_output_t
             } else
             {
                 LOGE("Failed to change adaptive sync on output: ", handle->name);
-                wlr_output_enable_adaptive_sync(handle, adaptive_sync_enabled);
+                wlr_output_rollback(handle);
             }
         }
     }

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -588,31 +588,19 @@ struct output_layout_output_t
 
         wlr_output_commit(handle);
 
-        if ((handle->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED) && current_state.vrr)
+        const bool adaptive_sync_enabled = (handle->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED);
+
+        if (adaptive_sync_enabled != current_state.vrr)
         {
             wlr_output_enable_adaptive_sync(handle, current_state.vrr);
             if (wlr_output_test(handle))
             {
                 wlr_output_commit(handle);
-                LOGD("Enabled adaptive sync on output: ", handle->name);
+                LOGD("Changed adaptive sync on output: ", handle->name, " to ", current_state.vrr);
             } else
             {
-                LOGE("Failed to enable adaptive sync on output: ", handle->name);
-                wlr_output_enable_adaptive_sync(handle, false);
-            }
-        }
-
-        if ((handle->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED) && !current_state.vrr)
-        {
-            wlr_output_enable_adaptive_sync(handle, false);
-            if (wlr_output_test(handle))
-            {
-                wlr_output_commit(handle);
-                LOGD("Disabled adaptive sync on output: ", handle->name);
-            } else
-            {
-                LOGE("Failed to disable adaptive sync on output: ", handle->name);
-                wlr_output_enable_adaptive_sync(handle, true);
+                LOGE("Failed to change adaptive sync on output: ", handle->name);
+                wlr_output_enable_adaptive_sync(handle, adaptive_sync_enabled);
             }
         }
     }

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -205,6 +205,7 @@ bool output_state_t::operator ==(const output_state_t& other) const
     eq &= (mode.refresh == other.mode.refresh);
     eq &= (transform == other.transform);
     eq &= (scale == other.scale);
+    eq &= (vrr == other.vrr);
 
     return eq;
 }
@@ -231,6 +232,7 @@ struct output_layout_output_t
     wf::option_wrapper_t<wf::output_config::position_t> position_opt;
     wf::option_wrapper_t<double> scale_opt;
     wf::option_wrapper_t<std::string> transform_opt;
+    wf::option_wrapper_t<bool> vrr_opt;
 
     wf::option_wrapper_t<bool> use_ext_config{
         "workarounds/use_external_output_configuration"};
@@ -243,6 +245,7 @@ struct output_layout_output_t
         position_opt.load_option(name + "/position");
         scale_opt.load_option(name + "/scale");
         transform_opt.load_option(name + "/transform");
+        vrr_opt.load_option(name + "/vrr");
     }
 
     output_layout_output_t(wlr_output *handle)
@@ -436,6 +439,7 @@ struct output_layout_output_t
 
         state.scale     = scale_opt;
         state.transform = get_transform_from_string(transform_opt);
+        state.vrr = vrr_opt;
         return state;
     }
 
@@ -557,7 +561,8 @@ struct output_layout_output_t
             /* Do not modeset if nothing changed */
             if ((handle->current_mode->width == mode.width) &&
                 (handle->current_mode->height == mode.height) &&
-                (handle->current_mode->refresh == mode.refresh))
+                (handle->current_mode->refresh == mode.refresh) &&
+                ((handle->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED) == current_state.vrr))
             {
                 /* Commit the enabling of the output */
                 wlr_output_commit(handle);
@@ -582,6 +587,34 @@ struct output_layout_output_t
         }
 
         wlr_output_commit(handle);
+
+        if ((handle->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_DISABLED) && current_state.vrr)
+        {
+            wlr_output_enable_adaptive_sync(handle, current_state.vrr);
+            if (wlr_output_test(handle))
+            {
+                wlr_output_commit(handle);
+                LOGD("Enabled adaptive sync on output: ", handle->name);
+            } else
+            {
+                LOGE("Failed to enable adaptive sync on output: ", handle->name);
+                wlr_output_enable_adaptive_sync(handle, false);
+            }
+        }
+
+        if ((handle->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED) && !current_state.vrr)
+        {
+            wlr_output_enable_adaptive_sync(handle, false);
+            if (wlr_output_test(handle))
+            {
+                wlr_output_commit(handle);
+                LOGD("Disabled adaptive sync on output: ", handle->name);
+            } else
+            {
+                LOGE("Failed to disable adaptive sync on output: ", handle->name);
+                wlr_output_enable_adaptive_sync(handle, true);
+            }
+        }
     }
 
     /* Mirroring implementation */
@@ -978,6 +1011,7 @@ class output_layout_t::impl
             state.position  = {head->state.x, head->state.y};
             state.scale     = head->state.scale;
             state.transform = head->state.transform;
+            state.vrr = head->state.adaptive_sync_enabled;
         }
 
         return result;


### PR DESCRIPTION
Enable by setting [output:<NAME>] vrr = true, or using a client like wlr-randr.

Fixes #1009.