### PR TITLE
ipc-scripts: fix wrong command name

### DIFF
--- a/ipc-scripts/move-to-workspace.py
+++ b/ipc-scripts/move-to-workspace.py
@@ -12,7 +12,7 @@ from wayfire_socket import *
 
 
 def move_to_workspace(s: WayfireSocket, view, ws_x: int, ws_y: int):
-    output = s.query_output(view["output"])
+    output = s.query_output(view["output-id"])
     xsize = output["workarea"]["width"]
     ysize = output["workarea"]["height"]
     cur_ws_x = output["workspace"]["x"]

--- a/ipc-scripts/wayfire_socket.py
+++ b/ipc-scripts/wayfire_socket.py
@@ -60,7 +60,7 @@ class WayfireSocket:
         return self.send_json(message)
 
     def list_views(self):
-        return self.send_json(get_msg_template("window-rules/list_views"))
+        return self.send_json(get_msg_template("window-rules/list-views"))
 
     def configure_view(self, view_id: int, x: int, y: int, w: int, h: int):
         message = get_msg_template("window-rules/configure-view")


### PR DESCRIPTION
This fixes the list_views method and the move-to-workspace.py example script.