### PR TITLE
output-layout: Don't initialize output position with values unconditi…

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -1047,7 +1047,8 @@ class output_layout_t::impl
                 state.mode.refresh = head->state.custom_mode.refresh;
             }
 
-            state.position  = {head->state.x, head->state.y};
+            state.position = {head->state.x, head->state.y};
+
             state.scale     = head->state.scale;
             state.transform = head->state.transform;
             state.vrr = head->state.adaptive_sync_enabled;
@@ -1247,8 +1248,7 @@ class output_layout_t::impl
         std::vector<wf::geometry_t> geometries;
         for (auto& entry : config)
         {
-            if (!(entry.second.source & OUTPUT_IMAGE_SOURCE_SELF) ||
-                entry.second.position.is_automatic_position())
+            if (!(entry.second.source & OUTPUT_IMAGE_SOURCE_SELF))
             {
                 continue;
             }


### PR DESCRIPTION
…onally

When initializing output::position, passing x and y arguments means that the position will not be marked automatic, even if it's set to auto or the default value. This spells trouble later, when enabling an output that was previously disabled that is not the default 0,0 output. This commit checks the position is set to automatic before blindly supplying x and y values to the position.

Fixes #2147.