### PR TITLE
toplevel-views: be more careful when mapping views

### DIFF
--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -60,6 +60,8 @@ class view_interface_t::view_priv_impl
 void adjust_geometry_for_gravity(wf::toplevel_state_t& desired_state, wf::dimensions_t actual_size);
 
 void adjust_view_output_on_map(wf::toplevel_view_interface_t *self);
+void adjust_view_pending_geometry_on_start_map(wf::toplevel_view_interface_t *self,
+    wf::geometry_t map_geometry_client, bool map_fs, bool map_maximized);
 
 /** Emit the map signal for the given view */
 void init_xdg_shell();

--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -508,12 +508,14 @@ void wf::xdg_toplevel_view_t::start_map_tx()
     LOGC(VIEWS, "Start mapping ", self());
     wlr_box box;
     wlr_xdg_surface_get_geometry(xdg_toplevel->base, &box);
+
     auto margins = wtoplevel->pending().margins;
+    box.x = wtoplevel->pending().geometry.x + margins.left;
+    box.y = wtoplevel->pending().geometry.y + margins.top;
 
     wtoplevel->pending().mapped = true;
-    wtoplevel->pending().geometry.width = box.width + margins.left + margins.right;
-    wtoplevel->pending().geometry.height = box.height + margins.top + margins.bottom;
     priv->set_mapped_surface_contents(main_surface);
+    adjust_view_pending_geometry_on_start_map(this, box, pending_fullscreen(), pending_tiled_edges());
     wf::get_core().tx_manager->schedule_object(wtoplevel);
 }
 


### PR DESCRIPTION
Depending on their state, we might want different things.

Fixes a regression introduced somewhere in the last commits.

Also, this makes xdg-toplevels not exceed the output size when they are created, which is already being done for Xwayland views.
We will have to consider whether this makes sense at all...
