### PR TITLE
views: emit pre_unmap immediately when starting a transaction

### DIFF
--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -69,8 +69,6 @@ void wf::xdg_toplevel_view_base_t::map()
 void wf::xdg_toplevel_view_base_t::unmap()
 {
     damage();
-    emit_view_pre_unmap();
-
     priv->unset_mapped_surface_contents();
 
     emit_view_unmap();
@@ -506,6 +504,8 @@ void wf::xdg_toplevel_view_t::start_map_tx()
 
 void wf::xdg_toplevel_view_t::start_unmap_tx()
 {
+    emit_view_pre_unmap();
+
     // Take reference until the view has been unmapped
     _self_ref = shared_from_this();
     wtoplevel->pending().mapped = false;

--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -17,6 +17,7 @@
 #include "xwayland-toplevel.hpp"
 #include <wayfire/txn/transaction-manager.hpp>
 #include <wayfire/view-helpers.hpp>
+#include "../toplevel-node.hpp"
 
 #if WF_HAS_XWAYLAND
 
@@ -372,6 +373,7 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
 
     void handle_unmap_request() override
     {
+        emit_view_pre_unmap();
         // Store a reference to this until the view is actually unmapped with a transaction.
         _self_ref = shared_from_this();
         toplevel->set_main_surface(nullptr);

--- a/src/view/xwayland/xwayland-unmanaged-view.hpp
+++ b/src/view/xwayland/xwayland-unmanaged-view.hpp
@@ -180,15 +180,9 @@ class wayfire_unmanaged_xwayland_view : public wayfire_xwayland_view_internal_ba
     void handle_unmap_request() override
     {
         LOGC(XWL, "Unmapping unmanaged xwayland surface ", self());
-        damage();
         emit_view_pre_unmap();
-
-        main_surface = nullptr;
-        priv->unset_mapped_surface_contents();
         on_surface_commit.disconnect();
-
-        emit_view_unmap();
-        priv->set_mapped(false);
+        do_unmap();
     }
 
     void destroy() override

--- a/src/view/xwayland/xwayland-view-base.cpp
+++ b/src/view/xwayland/xwayland-view-base.cpp
@@ -1,4 +1,6 @@
-#include "xwayland-view-base.hpp"
+#include "wayfire/unstable/xwl-toplevel-base.hpp"
+#include "wayfire/view-helpers.hpp"
+#include "../view-impl.hpp"
 
 #if WF_HAS_XWAYLAND
 
@@ -59,8 +61,6 @@ void wf::xwayland_view_base_t::do_map(wlr_surface *surface, bool autocommit, boo
 void wf::xwayland_view_base_t::do_unmap()
 {
     damage();
-    emit_view_pre_unmap();
-
     main_surface = nullptr;
     priv->unset_mapped_surface_contents();
 

--- a/src/view/xwayland/xwayland-view-base.hpp
+++ b/src/view/xwayland/xwayland-view-base.hpp
@@ -6,12 +6,7 @@
 #include <wayfire/workarea.hpp>
 #include <wayfire/signal-definitions.hpp>
 
-#include "../view-impl.hpp"
-#include "../toplevel-node.hpp"
-#include "wayfire/core.hpp"
-#include "wayfire/geometry.hpp"
 #include "wayfire/util.hpp"
-#include "wayfire/view.hpp"
 #include "xwayland-helpers.hpp"
 #include <wayfire/scene-operations.hpp>
 #include <wayfire/view-helpers.hpp>


### PR DESCRIPTION
The idea is that if the transaction is delayed, the surfaces and their textures may be destroyed. So, we need to emit the signal as soon as possible.

Fixes #2014
