### PR TITLE
add keybindings: prev_output, prev_output_with_win

### DIFF
--- a/metadata/oswitch.xml
+++ b/metadata/oswitch.xml
@@ -14,5 +14,15 @@
 			<_long>Moves focus to the next output with the focused window with the specified activator.</_long>
 			<default>&lt;super&gt; &lt;shift&gt; KEY_O</default>
 		</option>
+		<option name="prev_output" type="activator">
+			<_short>Previous output</_short>
+			<_long>Moves focus to the previous output with the specified activator.</_long>
+			<default></default>
+		</option>
+		<option name="prev_output_with_win" type="activator">
+			<_short>Previous output with window</_short>
+			<_long>Moves focus to the previous output with the focused window with the specified activator.</_long>
+			<default></default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -9,44 +9,74 @@
 
 class wayfire_oswitch : public wf::plugin_interface_t
 {
-    wf::wl_idle_call idle_next_output;
+    wf::wl_idle_call idle_switch_output;
 
-    wf::activator_callback switch_output = [=] (auto)
+    wf::output_t* get_output_relative(wf::output_t *output, int step)
+    {
+        /* get the target output n steps after the provided output
+         * if the provided output's index is i, and if there're n monitors
+         * then return the (i + step) mod n th monitor */
+        auto os = wf::get_core().output_layout->get_outputs();
+        auto it = std::find(os.begin(), os.end(), output);
+        int size = os.size();
+        int current_index = it - os.begin();
+        int target_index = ((current_index + step) % size + size) % size;
+        return os[target_index];
+    }
+
+    void switch_to_output(wf::output_t* target_output)
     {
         /* when we switch the output, the oswitch keybinding
          * may be activated for the next output, which we don't want,
          * so we postpone the switch */
-        auto current_output = wf::get_core().seat->get_active_output();
-        auto next = wf::get_core().output_layout->get_next_output(current_output);
-        idle_next_output.run_once([=] ()
+        idle_switch_output.run_once([=] ()
         {
-            wf::get_core().seat->focus_output(next);
-            next->ensure_pointer(true);
+            wf::get_core().seat->focus_output(target_output);
+            target_output->ensure_pointer(true);
         });
+    }
 
+    void switch_to_output_with_window(wf::output_t* target_output)
+    {
+        auto current_output = wf::get_core().seat->get_active_output();
+        auto view = wf::toplevel_cast(wf::get_active_view_for_output(current_output));
+        LOGI("Found view ", view);
+        if (view)
+        {
+            move_view_to_output(view, target_output, true);
+        }
+        switch_to_output(target_output);
+    }
+
+    wf::activator_callback next_output = [=] (auto)
+    {
+        auto current_output = wf::get_core().seat->get_active_output();
+        auto target_output = get_output_relative(current_output, 1);
+        switch_to_output(target_output);
         return true;
     };
 
-    wf::activator_callback switch_output_with_window = [=] (auto)
+    wf::activator_callback next_output_with_window = [=] (auto)
     {
         auto current_output = wf::get_core().seat->get_active_output();
-        auto next = wf::get_core().output_layout->get_next_output(current_output);
-        auto view = wf::toplevel_cast(wf::get_active_view_for_output(current_output));
-        LOGI("Found view ", view);
-        if (!view)
-        {
-            switch_output(wf::activator_data_t{});
+        auto target_output = get_output_relative(current_output, 1);
+        switch_to_output_with_window(target_output);
+        return true;
+    };
 
-            return true;
-        }
+    wf::activator_callback prev_output = [=] (auto)
+    {
+        auto current_output = wf::get_core().seat->get_active_output();
+        auto target_output = get_output_relative(current_output, -1);
+        switch_to_output(target_output);
+        return true;
+    };
 
-        move_view_to_output(view, next, true);
-        idle_next_output.run_once([=] ()
-        {
-            wf::get_core().seat->focus_output(next);
-            next->ensure_pointer(true);
-        });
-
+    wf::activator_callback prev_output_with_window = [=] (auto)
+    {
+        auto current_output = wf::get_core().seat->get_active_output();
+        auto target_output = get_output_relative(current_output, -1);
+        switch_to_output_with_window(target_output);
         return true;
     };
 
@@ -55,17 +85,23 @@ class wayfire_oswitch : public wf::plugin_interface_t
     {
         auto& bindings = wf::get_core().bindings;
         bindings->add_activator(wf::option_wrapper_t<wf::activatorbinding_t>{"oswitch/next_output"},
-            &switch_output);
+            &next_output);
         bindings->add_activator(wf::option_wrapper_t<wf::activatorbinding_t>{"oswitch/next_output_with_win"},
-            &switch_output_with_window);
+            &next_output_with_window);
+        bindings->add_activator(wf::option_wrapper_t<wf::activatorbinding_t>{"oswitch/prev_output"},
+            &prev_output);
+        bindings->add_activator(wf::option_wrapper_t<wf::activatorbinding_t>{"oswitch/prev_output_with_win"},
+            &prev_output_with_window);
     }
 
     void fini()
     {
         auto& bindings = wf::get_core().bindings;
-        bindings->rem_binding(&switch_output);
-        bindings->rem_binding(&switch_output_with_window);
-        idle_next_output.disconnect();
+        bindings->rem_binding(&next_output);
+        bindings->rem_binding(&next_output_with_window);
+        bindings->rem_binding(&prev_output);
+        bindings->rem_binding(&prev_output_with_window);
+        idle_switch_output.disconnect();
     }
 };
 

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -11,20 +11,27 @@ class wayfire_oswitch : public wf::plugin_interface_t
 {
     wf::wl_idle_call idle_switch_output;
 
-    wf::output_t* get_output_relative(wf::output_t *output, int step)
+    wf::output_t *get_output_relative(int step)
     {
-        /* get the target output n steps after the provided output
-         * if the provided output's index is i, and if there're n monitors
+        /* get the target output n steps after current output
+         * if current output's index is i, and if there're n monitors
          * then return the (i + step) mod n th monitor */
+        auto current_output = wf::get_core().seat->get_active_output();
         auto os = wf::get_core().output_layout->get_outputs();
-        auto it = std::find(os.begin(), os.end(), output);
+        auto it = std::find(os.begin(), os.end(), current_output);
+        if (it == os.end())
+        {
+            LOGI("Current output not found in output list");
+            return current_output;
+        }
+
         int size = os.size();
         int current_index = it - os.begin();
-        int target_index = ((current_index + step) % size + size) % size;
+        int target_index  = ((current_index + step) % size + size) % size;
         return os[target_index];
     }
 
-    void switch_to_output(wf::output_t* target_output)
+    void switch_to_output(wf::output_t *target_output)
     {
         /* when we switch the output, the oswitch keybinding
          * may be activated for the next output, which we don't want,
@@ -36,7 +43,7 @@ class wayfire_oswitch : public wf::plugin_interface_t
         });
     }
 
-    void switch_to_output_with_window(wf::output_t* target_output)
+    void switch_to_output_with_window(wf::output_t *target_output)
     {
         auto current_output = wf::get_core().seat->get_active_output();
         auto view = wf::toplevel_cast(wf::get_active_view_for_output(current_output));
@@ -45,37 +52,34 @@ class wayfire_oswitch : public wf::plugin_interface_t
         {
             move_view_to_output(view, target_output, true);
         }
+
         switch_to_output(target_output);
     }
 
     wf::activator_callback next_output = [=] (auto)
     {
-        auto current_output = wf::get_core().seat->get_active_output();
-        auto target_output = get_output_relative(current_output, 1);
+        auto target_output = get_output_relative(1);
         switch_to_output(target_output);
         return true;
     };
 
     wf::activator_callback next_output_with_window = [=] (auto)
     {
-        auto current_output = wf::get_core().seat->get_active_output();
-        auto target_output = get_output_relative(current_output, 1);
+        auto target_output = get_output_relative(1);
         switch_to_output_with_window(target_output);
         return true;
     };
 
     wf::activator_callback prev_output = [=] (auto)
     {
-        auto current_output = wf::get_core().seat->get_active_output();
-        auto target_output = get_output_relative(current_output, -1);
+        auto target_output = get_output_relative(-1);
         switch_to_output(target_output);
         return true;
     };
 
     wf::activator_callback prev_output_with_window = [=] (auto)
     {
-        auto current_output = wf::get_core().seat->get_active_output();
-        auto target_output = get_output_relative(current_output, -1);
+        auto target_output = get_output_relative(-1);
         switch_to_output_with_window(target_output);
         return true;
     };


### PR DESCRIPTION
provide an api `wf::output_t *get_prev_output(wf::output_t *output)` in core/output-layout.hpp
and use this api to implement `prev_output` and `prev_output_with_win`
fixes #2071 