### PR TITLE
Remove comment that says wf-dock started with autostart_wf_shell

### DIFF
--- a/wayfire.ini
+++ b/wayfire.ini
@@ -130,7 +130,6 @@ autostart_wf_shell = true
 #
 # background = wf-background
 # panel = wf-panel
-# dock = wf-dock
 
 # Output configuration
 # https://wayland.emersion.fr/kanshi/

--- a/wayfire.ini
+++ b/wayfire.ini
@@ -130,6 +130,11 @@ autostart_wf_shell = true
 #
 # background = wf-background
 # panel = wf-panel
+#
+# You may also use wf-dock,
+# which is included in wf-shell but is not enabled by default.
+#
+# dock = wf-dock
 
 # Output configuration
 # https://wayland.emersion.fr/kanshi/


### PR DESCRIPTION
Quick PR to remove comment from waybar.ini that says wf-dock is started by autostart_wf_shell ([issue](https://github.com/WayfireWM/wayfire/issues/2327))

Fixes #2327 