### PR TITLE
fix 1601

### DIFF
--- a/plugins/single_plugins/meson.build
+++ b/plugins/single_plugins/meson.build
@@ -2,7 +2,7 @@ plugins = [
   'move', 'resize', 'command', 'autostart', 'vswipe', 'wrot', 'expo',
   'switcher', 'fast-switcher', 'oswitch', 'place', 'invert',
   'fisheye', 'zoom', 'alpha', 'idle', 'extra-gestures', 'preserve-output',
-  'wsets', 'ipc-rules'
+  'wsets', 'ipc-rules', 'xkb-bindings'
 ]
 
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, vswitch_inc, wobbly_inc, grid_inc]

--- a/plugins/single_plugins/xkb-bindings.cpp
+++ b/plugins/single_plugins/xkb-bindings.cpp
@@ -1,0 +1,150 @@
+#include "wayfire/signal-definitions.hpp"
+#include "wayfire/signal-provider.hpp"
+#include <wayfire/plugin.hpp>
+#include <wayfire/bindings-repository.hpp>
+#include "wayfire/core.hpp"
+#include "wayfire/seat.hpp"
+
+namespace wf
+{
+static std::string to_lower(std::string str)
+{
+    std::transform(str.begin(), str.end(), str.begin(), tolower);
+    return str;
+}
+
+static const std::map<std::string, uint32_t> mod_name_to_mod = {
+    {to_lower(XKB_MOD_NAME_SHIFT), WLR_MODIFIER_SHIFT},
+    {to_lower(XKB_MOD_NAME_CAPS), WLR_MODIFIER_CAPS},
+    {to_lower(XKB_MOD_NAME_CTRL), WLR_MODIFIER_CTRL},
+    {"ctrl", WLR_MODIFIER_CTRL},
+    {to_lower(XKB_MOD_NAME_ALT), WLR_MODIFIER_ALT},
+    {"alt", WLR_MODIFIER_ALT},
+    {to_lower(XKB_MOD_NAME_NUM), WLR_MODIFIER_MOD2},
+    {"mod3", WLR_MODIFIER_MOD3},
+    {to_lower(XKB_MOD_NAME_LOGO), WLR_MODIFIER_LOGO},
+    {"mod5", WLR_MODIFIER_MOD5},
+};
+
+static uint32_t parse_modifier(std::string mod_name)
+{
+    auto it = mod_name_to_mod.find(to_lower(mod_name));
+    if (it != mod_name_to_mod.end())
+    {
+        return it->second;
+    }
+
+    return 0;
+}
+
+std::vector<std::string> tokenize_at(std::string str, char token)
+{
+    std::vector<std::string> tokens;
+    std::istringstream iss(str);
+    std::string token_str;
+    while (std::getline(iss, token_str, token))
+    {
+        tokens.push_back(token_str);
+    }
+
+    return tokens;
+}
+
+struct xkb_binding_t
+{
+    uint32_t mods;
+    std::string keysym;
+
+    bool operator ==(const xkb_binding_t& other) const
+    {
+        return (mods == other.mods) && (keysym == other.keysym);
+    }
+};
+
+static std::optional<xkb_binding_t> parse_keybinding_xkb(std::string binding)
+{
+    binding.erase(std::remove(binding.begin(), binding.end(), ' '), binding.end());
+    auto tokens = tokenize_at(binding, '+');
+    if (tokens.empty())
+    {
+        return std::nullopt;
+    }
+
+    uint32_t mods = 0;
+    for (size_t i = 0; i < tokens.size() - 1; i++)
+    {
+        auto mod = parse_modifier(tokens[i]);
+        if (!mod)
+        {
+            return std::nullopt;
+        }
+
+        mods |= mod;
+    }
+
+    return xkb_binding_t{mods, tokens.back()};
+}
+
+class xkb_bindings_t : public wf::plugin_interface_t
+{
+  public:
+    void init() override
+    {
+        wf::get_core().connect(&on_parse_extension);
+        wf::get_core().connect(&on_keyboard_key);
+        wf::get_core().bindings->reparse_extensions();
+    }
+
+    void fini() override
+    {
+        on_parse_extension.disconnect();
+        wf::get_core().bindings->reparse_extensions();
+    }
+
+    wf::signal::connection_t<parse_activator_extension_signal> on_parse_extension =
+        [=] (parse_activator_extension_signal *ev)
+    {
+        if (auto binding = parse_keybinding_xkb(ev->extension_binding))
+        {
+            ev->tag = binding.value();
+        }
+    };
+
+    wf::signal::connection_t<input_event_signal<wlr_keyboard_key_event>> on_keyboard_key =
+        [=] (input_event_signal<wlr_keyboard_key_event> *ev)
+    {
+        if (!ev->device || (ev->mode == wf::input_event_processing_mode_t::IGNORE) ||
+            (ev->event->state != WL_KEYBOARD_KEY_STATE_PRESSED))
+        {
+            return;
+        }
+
+        auto keyboard = wlr_keyboard_from_input_device(ev->device);
+
+        xkb_keysym_t sym = xkb_state_key_get_one_sym(keyboard->xkb_state, ev->event->keycode + 8);
+        if (sym == XKB_KEY_NoSymbol)
+        {
+            return;
+        }
+
+        static constexpr size_t max_keysym_len = 128;
+        char buffer[max_keysym_len];
+
+        size_t len = xkb_keysym_get_name(sym, buffer, max_keysym_len);
+        std::string keysym = std::string(buffer, len);
+        uint32_t mods = wf::get_core().seat->get_keyboard_modifiers();
+
+        wf::activator_data_t data = {
+            .source = wf::activator_source_t::KEYBINDING,
+            .activation_data = ev->event->keycode
+        };
+
+        if (wf::get_core().bindings->handle_extension(xkb_binding_t{mods, keysym}, data))
+        {
+            ev->mode = wf::input_event_processing_mode_t::NO_CLIENT;
+        }
+    };
+};
+}
+
+DECLARE_WAYFIRE_PLUGIN(wf::xkb_bindings_t);

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'03'27;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'04'01;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -225,6 +225,7 @@ void wf::compositor_core_impl_t::post_init()
     this->emit(&backend_started_ev);
     this->state = compositor_state_t::RUNNING;
     plugin_mgr  = std::make_unique<wf::plugin_manager_t>();
+    this->bindings->reparse_extensions();
 
     // Move pointer to the middle of the leftmost, topmost output
     wf::pointf_t p;

--- a/src/core/seat/bindings-repository-impl.hpp
+++ b/src/core/seat/bindings-repository-impl.hpp
@@ -26,6 +26,8 @@ struct wf::bindings_repository_t::impl
         });
     }
 
+    void reparse_extensions();
+
     binding_container_t<wf::keybinding_t, key_callback> keys;
     binding_container_t<wf::keybinding_t, axis_callback> axes;
     binding_container_t<wf::buttonbinding_t, button_callback> buttons;
@@ -36,8 +38,11 @@ struct wf::bindings_repository_t::impl
     wf::signal::connection_t<wf::reload_config_signal> on_config_reload = [=] (wf::reload_config_signal *ev)
     {
         recreate_hotspots();
+        reparse_extensions();
     };
 
     wf::wl_idle_call idle_recreate_hotspots;
+    wf::wl_idle_call idle_reparse_bindings;
+
     int enabled = 1;
 };

--- a/src/core/seat/hotspot-manager.hpp
+++ b/src/core/seat/hotspot-manager.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <map>
 #include "wayfire/util.hpp"
 #include <wayfire/config/types.hpp>
 #include <wayfire/output.hpp>
@@ -18,6 +17,7 @@ struct binding_t
 {
     wf::option_sptr_t<Option> activated_by;
     Callback *callback;
+    std::vector<std::any> tags;
 };
 
 template<class Option, class Callback> using binding_container_t =


### PR DESCRIPTION
This PR is an attempt at fixing #1601.

The solution is a bit more generic than that, though: we allow generic activators in the config file. Then, a plugin needs to parse them and activate them instead of core.

Fixes #1601
