### PR TITLE
ipc: do not be strict about utf8 when encoding json data

### DIFF
--- a/plugins/ipc/ipc.cpp
+++ b/plugins/ipc/ipc.cpp
@@ -296,7 +296,7 @@ static bool write_exact(int fd, char *buf, int n)
 
 void wf::ipc::client_t::send_json(nlohmann::json json)
 {
-    std::string buffer = json.dump();
+    std::string buffer = json.dump(-1, ' ', false, nlohmann::detail::error_handler_t::ignore);
     uint32_t len = buffer.length();
 
     write_exact(fd, (char*)&len, 4);


### PR DESCRIPTION
Fixes #2168