### PR TITLE
ipc: support workspace sets

### DIFF
--- a/plugins/ipc/ipc-helpers.hpp
+++ b/plugins/ipc/ipc-helpers.hpp
@@ -38,6 +38,19 @@ inline wf::output_t *find_output_by_id(int32_t id)
     return nullptr;
 }
 
+inline wf::workspace_set_t *find_workspace_set_by_id(int32_t id)
+{
+    for (auto ws : wf::workspace_set_t::get_all())
+    {
+        if ((int)ws->get_id() == id)
+        {
+            return ws;
+        }
+    }
+
+    return nullptr
+}
+
 inline nlohmann::json geometry_to_json(wf::geometry_t g)
 {
     nlohmann::json j;
@@ -63,6 +76,54 @@ inline std::optional<wf::geometry_t> geometry_from_json(const nlohmann::json& j)
         .x     = j["x"],
         .y     = j["y"],
         .width = j["width"],
+        .height = j["height"],
+    };
+}
+
+inline nlohmann::json point_to_json(wf::point_t p)
+{
+    nlohmann::json j;
+    j["x"] = p.x;
+    j["y"] = p.y;
+    return j;
+}
+
+inline std::optional<wf::point_t> point_from_json(const nlohmann::json& j)
+{
+#define CHECK(field, type) (j.contains(field) && j[field].is_number_ ## type())
+    if (!CHECK("x", integer) || !CHECK("y", integer))
+    {
+        return {};
+    }
+
+#undef CHECK
+
+    return wf::point_t{
+        .x = j["x"],
+        .y = j["y"],
+    };
+}
+
+inline nlohmann::json dimensions_to_json(wf::dimensions_t d)
+{
+    nlohmann::json j;
+    j["width"]  = d.width;
+    j["height"] = d.height;
+    return j;
+}
+
+inline std::optional<wf::dimensions_t> dimensions_from_json(const nlohmann::json& j)
+{
+#define CHECK(field, type) (j.contains(field) && j[field].is_number_ ## type())
+    if (!CHECK("width", integer) || !CHECK("height", integer))
+    {
+        return {};
+    }
+
+#undef CHECK
+
+    return wf::dimensions_t{
+        .width  = j["width"],
         .height = j["height"],
     };
 }


### PR DESCRIPTION
This is a draft PR for an implementation of querying and configuring workspace sets via IPC. This would be a way to interface with workspaces via bars such as waybar or window rule scripts specific to workspaces. Leaving it as a draft for now since I am unsure if this should live in `wsets` or `ipc-rules`. For now, it lives in `ipc-rules`. This is a very quick, very untested implementation as I do not have time at the moment to build and test the plugin.

This would likely require signals for seeing if a workspace set is created or destroyed. I'm not too sure if they already exist, but this would require more signals to be defined I imagine, if they aren't defined already.

Views should also know which workspace set and viewport they exist on, but I don't know if that would complicate anything in the codebase, or if that is considered out of scope for this PR. On paper, listing views and specifying the workspace set id and/or viewport position _should_ list all the views that exist on that workspace set (and viewport if specified). This would make it less simple for scripts to know which workspace set they exist on however- an example would be seeing if a view's title change is on the second workspace. One would have to list all the views that exist on the second workspace in order to check if the view is indeed on it whereas ideally, one could simply check properties such as `workspace-set-id` and `workspace-point`. Again, that might be out of scope for this specific PR as it doesn't necessarily pertain to interfacing with workspace sets.