### PR TITLE
session-lock: refocus after lock destroyed.

### DIFF
--- a/plugins/protocols/session-lock.cpp
+++ b/plugins/protocols/session-lock.cpp
@@ -474,6 +474,7 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
           case DESTROYED:
             // Session lock client terminated after unlocking.
             cur_lock.reset();
+            wf::get_core().seat->refocus();
             break;
 
           case ZOMBIE:


### PR DESCRIPTION
This ensures the active window, if any, has focus after the the screen is unlocked.

Fixes #2280