### PR TITLE
send preferred_buffer_scale event after entering an output

### DIFF
--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -485,7 +485,6 @@ void wf::scene::wlr_surface_node_t::update_pending_outputs()
             if (surface)
             {
                 wlr_surface_send_enter(surface, wo->handle);
-                wlr_fractional_scale_v1_notify_scale(surface, wo->handle->scale);
             }
         } else if (delta < 0)
         {
@@ -506,6 +505,18 @@ void wf::scene::wlr_surface_node_t::update_pending_outputs()
                 visibility.erase(wo);
             }
         }
+    }
+
+    if (surface && (visibility.size() > 0))
+    {
+        float max_scale = 1;
+        for (auto x : visibility)
+        {
+            max_scale = std::max(max_scale, x.first->handle->scale);
+        }
+
+        wlr_fractional_scale_v1_notify_scale(surface, max_scale);
+        wlr_surface_set_preferred_buffer_scale(surface, max_scale);
     }
 
     pending_visibility_delta.clear();


### PR DESCRIPTION
Qt 6.7.0+ requires this to correctly scale when fractional scale is not enabled.

A simple PyQt6 program to demostrate:

```py
#!/usr/bin/python3

import sys

from PyQt6 import QtWidgets, QtCore

def main():
  QtWidgets.QApplication.setHighDpiScaleFactorRoundingPolicy(
    QtCore.Qt.HighDpiScaleFactorRoundingPolicy.RoundPreferFloor)

  app = QtWidgets.QApplication(sys.argv)
  test = QtWidgets.QLabel("测试 Qt")
  test.show()
  sys.exit(app.exec())

if __name__ == '__main__':
  main()
```

Setting `QT_SCALE_FACTOR_ROUNDING_POLICY=RoundPreferFloor` for Qt6 apps should also reproduce it but not tested. This happens with Telegram (with "presice High DPI scaling" disabled) + Qt6 6.7.0.

Fixes #2253 