### PR TITLE
keyboard: do not send any press events which were not sent to the client

### DIFF
--- a/src/api/wayfire/debug.hpp
+++ b/src/api/wayfire/debug.hpp
@@ -57,6 +57,8 @@ enum class logging_category : size_t
     XWL     = 8,
     // Layer-shell-related events
     LSHELL  = 9,
+    // Input-Method-related events
+    IM      = 10,
     TOTAL,
 };
 

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -23,7 +23,8 @@ class input_method_relay
         on_grab_keyboard, on_grab_keyboard_destroy, on_new_popup_surface;
     wlr_input_method_keyboard_grab_v2 *keyboard_grab = nullptr;
 
-    std::optional<uint32_t> last_done_serial;
+    std::optional<uint32_t> last_focus_switch_serial;
+    std::optional<uint32_t> last_committed_serial;
     uint32_t next_done_serial = 0;
     void send_im_done();
 
@@ -59,6 +60,8 @@ class input_method_relay
     bool handle_key(struct wlr_keyboard*, uint32_t time, uint32_t key, uint32_t state);
     bool handle_modifier(struct wlr_keyboard*);
     bool is_im_sent(struct wlr_keyboard*);
+    bool is_im_in_sync();
+
     ~input_method_relay();
 };
 

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -62,6 +62,9 @@ void wf::keyboard_t::setup_listeners()
                 if (seat->priv->pressed_keys.count(ev->keycode))
                 {
                     seat->priv->pressed_keys.erase(seat->priv->pressed_keys.find(ev->keycode));
+                } else
+                {
+                    return;
                 }
             }
 

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -68,8 +68,7 @@ void wf::keyboard_t::setup_listeners()
                 }
             }
 
-            // don't send IM sent keys to plugin grabs
-            if (seat->priv->keyboard_focus && !(seat->priv->is_grab && is_im_sent))
+            if (seat->priv->keyboard_focus)
             {
                 LOGC(IM, "key=", ev->keycode, " state=", ev->state, " sent to node.");
                 seat->priv->keyboard_focus->keyboard_interaction()

--- a/src/core/seat/seat-impl.hpp
+++ b/src/core/seat/seat-impl.hpp
@@ -57,7 +57,6 @@ struct seat_t::impl
 
     void set_keyboard_focus(wf::scene::node_ptr keyboard_focus);
     wf::scene::node_ptr keyboard_focus;
-    bool is_grab = false;
     // Keys sent to the current keyboard focus
     std::multiset<uint32_t> pressed_keys;
     void transfer_grab(wf::scene::node_ptr new_focus);

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -500,7 +500,6 @@ void wf::seat_t::impl::transfer_grab(wf::scene::node_ptr grab_node)
     }
 
     this->keyboard_focus = grab_node;
-    this->is_grab = true;
     grab_node->keyboard_interaction().handle_keyboard_enter(wf::get_core().seat.get());
 
     wf::keyboard_focus_changed_signal data;
@@ -522,7 +521,6 @@ void wf::seat_t::impl::set_keyboard_focus(wf::scene::node_ptr new_focus)
     }
 
     this->keyboard_focus = new_focus;
-    this->is_grab = false;
     if (new_focus)
     {
         new_focus->keyboard_interaction().handle_keyboard_enter(wf::get_core().seat.get());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,6 +216,10 @@ void parse_extended_debugging(const std::vector<std::string>& categories)
         {
             LOGD("Enabling extended debugging for layer-shell events");
             wf::log::enabled_categories.set((size_t)wf::log::logging_category::LSHELL, 1);
+        } else if (cat == "im")
+        {
+            LOGD("Enabling extended debugging for input method events");
+            wf::log::enabled_categories.set((size_t)wf::log::logging_category::IM, 1);
         } else
         {
             LOGE("Unrecognized debugging category \"", cat, "\"");

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -384,15 +384,7 @@ wayfire_toplevel_view wf::find_topmost_parent(wayfire_toplevel_view v)
 wf::pointf_t wf::place_popup_at(wlr_surface *parent, wlr_surface *popup, wf::pointf_t relative)
 {
     auto popup_parent = wf::wl_surface_to_wayfire_view(parent->resource).get();
-
     wf::pointf_t popup_offset = relative;
-    if (wlr_xdg_surface *xdg_surface = wlr_xdg_surface_try_from_wlr_surface(parent))
-    {
-        wlr_box box;
-        wlr_xdg_surface_get_geometry(xdg_surface, &box);
-        popup_offset.x += box.x;
-        popup_offset.y += box.y;
-    }
 
     // Get the {0, 0} of the parent view in output coordinates
     popup_offset += popup_parent->get_surface_root_node()->to_global({0, 0});

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -164,11 +164,20 @@ void wayfire_xdg_popup::update_position()
     }
 
     // Offset relative to the parent surface
-    wf::pointf_t popup_offset = wf::place_popup_at(popup->parent, popup->base->surface, {
+    wf::pointf_t local_offset = {
         popup->current.geometry.x * 1.0 - popup->base->current.geometry.x,
         popup->current.geometry.y * 1.0 - popup->base->current.geometry.y,
-    });
+    };
 
+    if (wlr_xdg_surface *xdg_surface = wlr_xdg_surface_try_from_wlr_surface(popup->parent))
+    {
+        wlr_box box;
+        wlr_xdg_surface_get_geometry(xdg_surface, &box);
+        local_offset.x += box.x;
+        local_offset.y += box.y;
+    }
+
+    wf::pointf_t popup_offset = wf::place_popup_at(popup->parent, popup->base->surface, local_offset);
     this->move(popup_offset.x, popup_offset.y);
 }
 


### PR DESCRIPTION
This was erroneously removed in #2113.

@lilydjwg Do you remember why you removed this check? It should definitely be there, because otherwise we send release events to clients who have not received enter events, this is a quick recipe for messing up the client state. I have verified that without this check Wayfire sends extra release events so the check is needed for sure. If this breaks something for IMs, we'll have to figure out a better way to solve the particular problem.

Fixes #2166 
