### PR TITLE
ipc-rules: add output-added and output-removed signals

### DIFF
--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -181,15 +181,15 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
         output->connect(&on_wset_workspace_changed);
 
         nlohmann::json data;
-        data["event"] = "output-added";
-        data["output"]  = output_to_json(output);
+        data["event"]  = "output-added";
+        data["output"] = output_to_json(output);
         send_event_to_subscribes(data, data["event"]);
     }
 
     void handle_output_removed(wf::output_t *output) override
     {
         nlohmann::json data;
-        data["event"] = "output-removed";
+        data["event"]  = "output-removed";
         data["output"] = output_to_json(output);
         send_event_to_subscribes(data, data["event"]);
     }

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -179,11 +179,19 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
         output->connect(&_fullscreened);
         output->connect(&on_wset_changed);
         output->connect(&on_wset_workspace_changed);
+
+        nlohmann::json data;
+        data["event"] = "output-added";
+        data["output"]  = output_to_json(output);
+        send_event_to_subscribes(data, data["event"]);
     }
 
     void handle_output_removed(wf::output_t *output) override
     {
-        // no-op
+        nlohmann::json data;
+        data["event"] = "output-removed";
+        data["output"] = output_to_json(output);
+        send_event_to_subscribes(data, data["event"]);
     }
 
     wf::ipc::method_callback get_wayfire_configuration_info = [=] (nlohmann::json)


### PR DESCRIPTION
Haven't tested this yet, but this would be nice for laptop users plugging into different monitors.