### PR TITLE
another round of fuzz testing

### DIFF
--- a/ipc-scripts/headless.py
+++ b/ipc-scripts/headless.py
@@ -1,23 +1,34 @@
 import wayfire_socket as ws
 import os
-import sys
 import json
+import argparse
 
 addr = os.getenv('WAYFIRE_SOCKET')
 sock = ws.WayfireSocket(addr)
 
-if sys.argv[1] == "add":
-    output = sock.create_headless_output(int(sys.argv[2]), int(sys.argv[3]))
+parser = argparse.ArgumentParser()
+subparsers = parser.add_subparsers(dest='action')
+
+add = subparsers.add_parser('add')
+add.add_argument('width', nargs='?', type=int, default=1920)
+add.add_argument('height', nargs='?', type=int, default=1080)
+
+remove = subparsers.add_parser('remove')
+remove.add_argument('output')
+
+args = parser.parse_args()
+if args.action == "add":
+    output = sock.create_headless_output(int(args.width), int(args.height))
     if output and 'output' in output:
         print("Created headless output:\n" + json.dumps(output['output'], indent=4))
     else:
         print("Failed to create headless output: " + json.dumps(output, indent=4))
 
-elif sys.argv[1] == "remove":
-    if sys.argv[2].isdigit():
-        print(sock.destroy_headless_output(output_id=int(sys.argv[2])))
+elif args.action == "remove":
+    if args.output.isdigit():
+        print(sock.destroy_headless_output(output_id=int(args.output)))
     else:
-        print(sock.destroy_headless_output(output_name=sys.argv[2]))
+        print(sock.destroy_headless_output(output_name=args.output))
 
 else:
     print("Invalid usage, either add <width> <height> or remove <output-id|output-name>")

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -298,11 +298,15 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
         auto target_output = wf::get_core().output_layout->get_output_at(grab_position.x, grab_position.y);
         if (target_output && (view->get_output() != target_output))
         {
-            auto offset = wf::origin(view->get_output()->get_layout_geometry()) +
+            auto parent = wf::move_drag::get_toplevel(view);
+            auto offset = wf::origin(parent->get_output()->get_layout_geometry()) +
                 -wf::origin(target_output->get_layout_geometry());
 
-            move_view_to_output(view, target_output, false);
-            view->move(view->get_geometry().x + offset.x, view->get_geometry().y + offset.y);
+            move_view_to_output(parent, target_output, false);
+            for (auto& v : parent->enumerate_views(false))
+            {
+                v->move(v->get_geometry().x + offset.x, v->get_geometry().y + offset.y);
+            }
 
             // On the new output
             wf::get_core().default_wm->move_request(view);

--- a/plugins/tile/tree.cpp
+++ b/plugins/tile/tree.cpp
@@ -283,9 +283,14 @@ struct view_node_t::scale_transformer_t : public wf::scene::view_2d_transformer_
     {
         assert(box.width > 0 && box.height > 0);
 
-        this->view->damage();
+        auto _view = view.lock();
+        if (!_view)
+        {
+            return;
+        }
 
-        auto current = toplevel_cast(this->view)->get_geometry();
+        _view->damage();
+        auto current = toplevel_cast(_view.get())->get_geometry();
         if ((current.width <= 0) || (current.height <= 0))
         {
             /* view possibly unmapped?? */

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -454,8 +454,13 @@ class wobbly_state_floating_t : public iwobbly_state_t
         }
 
         /* Synchronize view position with the model */
-        auto new_bbox = view->get_transformed_node()->get_transformer("wobbly")
-            ->get_children_bounding_box();
+        auto tr = view->get_transformed_node()->get_transformer("wobbly");
+        if (!tr)
+        {
+            return true;
+        }
+
+        auto new_bbox = tr->get_children_bounding_box();
         auto wm = view->get_geometry();
 
         int target_x = model->x + wm.x - new_bbox.x;
@@ -470,9 +475,14 @@ class wobbly_state_floating_t : public iwobbly_state_t
 
     void handle_frame() override
     {
-        auto new_bbox = view->get_transformed_node()->get_transformer("wobbly")
-            ->get_children_bounding_box();
-        update_base_geometry(new_bbox);
+        auto tr = view->get_transformed_node()->get_transformer("wobbly");
+        if (tr)
+        {
+            // Transformer might not exist anymore if we've destroyed the model but we still hold on to any
+            // render instances.
+            auto new_bbox = tr->get_children_bounding_box();
+            update_base_geometry(new_bbox);
+        }
     }
 
     void handle_wm_geometry(const wf::geometry_t& old_wm) override

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'04'04;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'04'15;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/view-transform.hpp
+++ b/src/api/wayfire/view-transform.hpp
@@ -394,7 +394,7 @@ class view_2d_transformer_t : public transformer_base_node_t
     void gen_render_instances(std::vector<render_instance_uptr>& instances,
         damage_callback push_damage, wf::output_t *shown_on) override;
 
-    wayfire_view view;
+    std::weak_ptr<wf::view_interface_t> view;
 };
 
 /**
@@ -403,7 +403,7 @@ class view_2d_transformer_t : public transformer_base_node_t
 class view_3d_transformer_t : public transformer_base_node_t
 {
   protected:
-    wayfire_view view;
+    std::weak_ptr<wf::view_interface_t> view;
 
   public:
     glm::mat4 view_proj{1.0}, translation{1.0}, rotation{1.0}, scaling{1.0};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -494,6 +494,8 @@ void wf::start_move_view_to_wset(wayfire_toplevel_view v, std::shared_ptr<wf::wo
 
 void wf::move_view_to_output(wayfire_toplevel_view v, wf::output_t *new_output, bool reconfigure)
 {
+    wf::dassert(!v->parent, "Cannot move a dialog to a different output than its parent!");
+
     auto old_output = v->get_output();
     auto old_wset   = v->get_wset();
 

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -223,6 +223,15 @@ addr2line_result locate_source_file(const demangling_result& dr)
 
 void wf::print_trace(bool fast_mode)
 {
+    if (!fast_mode)
+    {
+    #if HAS_ASAN
+        // We run with asan: just crash and let it print the stacktrace.
+        int *p = 0;
+        *p = 1;
+    #endif
+    }
+
     void *addrlist[MAX_FRAMES];
     int addrlen = backtrace(addrlist, MAX_FRAMES);
     if (addrlen == 0)

--- a/src/meson.build
+++ b/src/meson.build
@@ -83,8 +83,11 @@ endif
 cxx_flags_asan = run_command('/bin/sh', '-c', 'echo $CXXFLAGS $CPPFLAGS | grep fsanitize', check: false)
 if get_option('b_sanitize').contains('address') or cxx_flags_asan.returncode() == 0
   print_trace = false
+  debug_arguments += ['-DHAS_ASAN=1']
   message('Address sanitizer enabled, disabling internal backtrace')
   message('Overriding print_trace build option')
+else
+  debug_arguments += ['-DHAS_ASAN=0']
 endif
 
 if print_trace

--- a/src/view/toplevel-view.cpp
+++ b/src/view/toplevel-view.cpp
@@ -180,6 +180,8 @@ std::vector<wayfire_toplevel_view> wf::toplevel_view_interface_t::enumerate_view
 
 void wf::toplevel_view_interface_t::set_output(wf::output_t *new_output)
 {
+    wf::dassert(!this->parent || this->parent->get_output() == new_output,
+        "Cannot set different output for a view with a parent!");
     wf::view_interface_t::set_output(new_output);
     for (auto& view : this->children)
     {


### PR DESCRIPTION
- ipc-scripts/headless: rewrite with proper python argparse
- scale: properly handle view lifetimes
- view-transform: use weak pointer to views
- debug: force a crash to print asan stacktrace in print_trace(false)
- wobbly: handle case where node outlives transformer
- move: handle race condition where move request comes after button is released
- bump wf-config to fix a race condition

Fixes #2295
Fixes #2297
