### PR TITLE
disable unity builds in one of the CIs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
     - run: (cd subprojects/wlroots && meson build --prefix=/usr && ninja -C build install)
-    - run: meson build -Dtests=enabled -Db_pch=true -Duse_system_wlroots=enabled --unity on
+    - run: meson build -Dtests=enabled -Db_pch=true -Duse_system_wlroots=enabled
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_glibc_llvm:


### PR DESCRIPTION
Unfortunately, unity builds are not very well suited for the CI because they merge all files together. As a result, we may forget includes (like happened in #2053). Therefore, this PR disables unity builds in one of the two CI builds.
