### PR TITLE
surface-node: add support for surface transform

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -2,10 +2,7 @@
 #define PLUGIN_H
 
 #include <functional>
-#include <memory>
-#include "wayfire/util.hpp"
-#include "wayfire/bindings.hpp"
-
+#include <string>
 #include <wayfire/nonstd/wlroots.hpp>
 
 class wayfire_config;
@@ -108,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'03'24;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'03'24'2;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/unstable/wlr-surface-node.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-node.hpp
@@ -20,6 +20,7 @@ struct surface_state_t
     wf::region_t accumulated_damage;
     wf::dimensions_t size = {0, 0};
     std::optional<wlr_fbox> src_viewport;
+    wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
 
     // Read the current surface state, get a lock on the current surface buffer (releasing any old locks),
     // and accumulate damage.


### PR DESCRIPTION
Tested with weston-transformed.

Fixes #1770
