### PR TITLE
wlr-surface-node: don't render to deleted outputs

### DIFF
--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -123,6 +123,13 @@ wf::scene::wlr_surface_node_t::wlr_surface_node_t(wlr_surface *surface, bool aut
 
         for (auto& [wo, _] : visibility)
         {
+            if (!wo->render)
+            {
+                // Client committed buffer to output that is being deleted?
+                LOGE("Trying to render ", this->surface, " to deleted output ", wo->handle);
+                continue;
+            }
+
             wo->render->schedule_redraw();
         }
     });


### PR DESCRIPTION
Fixes #2319