### PR TITLE
ipc: make client interface really an interface

### DIFF
--- a/plugins/ipc/ipc.cpp
+++ b/plugins/ipc/ipc.cpp
@@ -123,7 +123,7 @@ void wf::ipc::server_t::client_disappeared(client_t *client)
 
     client_disconnected_signal ev;
     ev.client = client;
-    this->emit(&ev);
+    method_repository->emit(&ev);
 
     auto it = std::remove_if(clients.begin(), clients.end(),
         [&] (const auto& cl) { return cl.get() == client; });
@@ -133,9 +133,7 @@ void wf::ipc::server_t::client_disappeared(client_t *client)
 void wf::ipc::server_t::handle_incoming_message(
     client_t *client, nlohmann::json message)
 {
-    this->current_client = client;
-    client->send_json(method_repository->call_method(message["method"], message["data"]));
-    this->current_client = nullptr;
+    client->send_json(method_repository->call_method(message["method"], message["data"], client));
 }
 
 /* --------------------------- Per-client code ------------------------------*/

--- a/plugins/ipc/ipc.hpp
+++ b/plugins/ipc/ipc.hpp
@@ -3,11 +3,9 @@
 #include <nlohmann/json.hpp>
 #include <sys/un.h>
 #include <wayfire/object.hpp>
-#include <variant>
 #include <wayland-server.h>
 #include <wayfire/plugins/common/shared-core-data.hpp>
 #include "ipc-method-repository.hpp"
-#include "wayfire/signal-provider.hpp"
 
 namespace wf
 {
@@ -17,12 +15,12 @@ namespace ipc
  * Represents a single connected client to the IPC socket.
  */
 class server_t;
-class client_t
+class client_t : public client_interface_t
 {
   public:
     client_t(server_t *server, int client_fd);
     ~client_t();
-    void send_json(nlohmann::json json);
+    void send_json(nlohmann::json json) override;
 
   private:
     int fd;
@@ -39,39 +37,20 @@ class client_t
 };
 
 /**
- * A signal emitted on the ipc server when a client disconnects.
- */
-struct client_disconnected_signal
-{
-    client_t *client;
-};
-
-/**
  * The IPC server is a singleton object accessed via shared_data::ref_ptr_t.
  * It represents the IPC socket used for communication with clients.
  */
-class server_t : public wf::signal::provider_t
+class server_t
 {
   public:
     server_t();
     void init(std::string socket_path);
     ~server_t();
 
-    /**
-     * While a method call is being executed, this function may be called to determine the client which
-     * called it.
-     */
-    client_t *get_current_request_client()
-    {
-        return current_client;
-    }
-
   private:
     friend class client_t;
     wf::shared_data::ref_ptr_t<wf::ipc::method_repository_t> method_repository;
 
-    // Valid only during a method call!
-    client_t *current_client = nullptr;
     void handle_incoming_message(client_t *client, nlohmann::json message);
 
     void client_disappeared(client_t *client);

--- a/plugins/ipc/meson.build
+++ b/plugins/ipc/meson.build
@@ -23,4 +23,4 @@ demoipc = shared_module('demo-ipc',
     install: true,
     install_dir: conf_data.get('PLUGIN_PATH'))
 
-install_headers(['ipc-method-repository.hpp', 'ipc.hpp', 'ipc-helpers.hpp', 'ipc-activator.hpp'], subdir: 'wayfire/plugins/ipc')
+install_headers(['ipc-method-repository.hpp', 'ipc-helpers.hpp', 'ipc-activator.hpp'], subdir: 'wayfire/plugins/ipc')

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -2,21 +2,17 @@
 #include "wayfire/plugin.hpp"
 #include "wayfire/plugins/common/shared-core-data.hpp"
 #include "wayfire/toplevel-view.hpp"
-#include "wayfire/unstable/wlr-surface-node.hpp"
 #include "wayfire/util.hpp"
-#include "wayfire/view-helpers.hpp"
 #include <wayfire/view.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/output-layout.hpp>
 #include <wayfire/txn/transaction-manager.hpp>
 #include "src/view/view-impl.hpp"
+#include <variant>
 
 #define WAYFIRE_PLUGIN
 #include <wayfire/debug.hpp>
-
-#include "ipc.hpp"
-#include "ipc-helpers.hpp"
 #include <wayfire/touch/touch.hpp>
 
 extern "C" {

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -8,10 +8,8 @@
 #include <set>
 
 #include "plugins/ipc/ipc-helpers.hpp"
-#include "plugins/ipc/ipc.hpp"
 #include "plugins/ipc/ipc-method-repository.hpp"
 #include "wayfire/core.hpp"
-#include "wayfire/object.hpp"
 #include "wayfire/plugins/common/util.hpp"
 #include "wayfire/unstable/wlr-surface-node.hpp"
 #include "wayfire/plugins/common/shared-core-data.hpp"
@@ -20,7 +18,6 @@
 #include "wayfire/view-helpers.hpp"
 #include "wayfire/window-manager.hpp"
 #include "wayfire/workarea.hpp"
-#include "wayfire/workspace-set.hpp"
 #include "config.h"
 #include <wayfire/nonstd/wlroots-full.hpp>
 
@@ -141,7 +138,7 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
         method_repository->register_method("window-rules/configure-view", configure_view);
         method_repository->register_method("window-rules/focus-view", focus_view);
         method_repository->register_method("window-rules/get-focused-view", get_focused_view);
-        ipc_server->connect(&on_client_disconnected);
+        method_repository->connect(&on_client_disconnected);
         wf::get_core().connect(&on_view_mapped);
         wf::get_core().connect(&on_kbfocus_changed);
         init_output_tracking();
@@ -346,14 +343,14 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
 
   private:
     wf::shared_data::ref_ptr_t<wf::ipc::method_repository_t> method_repository;
-    wf::shared_data::ref_ptr_t<wf::ipc::server_t> ipc_server;
 
     // Track a list of clients which have requested watch
-    std::set<wf::ipc::client_t*> clients;
+    std::set<wf::ipc::client_interface_t*> clients;
 
-    wf::ipc::method_callback on_client_watch = [=] (nlohmann::json data)
+    wf::ipc::method_callback_full on_client_watch =
+        [=] (nlohmann::json data, wf::ipc::client_interface_t *client)
     {
-        clients.insert(ipc_server->get_current_request_client());
+        clients.insert(client);
         return wf::ipc::json_ok();
     };
 


### PR DESCRIPTION
This allows to fully replace the IPC socket with an alternative
implementation (dbus, json-rpc, whatever).

Fixes the remaining of #2120
