### PR TITLE
Improvements to surface and node handling

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -58,5 +58,9 @@
       <_short>Enable support for the newer input-method-v2 protocol. Note that the input-method-v1 protocol works better in many cases.</_short>
       <default>false</default>
     </option>
+    <option name="enable_opaque_region_damage_optimizations" type="bool">
+      <_short>Enable certain damage optimizations which are based on a surfaces' opaque regions. In some cases, this optimization might give unexpected results (i.e background app stops updating) even though this is fine according to Wayland's protocol.</_short>
+      <default>false</default>
+    </option>
 	</plugin>
 </wayfire>

--- a/src/api/wayfire/debug.hpp
+++ b/src/api/wayfire/debug.hpp
@@ -63,6 +63,8 @@ enum class logging_category : size_t
     LSHELL  = 9,
     // Input-Method-related events
     IM      = 10,
+    // Rendering-related events
+    RENDER  = 11,
     TOTAL,
 };
 

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'03'24'2;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'03'27;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/unstable/translation-node.hpp
+++ b/src/api/wayfire/unstable/translation-node.hpp
@@ -8,6 +8,14 @@ namespace wf
 namespace scene
 {
 /**
+ * Emitted on: translation node
+ * The signal means that the translation node wishes to optimize a scenegraph update, and render instances
+ * should update their internal state to match.
+ */
+struct translation_node_regen_instances_signal
+{};
+
+/**
  * A node which simply applies an offset to its children.
  */
 class translation_node_t : public wf::scene::floating_inner_node_t
@@ -34,6 +42,7 @@ class translation_node_t : public wf::scene::floating_inner_node_t
     void gen_render_instances(std::vector<scene::render_instance_uptr>& instances,
         scene::damage_callback damage, wf::output_t *output) override;
     wf::geometry_t get_bounding_box() override;
+    uint32_t optimize_update(uint32_t flags) override;
 
   protected:
     wf::point_t offset = {0, 0};
@@ -46,6 +55,9 @@ class translation_node_instance_t : public render_instance_t
     damage_callback push_damage;
     translation_node_t *self;
     wf::signal::connection_t<wf::scene::node_damage_signal> on_node_damage;
+    wf::signal::connection_t<wf::scene::translation_node_regen_instances_signal> on_regen_instances;
+    wf::output_t *shown_on;
+    void regen_instances();
 
   public:
     translation_node_instance_t(translation_node_t *self,

--- a/src/api/wayfire/unstable/wlr-subsurface-controller.hpp
+++ b/src/api/wayfire/unstable/wlr-subsurface-controller.hpp
@@ -16,7 +16,7 @@ class wlr_subsurface_root_node_t : public wf::scene::translation_node_t
   public:
     wlr_subsurface_root_node_t(wlr_subsurface *subsurface);
     std::string stringify() const override;
-    void update_offset();
+    bool update_offset(bool damage = true);
 
   private:
     wlr_subsurface *subsurface;

--- a/src/api/wayfire/unstable/wlr-surface-controller.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-controller.hpp
@@ -22,6 +22,8 @@ class wlr_surface_controller_t
     wlr_surface_controller_t(wlr_surface *surface, scene::floating_inner_ptr root_node);
     ~wlr_surface_controller_t();
 
+    void update_subsurface_order_and_position();
+
     scene::floating_inner_ptr root;
     wlr_surface *surface;
 

--- a/src/api/wayfire/unstable/wlr-surface-node.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-node.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "wayfire/geometry.hpp"
+#include "wayfire/signal-definitions.hpp"
 #include "wayfire/util.hpp"
 #include "wayfire/view-transform.hpp"
 #include <wayfire/scene.hpp>
@@ -72,8 +73,17 @@ class wlr_surface_node_t : public node_t, public zero_copy_texturable_node_t
     std::unique_ptr<pointer_interaction_t> ptr_interaction;
     std::unique_ptr<touch_interaction_t> tch_interaction;
     wlr_surface *surface;
+
     std::map<wf::output_t*, int> visibility;
+    std::map<wf::output_t*, int> pending_visibility_delta;
+    wf::signal::connection_t<wf::output_removed_signal> on_output_remove;
+
     class wlr_surface_render_instance_t;
+    void handle_enter(wf::output_t *output);
+    void handle_leave(wf::output_t *output);
+    void update_pending_outputs();
+    wf::wl_idle_call idle_update_outputs;
+
     wf::wl_listener_wrapper on_surface_destroyed;
     wf::wl_listener_wrapper on_surface_commit;
 

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -3,18 +3,15 @@
 #include <wayfire/scene.hpp>
 #include <wayfire/view.hpp>
 #include <wayfire/output.hpp>
-#include <set>
 #include <algorithm>
 
 #include "scene-priv.hpp"
-#include "wayfire/debug.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/opengl.hpp"
 #include "wayfire/region.hpp"
 #include "wayfire/scene-input.hpp"
 #include "wayfire/scene-render.hpp"
 #include "wayfire/signal-provider.hpp"
-#include "wayfire/util.hpp"
 #include <wayfire/core.hpp>
 
 namespace wf
@@ -503,6 +500,7 @@ void update(node_ptr changed_node, uint32_t flags)
 
     if (changed_node->parent())
     {
+        flags = changed_node->parent()->optimize_update(flags);
         update(changed_node->parent()->shared_from_this(), flags);
     }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -227,6 +227,10 @@ void parse_extended_debugging(const std::vector<std::string>& categories)
         {
             LOGD("Enabling extended debugging for input method events");
             wf::log::enabled_categories.set((size_t)wf::log::logging_category::IM, 1);
+        } else if (cat == "render")
+        {
+            LOGD("Enabling extended debugging for render events");
+            wf::log::enabled_categories.set((size_t)wf::log::logging_category::RENDER, 1);
         } else
         {
             LOGE("Unrecognized debugging category \"", cat, "\"");

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -51,6 +51,7 @@ struct swapchain_damage_manager_t
 
         if (update_mask & recompute_instances_on)
         {
+            LOGC(RENDER, "Output ", wo->to_string(), ": regenerating instances.");
             auto root = wf::get_core().scene();
             scene::damage_callback push_damage = [=] (wf::region_t region)
             {
@@ -66,6 +67,7 @@ struct swapchain_damage_manager_t
 
         if (update_mask & recompute_visibility_on)
         {
+            LOGC(RENDER, "Output ", wo->to_string(), ": recomputing visibility.");
             wf::region_t region = this->wo->get_layout_geometry();
             for (auto& inst : render_instances)
             {

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -42,6 +42,7 @@ struct swapchain_damage_manager_t
     output_t *wo;
 
     bool pending_gamma_lut = false;
+    wf::wl_idle_call idle_recompute_visibility;
 
     void update_scenegraph(uint32_t update_mask)
     {
@@ -67,12 +68,15 @@ struct swapchain_damage_manager_t
 
         if (update_mask & recompute_visibility_on)
         {
-            LOGC(RENDER, "Output ", wo->to_string(), ": recomputing visibility.");
-            wf::region_t region = this->wo->get_layout_geometry();
-            for (auto& inst : render_instances)
+            idle_recompute_visibility.run_once([=] ()
             {
-                inst->compute_visibility(wo, region);
-            }
+                LOGC(RENDER, "Output ", wo->to_string(), ": recomputing visibility.");
+                wf::region_t region = this->wo->get_layout_geometry();
+                for (auto& inst : render_instances)
+                {
+                    inst->compute_visibility(wo, region);
+                }
+            });
         }
     }
 

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -1,5 +1,4 @@
 #include "wayfire/core.hpp"
-#include "../core/core-impl.hpp"
 #include "view-impl.hpp"
 #include "wayfire/scene-input.hpp"
 #include "wayfire/scene-render.hpp"
@@ -8,14 +7,11 @@
 #include "wayfire/unstable/wlr-surface-controller.hpp"
 #include "wayfire/unstable/wlr-surface-node.hpp"
 #include "wayfire/view.hpp"
-#include "wayfire/workspace-set.hpp"
 #include "wayfire/output-layout.hpp"
 #include <memory>
 #include <wayfire/util/log.hpp>
 #include <wayfire/view-helpers.hpp>
 #include <wayfire/scene-operations.hpp>
-
-#include "xdg-shell.hpp"
 
 void wf::view_implementation::emit_view_map_signal(wayfire_view view, bool has_position)
 {

--- a/src/view/wlr-subsurface-controller.cpp
+++ b/src/view/wlr-subsurface-controller.cpp
@@ -1,14 +1,10 @@
-#include "view/view-impl.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/scene-operations.hpp"
 #include "wayfire/scene.hpp"
-#include "wayfire/signal-definitions.hpp"
-#include "wayfire/unstable/translation-node.hpp"
 #include "wayfire/unstable/wlr-subsurface-controller.hpp"
 #include "wayfire/unstable/wlr-surface-node.hpp"
 #include <memory>
 #include <wayfire/debug.hpp>
-#include <cassert>
 
 wf::wlr_subsurface_controller_t::wlr_subsurface_controller_t(wlr_subsurface *sub)
 {
@@ -81,13 +77,20 @@ std::string wf::wlr_subsurface_root_node_t::stringify() const
     return "subsurface root node";
 }
 
-void wf::wlr_subsurface_root_node_t::update_offset()
+bool wf::wlr_subsurface_root_node_t::update_offset(bool apply_damage)
 {
     wf::point_t offset = {subsurface->current.x, subsurface->current.y};
-    if (offset != get_offset())
+    const bool changed = offset != get_offset();
+
+    if (changed && apply_damage)
     {
         scene::damage_node(this, get_bounding_box());
         set_offset(offset);
         scene::damage_node(this, get_bounding_box());
+    } else if (changed)
+    {
+        set_offset(offset);
     }
+
+    return changed;
 }

--- a/src/view/wlr-surface-controller.cpp
+++ b/src/view/wlr-surface-controller.cpp
@@ -1,16 +1,9 @@
-#include <algorithm>
-#include <map>
 #include <wayfire/util/log.hpp>
-#include "wayfire/geometry.hpp"
-#include "wayfire/opengl.hpp"
-#include "../core/core-impl.hpp"
-#include "wayfire/output.hpp"
 #include <wayfire/util/log.hpp>
-#include "wayfire/render-manager.hpp"
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
-#include "wayfire/signal-definitions.hpp"
 #include "wayfire/unstable/wlr-surface-controller.hpp"
+#include "wayfire/unstable/wlr-surface-node.hpp"
 #include "wayfire/unstable/wlr-subsurface-controller.hpp"
 #include <wayfire/scene-operations.hpp>
 
@@ -20,7 +13,8 @@ static void update_subsurface_position(wlr_surface *surface, int, int, void*)
     {
         if (sub->data)
         {
-            ((wf::wlr_subsurface_controller_t*)sub->data)->get_subsurface_root()->update_offset();
+            auto sub_root = ((wf::wlr_subsurface_controller_t*)sub->data)->get_subsurface_root();
+            sub_root->update_offset();
         }
     }
 }
@@ -72,15 +66,17 @@ wf::wlr_surface_controller_t::wlr_surface_controller_t(wlr_surface *surface,
         on_new_subsurface.emit(sub);
     }
 
-    if (!wlr_subsurface_try_from_wlr_surface(surface))
+    on_commit.set_callback([=] (void*)
     {
-        on_commit.set_callback([=] (void*)
+        if (!wlr_subsurface_try_from_wlr_surface(surface))
         {
             wlr_surface_for_each_surface(surface, update_subsurface_position, nullptr);
-        });
+        }
 
-        on_commit.connect(&surface->events.commit);
-    }
+        update_subsurface_order_and_position();
+    });
+
+    on_commit.connect(&surface->events.commit);
 }
 
 wf::wlr_surface_controller_t::~wlr_surface_controller_t()
@@ -99,5 +95,83 @@ void wf::wlr_surface_controller_t::try_free_controller(wlr_surface *surface)
     if (surface->data)
     {
         delete (wlr_surface_controller_t*)surface->data;
+    }
+}
+
+void wf::wlr_surface_controller_t::update_subsurface_order_and_position()
+{
+    auto old_bbox = root->get_bounding_box();
+
+    // Calculate whether we need to reorder the surfaces.
+    auto all_subsurfaces = this->root->get_children();
+
+    // Go until we find the main node, it should be a wlr_surface node.
+    auto it = std::find_if(all_subsurfaces.begin(), all_subsurfaces.end(),
+        [=] (const scene::node_ptr& node)
+    {
+        if (auto wlr_node = dynamic_cast<scene::wlr_surface_node_t*>(node.get()))
+        {
+            return wlr_node->get_surface() == surface;
+        }
+
+        return false;
+    });
+
+    if (it == all_subsurfaces.end())
+    {
+        // Maybe unmapped? Can't do anything at the moment anyway.
+        return;
+    }
+
+    // Now, put all subsurfaces above in the right order, then main view, then subsurfaces below.
+    // For nodes that we have not copied, we put them at the start/end depending on their original
+    // position.
+    std::vector<scene::node_ptr> new_subsurface_order;
+
+    // Update subsurface order
+    bool subsurface_repositioned = false;
+
+    wlr_subsurface *sub;
+    wl_list_for_each_reverse(sub, &surface->current.subsurfaces_above, current.link)
+    {
+        auto sub_root = ((wf::wlr_subsurface_controller_t*)sub->data)->get_subsurface_root();
+        new_subsurface_order.push_back(sub_root);
+        subsurface_repositioned |= sub_root->update_offset(false);
+    }
+    new_subsurface_order.push_back(*it);
+    wl_list_for_each_reverse(sub, &surface->current.subsurfaces_below, current.link)
+    {
+        auto sub_root = ((wf::wlr_subsurface_controller_t*)sub->data)->get_subsurface_root();
+        new_subsurface_order.push_back(sub_root);
+        subsurface_repositioned |= sub_root->update_offset(false);
+    }
+
+    // Place compositor subsurfaces correctly: either on top or below.
+    for (auto iter = all_subsurfaces.begin(); iter != all_subsurfaces.end(); ++iter)
+    {
+        if (!dynamic_cast<scene::wlr_surface_node_t*>(iter->get()) &&
+            !dynamic_cast<wlr_subsurface_root_node_t*>(iter->get()))
+        {
+            if (iter < it)
+            {
+                new_subsurface_order.insert(new_subsurface_order.begin(), *iter);
+            } else
+            {
+                new_subsurface_order.push_back(*iter);
+            }
+        }
+    }
+
+    const bool order_changed = new_subsurface_order != all_subsurfaces;
+    if (order_changed || subsurface_repositioned)
+    {
+        wf::scene::damage_node(root, old_bbox);
+        if (order_changed)
+        {
+            root->set_children_list(new_subsurface_order);
+            wf::scene::update(root, wf::scene::update_flag::CHILDREN_LIST);
+        }
+
+        wf::scene::damage_node(root, root->get_bounding_box());
     }
 }

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -431,7 +431,7 @@ wlr_surface*wf::scene::wlr_surface_node_t::get_surface() const
 
 std::optional<wf::texture_t> wf::scene::wlr_surface_node_t::to_texture() const
 {
-    if (this->current_state.current_buffer)
+    if (this->current_state.current_buffer && (this->current_state.transform == WL_OUTPUT_TRANSFORM_NORMAL))
     {
         return wf::texture_t{current_state.texture, current_state.src_viewport};
     }


### PR DESCRIPTION
This PR changes the ABI but there should be no plugin breaking changes, so a simple recompile should suffice.

Fixes #2264
Fixes #1272
Fixes #864 

This PR also potentially significantly improves CPU usage, for example in a Firefox+gfx.webrender, from 80% total CPU usage to around 15%.
