### PR TITLE
toplevel-view: emit move_to_wset() when changing to a dialog

### DIFF
--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -672,7 +672,7 @@ struct view_pre_moved_to_wset_signal
     wayfire_toplevel_view view;
     /* The old wset the view was on, may be NULL. */
     std::shared_ptr<wf::workspace_set_t> old_wset;
-    /* The new wset the view is being moved to. */
+    /* The new wset the view is being moved to, may be NULL. */
     std::shared_ptr<wf::workspace_set_t> new_wset;
 };
 
@@ -686,7 +686,7 @@ struct view_moved_to_wset_signal
     wayfire_toplevel_view view;
     /* The old wset the view was on, may be NULL. */
     std::shared_ptr<wf::workspace_set_t> old_wset;
-    /* The new wset the view is being moved to. */
+    /* The new wset the view is being moved to, may be NULL. */
     std::shared_ptr<wf::workspace_set_t> new_wset;
 };
 

--- a/src/view/toplevel-view.cpp
+++ b/src/view/toplevel-view.cpp
@@ -121,7 +121,19 @@ void wf::toplevel_view_interface_t::set_toplevel_parent(wayfire_toplevel_view ne
         /* Make sure the view is available only as a child */
         if (this->get_wset())
         {
+            wf::view_pre_moved_to_wset_signal pre_move_to_wset;
+            pre_move_to_wset.view     = {this};
+            pre_move_to_wset.old_wset = get_wset();
+            pre_move_to_wset.new_wset = nullptr;
+            wf::get_core().emit(&pre_move_to_wset);
+
             get_wset()->remove_view({this});
+
+            wf::view_moved_to_wset_signal move_to_wset;
+            move_to_wset.view     = {this};
+            move_to_wset.old_wset = pre_move_to_wset.old_wset;
+            move_to_wset.new_wset = nullptr;
+            wf::get_core().emit(&move_to_wset);
         }
 
         this->set_output(parent->get_output());


### PR DESCRIPTION
The view is technically moved to a NULL wset.
