### PR TITLE
Use the new animation option type

### DIFF
--- a/metadata/animate.xml
+++ b/metadata/animate.xml
@@ -53,15 +53,15 @@
 			<_long>Specifies the window types to be animated.</_long>
 			<default>(type equals "toplevel" | (type equals "x-or" &amp; focusable equals true))</default>
 		</option>
-		<option name="duration" type="int">
+		<option name="duration" type="animation">
 			<_short>Duration</_short>
 			<_long>Sets the duration of the animation in milliseconds.</_long>
-			<default>400</default>
+			<default>400ms</default>
 		</option>
-		<option name="startup_duration" type="int">
+		<option name="startup_duration" type="animation">
 			<_short>System fade duration when Wayfire starts</_short>
 			<_long>Sets the duration of fading (in milliseconds) when Wayfire starts.</_long>
-			<default>600</default>
+			<default>600ms linear</default>
 		</option>
 		<!-- Fade animation -->
 		<option name="fade_enabled_for" type="string">
@@ -69,10 +69,10 @@
 			<_long>Specifies the window types to be animated with a fade effect.</_long>
 			<default>type equals "overlay"</default>
 		</option>
-		<option name="fade_duration" type="int">
+		<option name="fade_duration" type="animation">
 			<_short>Fade duration</_short>
 			<_long>Sets the duration for the _fade_ animation in milliseconds.  Only applies for windows matched by `animate.fade_enabled_for`.</_long>
-			<default>400</default>
+			<default>400ms</default>
 		</option>
 		<!-- Zoom animation -->
 		<option name="zoom_enabled_for" type="string">
@@ -80,10 +80,10 @@
 			<_long>Specifies the window types to be animated with a zoom effect.</_long>
 			<default>none</default>
 		</option>
-		<option name="zoom_duration" type="int">
+		<option name="zoom_duration" type="animation">
 			<_short>Zoom duration</_short>
 			<_long>Sets the duration for the _zoom_ animation in milliseconds.  Only applies for windows matched by `animate.zoom_enabled_for`.</_long>
-			<default>500</default>
+			<default>500ms circle</default>
 		</option>
 		<!-- Fire animation -->
 		<option name="fire_enabled_for" type="string">
@@ -91,10 +91,10 @@
 			<_long>Specifies the window types to be animated with a fire effect.</_long>
 			<default>none</default>
 		</option>
-		<option name="fire_duration" type="int">
+		<option name="fire_duration" type="animation">
 			<_short>Fire duration</_short>
 			<_long>Sets the duration for the _fire_ animation in milliseconds.  Only applies for windows matched by `animate.fire_enabled_for`.</_long>
-			<default>300</default>
+			<default>300ms linear</default>
 		</option>
 		<option name="fire_particles" type="int">
 			<_short>Fire particles</_short>

--- a/metadata/cube.xml
+++ b/metadata/cube.xml
@@ -56,10 +56,10 @@
 			<default>0.1</default>
 			<precision>0.01</precision>
 		</option>
-		<option name="initial_animation" type="int">
+		<option name="initial_animation" type="animation">
 			<_short>Duration</_short>
 			<_long>Sets the initial animation duration in milliseconds.</_long>
-			<default>350</default>
+			<default>350ms</default>
 		</option>
 		<!-- Velocity -->
 		<option name="speed_zoom" type="double">

--- a/metadata/expo.xml
+++ b/metadata/expo.xml
@@ -14,10 +14,10 @@
 			<_long>Sets the background color.</_long>
 			<default>0.1 0.1 0.1 1.0</default>
 		</option>
-		<option name="duration" type="int">
+		<option name="duration" type="animation">
 			<_short>Zoom duration</_short>
 			<_long>Sets the zoom duration in milliseconds.</_long>
-			<default>300</default>
+			<default>300ms circle</default>
 		</option>
 		<option name="offset" type="int">
 			<_short>Delimiter offset</_short>

--- a/metadata/grid.xml
+++ b/metadata/grid.xml
@@ -4,10 +4,10 @@
 		<_short>Grid</_short>
 		<_long>A plugin to position the windows in certain regions of the output.</_long>
 		<category>Window Management</category>
-		<option name="duration" type="int">
+		<option name="duration" type="animation">
 			<_short>Duration</_short>
 			<_long>Sets the duration of the animation in milliseconds.</_long>
-			<default>300</default>
+			<default>300ms</default>
 		</option>
 		<option name="type" type="string">
 			<_short>Type</_short>

--- a/metadata/scale.xml
+++ b/metadata/scale.xml
@@ -16,10 +16,10 @@
 				<_long>Toggles scale showing windows from all workspaces.</_long>
 				<default></default>
 			</option>
-			<option name="duration" type="int">
+			<option name="duration" type="animation">
 				<_short>Animation Transition Time</_short>
 				<_long>Time it takes for views to transition. Units are in milliseconds.</_long>
-				<default>750</default>
+				<default>750ms</default>
 				<min>0</min>
 			</option>
 			<option name="allow_zoom" type="bool">

--- a/metadata/simple-tile.xml
+++ b/metadata/simple-tile.xml
@@ -65,7 +65,7 @@
 			<_long>Number of pixels to shrink of a view when it has no neighbor above or below.</_long>
 			<default>0</default>
 		</option>
-		<option name="animation_duration" type="int">
+		<option name="animation_duration" type="animation">
 			<_short>Resize animation duration</_short>
 			<_long>The duration of the crossfade animation in situations where a tiled view's geometry changes.</_long>
 			<default>0</default>

--- a/metadata/switcher.xml
+++ b/metadata/switcher.xml
@@ -16,7 +16,7 @@
 			<default>&lt;alt&gt; &lt;shift&gt; KEY_TAB</default>
 		</option>
 		<!-- Effects -->
-		<option name="speed" type="int">
+		<option name="speed" type="animation">
 			<_short>Duration</_short>
 			<_long>Sets the duration of the animation in milliseconds.</_long>
 			<default>500</default>

--- a/metadata/vswipe.xml
+++ b/metadata/vswipe.xml
@@ -24,10 +24,10 @@
 			<_long>Enables or disables smooth transition.</_long>
 			<default>false</default>
 		</option>
-		<option name="duration" type="int">
+		<option name="duration" type="animation">
 			<_short>Duration</_short>
 			<_long>Sets the duration of the animation in milliseconds.</_long>
-			<default>180</default>
+			<default>180ms</default>
 		</option>
 		<option name="background" type="color">
 			<_short>Background color</_short>

--- a/metadata/vswitch.xml
+++ b/metadata/vswitch.xml
@@ -107,7 +107,7 @@
 			</entry>
 		</option>
 
-		<option name="duration" type="int">
+		<option name="duration" type="animation">
 			<_short>Duration</_short>
 			<_long>Sets the duration of the workspace switching animation in milliseconds.</_long>
 			<default>300</default>

--- a/metadata/wsets.xml
+++ b/metadata/wsets.xml
@@ -14,10 +14,10 @@
 			<_long>A binding to move the currently focused window to the workspace set #N.</_long>
 			<entry prefix="send_to_wset_" type="activator"/>
 		</option>
-		<option name="label_duration" type="int">
+		<option name="label_duration" type="animation">
 			<_short>Label duration</_short>
 			<_long>Sets the duration in milliseconds for which the workspace set label is shown.</_long>
-			<default>2000</default>
+			<default>2s linear</default>
 		</option>
 	</plugin>
 </wayfire>

--- a/metadata/zoom.xml
+++ b/metadata/zoom.xml
@@ -15,10 +15,10 @@
 			<default>0.01</default>
 			<precision>0.001</precision>
 		</option>
-		<option name="smoothing_duration" type="int">
+		<option name="smoothing_duration" type="animation">
 			<_short>Smoothing duration</_short>
 			<_long>Sets the smoothing duration in milliseconds.</_long>
-			<default>300</default>
+			<default>300ms linear</default>
 		</option>
 		<option name="interpolation_method" type="int">
 			<_short>Interpolation method</_short>

--- a/plugins/animate/animate.cpp
+++ b/plugins/animate/animate.cpp
@@ -1,11 +1,9 @@
-#include <cstddef>
 #include <wayfire/per-output-plugin.hpp>
 #include <wayfire/output.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/render-manager.hpp>
 #include <wayfire/workspace-set.hpp>
 #include <type_traits>
-#include <map>
 #include <wayfire/core.hpp>
 #include "animate.hpp"
 #include "system_fade.hpp"
@@ -19,7 +17,7 @@
 #include "wayfire/view.hpp"
 #include <wayfire/matcher.hpp>
 
-void animation_base::init(wayfire_view, int, wf_animation_type)
+void animation_base::init(wayfire_view, wf::animation_description_t, wf_animation_type)
 {}
 bool animation_base::step()
 {
@@ -122,7 +120,7 @@ struct animation_hook : public animation_hook_base
         set_output(view->get_output());
     };
 
-    animation_hook(wayfire_view view, int duration, wf_animation_type type,
+    animation_hook(wayfire_view view, wf::animation_description_t duration, wf_animation_type type,
         std::string name)
     {
         this->type = type;
@@ -269,12 +267,12 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
     wf::option_wrapper_t<std::string> open_animation{"animate/open_animation"};
     wf::option_wrapper_t<std::string> close_animation{"animate/close_animation"};
 
-    wf::option_wrapper_t<int> default_duration{"animate/duration"};
-    wf::option_wrapper_t<int> fade_duration{"animate/fade_duration"};
-    wf::option_wrapper_t<int> zoom_duration{"animate/zoom_duration"};
-    wf::option_wrapper_t<int> fire_duration{"animate/fire_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> default_duration{"animate/duration"};
+    wf::option_wrapper_t<wf::animation_description_t> fade_duration{"animate/fade_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> zoom_duration{"animate/zoom_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> fire_duration{"animate/fire_duration"};
 
-    wf::option_wrapper_t<int> startup_duration{"animate/startup_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> startup_duration{"animate/startup_duration"};
 
     wf::view_matcher_t animation_enabled_for{"animate/enabled_for"};
     wf::view_matcher_t fade_enabled_for{"animate/fade_enabled_for"};
@@ -308,7 +306,7 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
     struct view_animation_t
     {
         std::string animation_name;
-        int duration;
+        wf::animation_description_t duration;
     };
 
     view_animation_t get_animation_for_view(
@@ -337,7 +335,7 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
             return {anim_type, default_duration};
         }
 
-        return {"none", 0};
+        return {"none", wf::animation_description_t{0, {}, ""}};
     }
 
     bool try_reverse(wayfire_view view, wf_animation_type type, std::string name,
@@ -359,7 +357,7 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
 
     template<class animation_t>
     void set_animation(wayfire_view view,
-        wf_animation_type type, int duration, std::string name)
+        wf_animation_type type, wf::animation_description_t duration, std::string name)
     {
         name = "animation-hook-" + name;
 

--- a/plugins/animate/animate.hpp
+++ b/plugins/animate/animate.hpp
@@ -21,7 +21,7 @@ enum wf_animation_type
 class animation_base
 {
   public:
-    virtual void init(wayfire_view view, int duration, wf_animation_type type);
+    virtual void init(wayfire_view view, wf::animation_description_t duration, wf_animation_type type);
     virtual bool step(); /* return true if continue, false otherwise */
     virtual void reverse(); /* reverse the animation */
     virtual int get_direction();

--- a/plugins/animate/basic_animations.hpp
+++ b/plugins/animate/basic_animations.hpp
@@ -16,11 +16,11 @@ class fade_animation : public animation_base
 
   public:
 
-    void init(wayfire_view view, int dur, wf_animation_type type) override
+    void init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type) override
     {
         this->view = view;
         this->progression =
-            wf::animation::simple_animation_t(wf::create_option<int>(dur));
+            wf::animation::simple_animation_t(wf::create_option<wf::animation_description_t>(dur));
 
         this->progression.animate(start, end);
 
@@ -81,10 +81,10 @@ class zoom_animation : public animation_base
 
   public:
 
-    void init(wayfire_view view, int dur, wf_animation_type type) override
+    void init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type) override
     {
         this->view = view;
-        this->progression = zoom_animation_t(wf::create_option<int>(dur));
+        this->progression = zoom_animation_t(wf::create_option<wf::animation_description_t>(dur));
         this->progression.alpha = wf::animation::timed_transition_t(
             this->progression, 0, 1);
         this->progression.zoom = wf::animation::timed_transition_t(

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -8,7 +8,6 @@
 #include "wayfire/view-transform.hpp"
 
 #include <memory>
-#include <thread>
 #include <wayfire/output.hpp>
 #include <wayfire/core.hpp>
 #include <glm/gtc/matrix_transform.hpp>
@@ -234,14 +233,14 @@ static float fire_duration_mod_for_height(int height)
     return std::min(height / 400.0, 3.0);
 }
 
-void FireAnimation::init(wayfire_view view, int dur, wf_animation_type type)
+void FireAnimation::init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type)
 {
     this->view = view;
 
     auto bbox = view->get_transformed_node()->get_bounding_box();
-    int msec  = dur * fire_duration_mod_for_height(bbox.height);
-    this->progression = wf::animation::simple_animation_t(wf::create_option<int>(
-        msec), wf::animation::smoothing::linear);
+    dur.length_ms    *= fire_duration_mod_for_height(bbox.height);
+    this->progression = wf::animation::simple_animation_t(
+        wf::create_option<wf::animation_description_t>(dur));
     this->progression.animate(0, 1);
 
     if (type & HIDING_ANIMATION)

--- a/plugins/animate/fire/fire.hpp
+++ b/plugins/animate/fire/fire.hpp
@@ -3,8 +3,6 @@
 
 #include <wayfire/view-transform.hpp>
 #include <wayfire/render-manager.hpp>
-#include <memory>
-
 #include "../animate.hpp"
 
 class FireTransformer;
@@ -19,7 +17,7 @@ class FireAnimation : public animation_base
   public:
 
     ~FireAnimation();
-    void init(wayfire_view view, int duration, wf_animation_type type) override;
+    void init(wayfire_view view, wf::animation_description_t, wf_animation_type type) override;
     bool step() override; /* return true if continue, false otherwise */
     void reverse() override; /* reverse the animation */
 };

--- a/plugins/animate/system_fade.hpp
+++ b/plugins/animate/system_fade.hpp
@@ -5,7 +5,7 @@
 #include <wayfire/output.hpp>
 #include <wayfire/opengl.hpp>
 #include <wayfire/render-manager.hpp>
-#include "animate.hpp"
+#include <wayfire/util/duration.hpp>
 
 /* animates wake from suspend/startup by fading in the whole output */
 class wf_system_fade
@@ -17,8 +17,8 @@ class wf_system_fade
     wf::effect_hook_t damage_hook, render_hook;
 
   public:
-    wf_system_fade(wf::output_t *out, int dur) :
-        progression(wf::create_option<int>(dur)), output(out)
+    wf_system_fade(wf::output_t *out, wf::animation_description_t dur) :
+        progression(wf::create_option<wf::animation_description_t>(dur)), output(out)
     {
         damage_hook = [=] ()
         { output->render->damage_whole(); };

--- a/plugins/cube/cube.hpp
+++ b/plugins/cube/cube.hpp
@@ -24,7 +24,7 @@ class cube_animation_t : public duration_t
 
 struct wf_cube_animation_attribs
 {
-    wf::option_wrapper_t<int> animation_duration{"cube/initial_animation"};
+    wf::option_wrapper_t<wf::animation_description_t> animation_duration{"cube/initial_animation"};
     cube_animation_t cube_animation{animation_duration};
 
     glm::mat4 projection, view;

--- a/plugins/grid/grid.cpp
+++ b/plugins/grid/grid.cpp
@@ -5,7 +5,6 @@
 #include <wayfire/workarea.hpp>
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/render-manager.hpp>
-#include <algorithm>
 #include <cmath>
 #include <linux/input-event-codes.h>
 #include "wayfire/plugin.hpp"
@@ -33,7 +32,7 @@ nonstd::observer_ptr<wf::grid::grid_animation_t> ensure_grid_view(wayfire_toplev
     if (!view->has_data<wf::grid::grid_animation_t>())
     {
         wf::option_wrapper_t<std::string> animation_type{"grid/type"};
-        wf::option_wrapper_t<int> duration{"grid/duration"};
+        wf::option_wrapper_t<wf::animation_description_t> duration{"grid/duration"};
 
         wf::grid::grid_animation_t::type_t type = wf::grid::grid_animation_t::NONE;
         if (animation_type.value() == "crossfade")

--- a/plugins/grid/wayfire/plugins/crossfade.hpp
+++ b/plugins/grid/wayfire/plugins/crossfade.hpp
@@ -179,7 +179,7 @@ class grid_animation_t : public wf::custom_data_t
      * @param duration Indicates the duration of the animation (only for crossfade)
      */
     grid_animation_t(wayfire_toplevel_view view, type_t type,
-        wf::option_sptr_t<int> duration)
+        wf::option_sptr_t<wf::animation_description_t> duration)
     {
         this->view   = view;
         this->output = view->get_output();

--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -50,7 +50,7 @@ class scale_animation_t : public duration_t
 
 struct wf_scale_animation_attribs
 {
-    wf::option_wrapper_t<int> duration{"scale/duration"};
+    wf::option_wrapper_t<wf::animation_description_t> duration{"scale/duration"};
     scale_animation_t scale_animation{duration};
 };
 
@@ -802,7 +802,7 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
             view_data.transformer->translation_y, translation_y);
         view_data.animation.scale_animation.start();
         view_data.fade_animation = wf::animation::simple_animation_t(
-            wf::option_wrapper_t<int>{"scale/duration"});
+            wf::option_wrapper_t<wf::animation_description_t>{"scale/duration"});
         view_data.fade_animation.animate(view_data.transformer->alpha,
             target_alpha);
     }

--- a/plugins/single_plugins/expo.cpp
+++ b/plugins/single_plugins/expo.cpp
@@ -37,7 +37,7 @@ class wayfire_expo : public wf::per_output_plugin_instance_t, public wf::keyboar
     }
 
     wf::option_wrapper_t<wf::color_t> background_color{"expo/background"};
-    wf::option_wrapper_t<int> zoom_duration{"expo/duration"};
+    wf::option_wrapper_t<wf::animation_description_t> zoom_duration{"expo/duration"};
     wf::option_wrapper_t<int> delimiter_offset{"expo/offset"};
     wf::option_wrapper_t<bool> keyboard_interaction{"expo/keyboard_interaction"};
     wf::option_wrapper_t<double> inactive_brightness{"expo/inactive_brightness"};

--- a/plugins/single_plugins/switcher.cpp
+++ b/plugins/single_plugins/switcher.cpp
@@ -101,7 +101,7 @@ class WayfireSwitcher : public wf::per_output_plugin_instance_t, public wf::keyb
 {
     wf::option_wrapper_t<double> view_thumbnail_scale{
         "switcher/view_thumbnail_scale"};
-    wf::option_wrapper_t<int> speed{"switcher/speed"};
+    wf::option_wrapper_t<wf::animation_description_t> speed{"switcher/speed"};
     wf::option_wrapper_t<int> view_thumbnail_rotation{
         "switcher/view_thumbnail_rotation"};
 

--- a/plugins/single_plugins/vswipe.cpp
+++ b/plugins/single_plugins/vswipe.cpp
@@ -83,7 +83,7 @@ class vswipe : public wf::per_output_plugin_instance_t
     wf::option_wrapper_t<bool> smooth_transition{"vswipe/enable_smooth_transition"};
 
     wf::option_wrapper_t<wf::color_t> background_color{"vswipe/background"};
-    wf::option_wrapper_t<int> animation_duration{"vswipe/duration"};
+    wf::option_wrapper_t<wf::animation_description_t> animation_duration{"vswipe/duration"};
 
     vswipe_smoothing_t smooth_delta{animation_duration};
     wf::option_wrapper_t<int> fingers{"vswipe/fingers"};

--- a/plugins/single_plugins/wsets.cpp
+++ b/plugins/single_plugins/wsets.cpp
@@ -16,6 +16,7 @@
 #include <wayfire/debug.hpp>
 #include <wayfire/core.hpp>
 #include <wayfire/plugin.hpp>
+#include <wayfire/util/duration.hpp>
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/config/types.hpp>
 #include <wayfire/output-layout.hpp>
@@ -113,7 +114,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
     workspace_bindings{"wsets/wsets_bindings"};
     wf::option_wrapper_t<wf::config::compound_list_t<wf::activatorbinding_t>>
     send_to_bindings{"wsets/send_window_bindings"};
-    wf::option_wrapper_t<int> label_duration{"wsets/label_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> label_duration{"wsets/label_duration"};
 
     std::list<wf::activator_callback> select_callback;
     std::list<wf::activator_callback> send_callback;
@@ -225,7 +226,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
         wf::scene::readd_front(wo->node_for_layer(wf::scene::layer::DWIDGET), overlay->node);
         wf::scene::damage_node(overlay->node, overlay->node->get_bounding_box());
 
-        overlay->timer.set_timeout(label_duration, [wo] ()
+        overlay->timer.set_timeout(label_duration.value().length_ms, [wo] ()
         {
             wo->erase_data<output_overlay_data_t>();
         });

--- a/plugins/single_plugins/zoom.cpp
+++ b/plugins/single_plugins/zoom.cpp
@@ -14,7 +14,7 @@ class wayfire_zoom_screen : public wf::per_output_plugin_instance_t
 
     wf::option_wrapper_t<wf::keybinding_t> modifier{"zoom/modifier"};
     wf::option_wrapper_t<double> speed{"zoom/speed"};
-    wf::option_wrapper_t<int> smoothing_duration{"zoom/smoothing_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> smoothing_duration{"zoom/smoothing_duration"};
     wf::option_wrapper_t<int> interpolation_method{"zoom/interpolation_method"};
     wf::animation::simple_animation_t progression{smoothing_duration};
     bool hook_set = false;

--- a/plugins/tile/tree.cpp
+++ b/plugins/tile/tree.cpp
@@ -8,7 +8,6 @@
 #include <wayfire/output.hpp>
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/view-transform.hpp>
-#include <algorithm>
 #include <wayfire/plugins/crossfade.hpp>
 #include <wayfire/plugins/common/util.hpp>
 #include <wayfire/toplevel.hpp>
@@ -407,7 +406,7 @@ wf::geometry_t view_node_t::calculate_target_geometry()
 
 bool view_node_t::needs_crossfade()
 {
-    if (animation_duration == 0)
+    if (animation_duration.value().length_ms == 0)
     {
         return false;
     }
@@ -427,7 +426,7 @@ bool view_node_t::needs_crossfade()
 }
 
 static nonstd::observer_ptr<wf::grid::grid_animation_t> ensure_animation(
-    wayfire_toplevel_view view, wf::option_sptr_t<int> duration)
+    wayfire_toplevel_view view, wf::option_sptr_t<wf::animation_description_t> duration)
 {
     if (!view->has_data<wf::grid::grid_animation_t>())
     {

--- a/plugins/tile/tree.hpp
+++ b/plugins/tile/tree.hpp
@@ -3,6 +3,7 @@
 
 #include "wayfire/signal-definitions.hpp"
 #include "wayfire/workspace-set.hpp"
+#include <wayfire/util/duration.hpp>
 #include <wayfire/view.hpp>
 #include <wayfire/option-wrapper.hpp>
 #include <wayfire/txn/transaction.hpp>
@@ -178,7 +179,7 @@ struct view_node_t : public tree_node_t
     wf::signal::connection_t<view_geometry_changed_signal> on_geometry_changed;
     wf::signal::connection_t<tile_adjust_transformer_signal> on_adjust_transformer;
 
-    wf::option_wrapper_t<int> animation_duration{"simple-tile/animation_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> animation_duration{"simple-tile/animation_duration"};
 
     /**
      * Check whether the crossfade animation should be enabled for the view

--- a/plugins/vswitch/wayfire/plugins/vswitch.hpp
+++ b/plugins/vswitch/wayfire/plugins/vswitch.hpp
@@ -96,7 +96,7 @@ class workspace_switch_t
         this->output = output;
         wall = std::make_unique<workspace_wall_t>(output);
         animation = workspace_animation_t{
-            wf::option_wrapper_t<int>{"vswitch/duration"}
+            wf::option_wrapper_t<wf::animation_description_t>{"vswitch/duration"}
         };
     }
 


### PR DESCRIPTION
This PR updates the plugins to use the new animation option type from wf-config.

Note that there are no breaking changes, because the old way to use animations (integer duration option) still works.
Plugins which want to be more configurable have to update their code to use the new option type (which is very simple in most cases).

In any case, this change makes it possible to be a bit more explicit in the config file, for example `200ms` or `2.5s`, both are accepted.
For backwards compatibility, the user can also just write a simple number, `200` as before, which is interpreted as `200ms`.

Also, the animation easing function is now configurable if one uses the full format. For example, `200ms linear` or `200ms circle`. The default easing function was and remains circle, but sometimes `sigmoid` or `linear` might look better. Also for fun one can use `easeOutElastic`. We can also add more functions to wf-config, if desired.
