### PR TITLE
Listen to tiled signal in deco plugin and emit view_tiled signal on core

### DIFF
--- a/plugins/decor/decoration.cpp
+++ b/plugins/decor/decoration.cpp
@@ -58,11 +58,19 @@ class wayfire_decoration : public wf::plugin_interface_t
         update_view_decoration(ev->view);
     };
 
+    // allows criteria containing maximized or floating check
+    wf::signal::connection_t<wf::view_tiled_signal> on_view_tiled =
+        [=] (wf::view_tiled_signal *ev)
+    {
+        update_view_decoration(ev->view);
+    };
+
   public:
     void init() override
     {
         wf::get_core().connect(&on_decoration_state_changed);
         wf::get_core().tx_manager->connect(&on_new_tx);
+        wf::get_core().connect(&on_view_tiled);
 
         for (auto& view : wf::get_core().get_all_views())
         {

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -118,6 +118,7 @@ void wf::view_implementation::emit_toplevel_state_change_signals(wayfire_topleve
         data.new_edges = view->toplevel()->current().tiled_edges;
 
         view->emit(&data);
+        wf::get_core().emit(&data);
         if (view->get_output())
         {
             view->get_output()->emit(&data);
@@ -130,6 +131,7 @@ void wf::view_implementation::emit_toplevel_state_change_signals(wayfire_topleve
         data.view  = view;
         data.state = view->toplevel()->current().fullscreen;
         view->emit(&data);
+        wf::get_core().emit(&data);
         if (view->get_output())
         {
             view->get_output()->emit(&data);


### PR DESCRIPTION
Fixes https://github.com/timgott/wayfire-shadows/issues/19 and partially https://github.com/WayfireWM/wayfire/issues/2043

For the decoration plugin that should be very low overhead even if the maximized criterion is not used, so why not.

But please, can all view signals be consistently emitted on view, output and core at once.