### PR TITLE
ipc: dynamically connect signals to core/outputs

### DIFF
--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -173,7 +173,7 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
 
     void handle_new_output(wf::output_t *output) override
     {
-        if (clients.size() > 0)
+        if (!clients.empty())
         {
             connect_output_signals(output);
 
@@ -186,7 +186,7 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
 
     void handle_output_removed(wf::output_t *output) override
     {
-        if (clients.size() > 0)
+        if (!clients.empty())
         {
             nlohmann::json data;
             data["event"]  = "output-removed";


### PR DESCRIPTION
Connect signals to core and outputs if any clients exist, and disconnect them when all clients are disconnected.

This should ensure that no unnecessary creation of JSON data is done when no clients are available to receive such data.