### PR TITLE
Set initial decoration mode properly

### DIFF
--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -304,7 +304,7 @@ void wf::xdg_toplevel_view_t::map()
 {
     if (xdg_toplevel && uses_csd.count(xdg_toplevel->base->surface))
     {
-        this->has_client_decoration = uses_csd[xdg_toplevel->base->surface];
+        this->set_decoration_mode(uses_csd[xdg_toplevel->base->surface]);
     }
 
     adjust_view_output_on_map(this);


### PR DESCRIPTION
This sets the initial decoration mode properly for clients that announce the `wl_surface` with the decoration protocol before the xdg-surface view, such as GTK 4, so that they are properly decorated.