### PR TITLE
final fixes for 09

### DIFF
--- a/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
+++ b/plugins/common/wayfire/plugins/common/move-drag-interface.hpp
@@ -728,16 +728,15 @@ class core_drag_t : public signal::provider_t
 
             drag_focus_output_signal data;
             data.previous_focus_output = current_output;
-
             current_output    = output;
             data.focus_output = output;
-            wf::get_core().seat->focus_output(output);
-            emit(&data);
-
             if (output)
             {
-                current_output->render->add_effect(&on_pre_frame, OUTPUT_EFFECT_PRE);
+                wf::get_core().seat->focus_output(output);
+                output->render->add_effect(&on_pre_frame, OUTPUT_EFFECT_PRE);
             }
+
+            emit(&data);
         }
     }
 

--- a/plugins/tile/tree.cpp
+++ b/plugins/tile/tree.cpp
@@ -421,6 +421,11 @@ bool view_node_t::needs_crossfade()
         return true;
     }
 
+    if (!view->get_output())
+    {
+        return false;
+    }
+
     if (view->get_output()->is_plugin_active("simple-tile"))
     {
         // Disable animations while controllers are active

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -730,6 +730,9 @@ void program_t::free_resources()
             GL_CALL(glDeleteProgram(priv->id[i]));
             this->priv->id[i] = 0;
         }
+
+        priv->uniforms[i].clear();
+        priv->attribs[i].clear();
     }
 }
 

--- a/src/core/txn/transaction-manager-impl.hpp
+++ b/src/core/txn/transaction-manager-impl.hpp
@@ -123,6 +123,8 @@ struct wf::txn::transaction_manager_t::impl
             return existing.get() == ev->self;
         });
 
+        wf::dassert(it != committed.end(), "Transaction not found in committed list");
+
         done.push_back(std::move(*it));
         committed.erase(it);
         consider_commit();


### PR DESCRIPTION
- opengl: clear uniforms and attribute locations in free_resources()
- move-drag-interface: fix rare crash where focused output becomes null
- simple-tile: do not do crossfade for views without an output
- transaction: handle case with timeout=0 and empty transactions

Fixes #2342
Fixes #2344
Fixes #2351
