### PR TITLE
Add subsurfaces to the back that are meant to be below the parent surface

### DIFF
--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -45,6 +45,15 @@ wf::wlr_surface_controller_t::wlr_surface_controller_t(wlr_surface *surface,
         // Allocate memory, it will be auto-freed when the wlr objects are destroyed
         auto sub_controller = new wlr_subsurface_controller_t(sub);
         create_controller(sub->surface, sub_controller->get_subsurface_root());
+        wlr_subsurface *s;
+        wl_list_for_each(s, &surface->current.subsurfaces_below, current.link)
+        {
+            if (sub == s)
+            {
+                wf::scene::add_back(this->root, sub_controller->get_subsurface_root());
+                return;
+            }
+        }
         wf::scene::add_front(this->root, sub_controller->get_subsurface_root());
     });
 


### PR DESCRIPTION
Most applications add their subsurfaces above the parent, so we were blindly adding them to the front. This patch checks if the subsurface should be below, and adds it to the back in that case, or else adds it to the front.

Fixes #1206.
Fixes #1615.