### PR TITLE
Provide "natural scrolling" option for mice.

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -111,6 +111,11 @@
 				<default>1.0</default>
 				<min>0.0</min>
 			</option>
+			<option name="mouse_natural_scroll" type="bool">
+				<_short>Mouse natural scroll</_short>
+				<_long>Enables or disables mouse natural (inverted) scrolling.</_long>
+				<default>false</default>
+			</option>
 		</group>
 		<!-- Touchpad -->
 		<group>

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -17,6 +17,7 @@ void wf::pointing_device_t::config_t::load()
     touchpad_cursor_speed.load_option("input/touchpad_cursor_speed");
     touchpad_scroll_speed.load_option("input/touchpad_scroll_speed");
 
+    mouse_natural_scroll_enabled.load_option("input/mouse_natural_scroll");
     touchpad_tap_enabled.load_option("input/tap_to_click");
     touchpad_dwt_enabled.load_option("input/disable_touchpad_while_typing");
     touchpad_dwmouse_enabled.load_option("input/disable_touchpad_while_mouse");
@@ -144,5 +145,11 @@ void wf::pointing_device_t::update_options()
         libinput_device_config_accel_set_speed(dev,
             config.mouse_cursor_speed);
         set_libinput_accel_profile(dev, config.mouse_accel_profile);
+
+        if (libinput_device_config_scroll_has_natural_scroll(dev) > 0)
+        {
+            libinput_device_config_scroll_set_natural_scroll_enabled(dev,
+                (bool)config.mouse_natural_scroll_enabled);
+        }
     }
 }

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -29,6 +29,7 @@ struct pointing_device_t : public input_device_impl_t
         wf::option_wrapper_t<bool> touchpad_dwt_enabled;
         wf::option_wrapper_t<bool> touchpad_dwmouse_enabled;
         wf::option_wrapper_t<bool> touchpad_natural_scroll_enabled;
+        wf::option_wrapper_t<bool> mouse_natural_scroll_enabled;
         wf::option_wrapper_t<bool> touchpad_drag_lock_enabled;
         void load();
     } config;


### PR DESCRIPTION
Many mice support natural/reversed scrolling through libinput these days. This enables mouse natural scrolling throug a separate config option specifically for mice.