### PR TITLE
Copy config.h approach from wlroots-full.hpp to other public api headers

### DIFF
--- a/src/api/wayfire/debug.hpp
+++ b/src/api/wayfire/debug.hpp
@@ -1,8 +1,12 @@
 #ifndef DEBUG_HPP
 #define DEBUG_HPP
 
-#ifndef WAYFIRE_PLUGIN
-    #include "config.h"
+// WF_USE_CONFIG_H is set only when building Wayfire itself, external plugins
+// need to use <wayfire/config.h>
+#ifdef WF_USE_CONFIG_H
+    #include <config.h>
+#else
+    #include <wayfire/config.h>
 #endif
 
 #define nonull(x) ((x) ? (x) : ("nil"))

--- a/src/api/wayfire/unstable/wlr-view-events.hpp
+++ b/src/api/wayfire/unstable/wlr-view-events.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#if __has_include(<wayfire/config.h>)
-    #include <wayfire/config.h>
+// WF_USE_CONFIG_H is set only when building Wayfire itself, external plugins
+// need to use <wayfire/config.h>
+#ifdef WF_USE_CONFIG_H
+    #include <config.h>
 #else
-    #include "config.h"
+    #include <wayfire/config.h>
 #endif
 
 #include <wayfire/nonstd/wlroots-full.hpp>

--- a/src/api/wayfire/unstable/xwl-toplevel-base.hpp
+++ b/src/api/wayfire/unstable/xwl-toplevel-base.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
-#if __has_include(<wayfire/config.h>)
-    #include <wayfire/config.h>
+// WF_USE_CONFIG_H is set only when building Wayfire itself, external plugins
+// need to use <wayfire/config.h>
+#ifdef WF_USE_CONFIG_H
+    #include <config.h>
 #else
-    #include "config.h"
+    #include <wayfire/config.h>
 #endif
 
 #include <wayfire/nonstd/wlroots-full.hpp>


### PR DESCRIPTION
* Otherwise wayfire could use the config.h of an already installed wayfire installation and lead to confusing linking issues if the options differed (like installed wayfire has xwayland disabled and the new build has it enabled).