### PR TITLE
improve log on wfconfig error

### DIFF
--- a/plugins/animate/fire/fire.hpp
+++ b/plugins/animate/fire/fire.hpp
@@ -8,7 +8,7 @@
 #include "../animate.hpp"
 
 class FireTransformer;
-struct ParticleSystem;
+class ParticleSystem;
 
 class FireAnimation : public animation_base
 {

--- a/plugins/ipc/ipc-method-repository.hpp
+++ b/plugins/ipc/ipc-method-repository.hpp
@@ -17,6 +17,7 @@ class client_interface_t
 {
   public:
     virtual void send_json(nlohmann::json json) = 0;
+    virtual ~client_interface_t() = default;
 };
 
 /**

--- a/src/api/wayfire/option-wrapper.hpp
+++ b/src/api/wayfire/option-wrapper.hpp
@@ -6,6 +6,15 @@
 
 namespace wf
 {
+namespace detail
+{
+// Forward declaration to avoid adding unnecessary includes.
+[[noreturn]]
+void option_wrapper_debug_message(const std::string& option_name, const std::runtime_error& err);
+[[noreturn]]
+void option_wrapper_debug_message(const std::string& option_name, const std::logic_error& err);
+}
+
 /**
  * A simple wrapper around a config option.
  */
@@ -20,6 +29,19 @@ class option_wrapper_t : public base_option_wrapper_t<Type>
         wf::base_option_wrapper_t<Type>()
     {
         this->load_option(option_name);
+    }
+
+    void load_option(const std::string& option_name)
+    {
+        try {
+            base_option_wrapper_t<Type>::load_option(option_name);
+        } catch (const std::runtime_error& err)
+        {
+            detail::option_wrapper_debug_message(option_name, err);
+        } catch (const std::logic_error& err)
+        {
+            detail::option_wrapper_debug_message(option_name, err);
+        }
     }
 
     option_wrapper_t() : wf::base_option_wrapper_t<Type>()

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -108,7 +108,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'03'11;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'03'13;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/unstable/wlr-text-input-v3-popup.hpp
+++ b/src/api/wayfire/unstable/wlr-text-input-v3-popup.hpp
@@ -11,6 +11,7 @@ class text_input_v3_im_relay_interface_t
 {
   public:
     virtual wlr_text_input_v3 *find_focused_text_input_v3() = 0;
+    virtual ~text_input_v3_im_relay_interface_t() = default;
 };
 
 /**

--- a/src/core/seat/drag-icon.hpp
+++ b/src/core/seat/drag-icon.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <wayfire/nonstd/wlroots-full.hpp>
-#include "../view/surface-impl.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/scene.hpp"
 
 namespace wf
 {
-struct drag_icon_t
+class drag_icon_t
 {
+  public:
     wlr_drag_icon *icon;
     wl_listener_wrapper on_map, on_unmap, on_destroy;
 

--- a/src/core/seat/hotspot-manager.hpp
+++ b/src/core/seat/hotspot-manager.hpp
@@ -87,7 +87,6 @@ class hotspot_manager_t
     void update_hotspots(const container_t& activators);
 
   private:
-    bool enabled = true;
     std::vector<std::unique_ptr<hotspot_instance_t>> hotspots;
 };
 }

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -3,7 +3,9 @@
 #include <wayfire/util/log.hpp>
 #include <wayfire/debug.hpp>
 #include <wayfire/view.hpp>
+#include <wayfire/option-wrapper.hpp>
 #include <sstream>
+#include <stdlib.h>
 #include <iomanip>
 
 #if __has_include(<execinfo.h>)
@@ -383,4 +385,23 @@ static void _dump_scene(wf::scene::node_ptr root, int depth = 0)
 void wf::dump_scene(scene::node_ptr root)
 {
     _dump_scene(root);
+}
+
+void wf::detail::option_wrapper_debug_message(const std::string & option_name, const std::runtime_error & err)
+{
+    LOGE("Wayfire encountered error loading option \"", option_name, "\": ", err.what(), ". ",
+        "Usual reasons for this include missing or outdated plugin XML files, ",
+        "a bug in the plugin itself, or mismatch between the versions of Wayfire and wf-config. ",
+        "Make sure that you have the correct versions of all relevant packages and make sure that there ",
+        "are no conflicting installations of Wayfire using the same prefix.");
+    wf::print_trace(false);
+    std::_Exit(0);
+}
+
+void wf::detail::option_wrapper_debug_message(const std::string & option_name, const std::logic_error & err)
+{
+    LOGE("Wayfire encountered error loading option \"", option_name, "\": ", err.what(), ". ",
+        "This usually indicates a bug in the plugin.");
+    wf::print_trace(false);
+    std::_Exit(0);
 }


### PR DESCRIPTION
- option-wrapper: catch exceptions and print meaningful error messages
- fix compilation warnings from clang

Fixes #638
