### PR TITLE
Fix memory leak when activating cube plugin

### DIFF
--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -81,6 +81,17 @@ class wayfire_cube : public wf::per_output_plugin_instance_t, public wf::pointer
                 }
             }
 
+            ~cube_render_instance_t()
+            {
+                OpenGL::render_begin();
+                for (auto& buf : framebuffers)
+                {
+                    buf.release();
+                }
+
+                OpenGL::render_end();
+            }
+
             void schedule_instructions(
                 std::vector<wf::scene::render_instruction_t>& instructions,
                 const wf::render_target_t& target, wf::region_t& damage) override


### PR DESCRIPTION
Currently it looks like the framebuffers are allocated on activate but never released. This causes a substantial memory leak. Fix this by adding a destructor to cube_render_instance_t that releases them.

Fixes #2059