### PR TITLE
move: Check if grid is enabled before activating edges on drag

### DIFF
--- a/plugins/grid/grid.cpp
+++ b/plugins/grid/grid.cpp
@@ -102,7 +102,15 @@ class wayfire_grid : public wf::plugin_interface_t, public wf::per_output_tracke
                 return false;
             });
         }
+
+        wf::get_core().connect(&grid_request_signal_cb);
     }
+
+    wf::signal::connection_t<wf::grid::grid_request_signal> grid_request_signal_cb =
+        [=] (wf::grid::grid_request_signal *ev)
+    {
+        ev->carried_out = true;
+    };
 
     void handle_new_output(wf::output_t *output) override
     {

--- a/plugins/grid/wayfire/plugins/grid.hpp
+++ b/plugins/grid/wayfire/plugins/grid.hpp
@@ -9,6 +9,18 @@ namespace wf
 namespace grid
 {
 /**
+ * name: request
+ * on: core
+ * when: Emitted before move renders a grid indicator and sets the slot.
+ * carried_out: true if a plugin can handle move request to grid.
+ */
+struct grid_request_signal
+{
+    /* True if a plugin handled this signal */
+    bool carried_out = false;
+};
+
+/**
  * The slot where a view can be placed with grid.
  * BL = bottom-left, TR = top-right, etc.
  */

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -490,7 +490,16 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
             slot.preview = nullptr;
         }
 
-        slot.slot_id = new_slot_id;
+        wf::grid::grid_request_signal grid_signal;
+        wf::get_core().emit(&grid_signal);
+
+        if (grid_signal.carried_out || (new_slot_id == wf::grid::slot_t::SLOT_CENTER))
+        {
+            slot.slot_id = new_slot_id;
+        } else
+        {
+            slot.slot_id = new_slot_id = wf::grid::slot_t::SLOT_NONE;
+        }
 
         /* Show a preview overlay */
         if (new_slot_id)


### PR DESCRIPTION
Before, dragging to an edge with move enabled and grid disabled would result in the indicator being drawn for the slot but always maximized. Fix this by emitting a signal that grid or another plugin can tell move the request is handled, so move can try gridding. In this implementation, we just hard code top to maximize if grid is disabled.

Fixes #2403.