### PR TITLE
core: add a reason hint for keyboard focus change

### DIFF
--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'04'16;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'06'18;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/seat.hpp
+++ b/src/api/wayfire/seat.hpp
@@ -8,6 +8,14 @@
 
 namespace wf
 {
+enum class keyboard_focus_reason
+{
+    USER,
+    GRAB,
+    REFOCUS,
+    UNKNOWN,
+};
+
 /**
  * A seat represents a group of input devices (mouse, keyboard, etc.) which logically belong together.
  * Each seat has its own keyboard, touch, pointer and tablet focus.
@@ -52,7 +60,8 @@ class seat_t
      *
      * The new_focus' last focus timestamp will be updated.
      */
-    void set_active_node(wf::scene::node_ptr node);
+    void set_active_node(wf::scene::node_ptr node,
+        wf::keyboard_focus_reason reason = keyboard_focus_reason::UNKNOWN);
 
     /**
      * Get the node which has current keyboard focus.

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -3,6 +3,7 @@
 
 #include "wayfire/view.hpp"
 #include "wayfire/output.hpp"
+#include "wayfire/seat.hpp"
 
 /**
  * Documentation of signals emitted from core components.
@@ -201,6 +202,7 @@ struct reload_config_signal
 struct keyboard_focus_changed_signal
 {
     wf::scene::node_ptr new_focus;
+    keyboard_focus_reason reason = keyboard_focus_reason::UNKNOWN;
 };
 
 /**

--- a/src/core/seat/seat-impl.hpp
+++ b/src/core/seat/seat-impl.hpp
@@ -55,7 +55,7 @@ struct seat_t::impl
     uint32_t get_modifiers();
     void break_mod_bindings();
 
-    void set_keyboard_focus(wf::scene::node_ptr keyboard_focus);
+    void set_keyboard_focus(wf::scene::node_ptr keyboard_focus, wf::keyboard_focus_reason reason);
     wf::scene::node_ptr keyboard_focus;
     // Keys sent to the current keyboard focus
     std::multiset<uint32_t> pressed_keys;

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -15,8 +15,7 @@ class wayfire_xdg_popup_node;
 class wayfire_xdg_popup : public wf::view_interface_t
 {
   protected:
-    wf::wl_listener_wrapper on_destroy, on_new_popup,
-        on_map, on_unmap, on_ping_timeout, on_reposition;
+    wf::wl_listener_wrapper on_new_popup, on_map, on_unmap, on_ping_timeout, on_reposition;
 
     wf::signal::connection_t<wf::view_geometry_changed_signal> parent_geometry_changed;
     wf::signal::connection_t<wf::view_title_changed_signal> parent_title_changed;
@@ -74,6 +73,8 @@ class wayfire_xdg_popup : public wf::view_interface_t
     void handle_app_id_changed(std::string new_app_id);
     void handle_title_changed(std::string new_title);
     void update_size();
+
+    bool should_close_on_focus_change(wf::keyboard_focus_changed_signal *ev);
 };
 
 void create_xdg_popup(wlr_xdg_popup *popup);


### PR DESCRIPTION
This is useful for example when we want to close popups on actual
focus change (user alt-tabbed, clicked outside of the view, etc.) but
not for 'mundane' reasons like a refocus if the popup does not have a
grab.

Fixes #2381
Workaround for #2365
