### PR TITLE
Support for wlr_drm_lease_v1

### DIFF
--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -139,6 +139,7 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
         wlr_presentation *presentation;
         wlr_primary_selection_v1_device_manager *primary_selection_v1;
         wlr_viewporter *viewporter;
+        wlr_drm_lease_v1_manager *drm_v1;
 
         wlr_xdg_foreign_registry *foreign_registry;
         wlr_xdg_foreign_v1 *foreign_v1;

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -101,6 +101,7 @@ extern "C"
 #endif
 #include <wlr/types/wlr_gamma_control_v1.h>
 #include <wlr/types/wlr_xdg_output_v1.h>
+#include <wlr/types/wlr_drm_lease_v1.h>
 
 // Input
 #include <wlr/types/wlr_seat.h>

--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -37,6 +37,7 @@ extern "C"
     struct wlr_text_input_manager_v3;
     struct wlr_presentation;
     struct wlr_primary_selection_v1_device_manager;
+    struct wlr_drm_lease_v1_manager;
 
     struct wlr_xdg_foreign_v1;
     struct wlr_xdg_foreign_v2;

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -76,6 +76,7 @@ class compositor_core_impl_t : public compositor_core_t
     wf::wl_listener_wrapper input_inhibit_deactivated;
     wf::wl_listener_wrapper pointer_constraint_added;
     wf::wl_listener_wrapper idle_inhibitor_created;
+    wf::wl_listener_wrapper drm_lease_request;
     std::shared_ptr<scene::root_node_t> scene_root;
 
     compositor_state_t state = compositor_state_t::UNKNOWN;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -126,7 +126,14 @@ void wf::compositor_core_impl_t::init()
             wlr_drm_lease_request_v1_reject(req);
         }
     });
-    drm_lease_request.connect(&protocols.drm_v1->events.request);
+    if (protocols.drm_v1)
+    {
+        drm_lease_request.connect(&protocols.drm_v1->events.request);
+    }
+    else
+    {
+        LOGI("Failed to create wlr_drm_lease_device_v1; VR will not be available!");
+    }
 
     
     /* input-inhibit setup */

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -118,7 +118,7 @@ void wf::compositor_core_impl_t::init()
     protocols.output_manager = wlr_xdg_output_manager_v1_create(display,
         output_layout->get_handle());
     protocols.drm_v1 = wlr_drm_lease_v1_manager_create(display, backend);
-    drm_lease_request.set_callback([&] (void* data)
+    drm_lease_request.set_callback([&] (void *data)
     {
         auto req = static_cast<wlr_drm_lease_request_v1*>(data);
         struct wlr_drm_lease_v1 *lease = wlr_drm_lease_request_v1_grant(req);
@@ -130,13 +130,11 @@ void wf::compositor_core_impl_t::init()
     if (protocols.drm_v1)
     {
         drm_lease_request.connect(&protocols.drm_v1->events.request);
-    }
-    else
+    } else
     {
         LOGE("Failed to create wlr_drm_lease_device_v1; VR will not be available!");
     }
 
-    
     /* input-inhibit setup */
     protocols.input_inhibit = wlr_input_inhibit_manager_create(display);
     input_inhibit_activated.set_callback([&] (void*)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -117,7 +117,18 @@ void wf::compositor_core_impl_t::init()
     protocols.export_dmabuf  = wlr_export_dmabuf_manager_v1_create(display);
     protocols.output_manager = wlr_xdg_output_manager_v1_create(display,
         output_layout->get_handle());
+    protocols.drm_v1 = wlr_drm_lease_v1_manager_create(display, backend);
+    drm_lease_request.set_callback([&] (void* data)
+    {
+        auto req = static_cast<wlr_drm_lease_request_v1*>(data);
+        struct wlr_drm_lease_v1 *lease = wlr_drm_lease_request_v1_grant(req);
+        if (!lease) {
+            wlr_drm_lease_request_v1_reject(req);
+        }
+    });
+    drm_lease_request.connect(&protocols.drm_v1->events.request);
 
+    
     /* input-inhibit setup */
     protocols.input_inhibit = wlr_input_inhibit_manager_create(display);
     input_inhibit_activated.set_callback([&] (void*)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -122,7 +122,8 @@ void wf::compositor_core_impl_t::init()
     {
         auto req = static_cast<wlr_drm_lease_request_v1*>(data);
         struct wlr_drm_lease_v1 *lease = wlr_drm_lease_request_v1_grant(req);
-        if (!lease) {
+        if (!lease)
+        {
             wlr_drm_lease_request_v1_reject(req);
         }
     });
@@ -132,7 +133,7 @@ void wf::compositor_core_impl_t::init()
     }
     else
     {
-        LOGI("Failed to create wlr_drm_lease_device_v1; VR will not be available!");
+        LOGE("Failed to create wlr_drm_lease_device_v1; VR will not be available!");
     }
 
     

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1085,10 +1085,10 @@ class output_layout_t::impl
 
         if (output->non_desktop)
         {
-            LOGI("NON DESKTOP OUTPUT FOUND");
+            LOGD("Non-desktop output ", output->name, " found");
             if (get_core().protocols.drm_v1)
             {
-                LOGI("DRM LEASE OFFERED");
+                LOGD("Drm lease offered to ", output->name);
                 wlr_drm_lease_v1_manager_offer_output(get_core().protocols.drm_v1, output);
             }
             return;

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1091,6 +1091,7 @@ class output_layout_t::impl
                 LOGD("Drm lease offered to ", output->name);
                 wlr_drm_lease_v1_manager_offer_output(get_core().protocols.drm_v1, output);
             }
+
             return;
         }
 

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1083,19 +1083,22 @@ class output_layout_t::impl
         LOGI("new output: ", output->name,
             " (\"", output->make, " ", output->model, " ", output->serial, "\")");
 
+        if (output->non_desktop)
+        {
+            LOGI("NON DESKTOP OUTPUT FOUND");
+            if (get_core().protocols.drm_v1)
+            {
+                LOGI("DRM LEASE OFFERED");
+                wlr_drm_lease_v1_manager_offer_output(get_core().protocols.drm_v1, output);
+            }
+            return;
+        }
+
         if (!wlr_output_init_render(output,
             get_core().allocator, get_core().renderer))
         {
             LOGE("failed to init wlr render for output ", output->name);
             return;
-        }
-
-        if (output->non_desktop)
-        {
-            if (get_core().protocols.drm_v1)
-            {
-                wlr_drm_lease_v1_manager_offer_output(get_core().protocols.drm_v1, output);
-            }
         }
 
         auto lo = new output_layout_output_t(output);

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1090,6 +1090,14 @@ class output_layout_t::impl
             return;
         }
 
+        if (output->non_desktop)
+        {
+            if (get_core().protocols.drm_v1)
+            {
+                wlr_drm_lease_v1_manager_offer_output(get_core().protocols.drm_v1, output);
+            }
+        }
+
         auto lo = new output_layout_output_t(output);
         outputs[output] = std::unique_ptr<output_layout_output_t>(lo);
         lo->on_destroy.set_callback([output, this] (void*)


### PR DESCRIPTION
First time with C++ and wlroots, so not sure if everything here is exactly proper C++. This is based off of how swaywm handles DRM leasing. I'm running on Fedora Silverblue via my own image based off of Universal Blue, and I used SteamVR in an Arch Linux container via Distrobox. It seems to work fine with my HTC Vive, but I've only tested this for a few minutes. It should work fine with other native VR headsets, but I don't have any to test. It should also work fine with other VR runtimes such as Monado, but I haven't figured out how to set that up yet.

Fixes #1581 