### PR TITLE
main: ignore SIGPIPE globally.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -311,6 +311,9 @@ int main(int argc, char *argv[])
         }
     }
 
+    /* Don't crash on SIGPIPE, e.g., when doing IPC to a client whose fd has been closed. */
+    signal(SIGPIPE, SIG_IGN);
+
     wf::log::initialize_logging(std::cout, log_level, detect_color_mode());
 
     parse_extended_debugging(extended_debug_categories);


### PR DESCRIPTION
By default, writing to a pipe that has been closed terminates the program with SIGPIPE. Ignoring SIGPIPE results in the syscall failing with EPIPE instead.

This generally prevents crashing on IPCs. One crash I found is in write_selection_property_to_wl_client when using xpra to run remote apps. If xpra updates the selection too often, wayfire crashes with SIGPIPE. But this probably prevents other crashes in general. It also matches what other compositors do, e.g., sway also globally ignores SIGPIPE to prevent crashes caused by IPCs.