### PR TITLE
output-layout: mark custom modes explicitly

### DIFF
--- a/src/api/wayfire/output-layout.hpp
+++ b/src/api/wayfire/output-layout.hpp
@@ -47,6 +47,9 @@ struct output_state_t
     /** Only width, height and refresh fields are used. */
     wlr_output_mode mode;
 
+    /** Whether a custom mode was requested for the output. */
+    bool uses_custom_mode = false;
+
     /* The transform of the output */
     wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
     /* The scale of the output */

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'06'18;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'06'19;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -55,7 +55,7 @@ static wl_output_transform get_transform_from_string(std::string transform)
 }
 
 wlr_output_mode *find_matching_mode(wlr_output *output,
-    const wlr_output_mode& reference)
+    const wlr_output_mode& reference, bool exact_match = false)
 {
     wlr_output_mode *mode;
     wlr_output_mode *best = NULL;
@@ -80,6 +80,11 @@ wlr_output_mode *find_matching_mode(wlr_output *output,
             {
                 // If there is a preferred mode and there is no refresh configured, pick preferred mode.
                 return mode;
+            }
+
+            if (exact_match)
+            {
+                continue;
             }
 
             const int best_so_far = best ? std::abs(best->refresh - target_refresh) : INT_MAX;
@@ -601,7 +606,7 @@ struct output_layout_output_t
     }
 
     /** Change the output mode */
-    void apply_mode(const wlr_output_mode& mode)
+    void apply_mode(const wlr_output_mode& mode, bool custom_mode)
     {
         if (handle->current_mode)
         {
@@ -620,7 +625,7 @@ struct output_layout_output_t
         }
 
         refresh_custom_modes();
-        auto built_in = find_matching_mode(handle, mode);
+        auto built_in = find_matching_mode(handle, mode, custom_mode);
         if (built_in)
         {
             wlr_output_set_mode(handle, built_in);
@@ -892,7 +897,7 @@ struct output_layout_output_t
         }
 
         set_enabled(!(state.source & OUTPUT_IMAGE_SOURCE_NONE));
-        apply_mode(state.mode);
+        apply_mode(state.mode, state.uses_custom_mode);
 
         if (state.source & OUTPUT_IMAGE_SOURCE_SELF)
         {
@@ -1074,6 +1079,7 @@ class output_layout_t::impl
                 state.mode.width   = head->state.custom_mode.width;
                 state.mode.height  = head->state.custom_mode.height;
                 state.mode.refresh = head->state.custom_mode.refresh;
+                state.uses_custom_mode = true;
             }
 
             state.position  = {head->state.x, head->state.y};


### PR DESCRIPTION
Fixes #2379
