### PR TITLE
workarounds: Clean up metadata

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -26,41 +26,47 @@
 			<_long>If false, the main window can be focused even if it has a dialog. The dialog is nevertheless kept on top of the main window. Kwin defaults to false.</_long>
 			<default>true</default>
 		</option>
-    <option name="dynamic_repaint_delay" type="bool">
-      <_short>Allow dynamic repaint delay</_short>
-      <_long>If true, allows Wayfire to dynamically recalculate its max_render_time, i.e allow render time higher than max_render_time.</_long>
-      <default>false</default>
-    </option>
-    <option name="use_external_output_configuration" type="bool">
-      <_short>Use external output configuration instead of Wayfire's own.</_short>
-      <_long>If true, Wayfire will not handle any configuration options for outputs in the config file once an
-      external daemon like https://github.com/emersion/kanshi sets the output configuration via the wlr-output-management protocol.
-      Exceptions are made for options not available via wlr-output-management, like output mirroring and custom modelines.</_long>
-      <default>false</default>
-    </option>
-    <option name="remove_output_limits" type="bool">
-      <_short>Allow views to overlap between multiple outputs. Many of the core plugins will not behave properly with this option set!</_short>
-      <default>false</default>
-    </option>
-    <option name="force_preferred_decoration_mode" type="bool">
-      <_short>Force xdg-decoration clients to use the compositor-preferred decoration mode regardless of the client's preference.</_short>
-      <default>false</default>
-    </option>
-    <option name="enable_so_unloading" type="bool">
-      <_short>Enable calling dlclose() when a plugin is unloaded. Note that this may not work well with all plugins.</_short>
-      <default>false</default>
-    </option>
-    <option name="discard_command_output" type="bool">
-      <_short>Discard output from commands invoked by Wayfire, so that they don't end up in the logs.</_short>
-      <default>true</default>
-    </option>
-    <option name="enable_input_method_v2" type="bool">
-      <_short>Enable support for the newer input-method-v2 protocol. Note that the input-method-v1 protocol works better in many cases.</_short>
-      <default>false</default>
-    </option>
-    <option name="enable_opaque_region_damage_optimizations" type="bool">
-      <_short>Enable certain damage optimizations which are based on a surfaces' opaque regions. In some cases, this optimization might give unexpected results (i.e background app stops updating) even though this is fine according to Wayland's protocol.</_short>
-      <default>false</default>
-    </option>
+		<option name="dynamic_repaint_delay" type="bool">
+			<_short>Allow dynamic repaint delay</_short>
+			<_long>If true, allows Wayfire to dynamically recalculate its max_render_time, i.e allow render time higher than max_render_time.</_long>
+			<default>false</default>
+		</option>
+		<option name="use_external_output_configuration" type="bool">
+			<_short>Use external output configuration instead of Wayfire's own.</_short>
+			<_long>If true, Wayfire will not handle any configuration options for outputs in the config file once an
+			external daemon like https://github.com/emersion/kanshi sets the output configuration via the wlr-output-management protocol.
+			Exceptions are made for options not available via wlr-output-management, like output mirroring and custom modelines.</_long>
+			<default>false</default>
+		</option>
+		<option name="remove_output_limits" type="bool">
+			<_short>Allow views to overlap between multiple outputs.</_short>
+			<_long>Allow views to overlap between multiple outputs. Many of the core plugins will not behave properly with this option set!</_long>
+			<default>false</default>
+		</option>
+		<option name="force_preferred_decoration_mode" type="bool">
+			<_short>Force xdg-decoration clients to use the compositor-preferred decoration mode.</_short>
+			<_long>Force xdg-decoration clients to use the compositor-preferred decoration mode regardless of the client's preference.</_long>
+			<default>false</default>
+		</option>
+		<option name="enable_so_unloading" type="bool">
+			<_short>Enable calling dlclose() when a plugin is unloaded</_short>
+			<_long>Enable calling dlclose() when a plugin is unloaded. Note that this may not work well with all plugins.</_long>
+			<default>false</default>
+		</option>
+		<option name="discard_command_output" type="bool">
+			<_short>Discard output from commands invoked by Wayfire.</_short>
+			<_long>Discard output from commands invoked by Wayfire, so that they don't end up in the logs.</_long>
+			<default>true</default>
+		</option>
+		<option name="enable_input_method_v2" type="bool">
+			<_short>Enable support for the newer input-method-v2 protocol.</_short>
+			<_long>Enable support for the newer input-method-v2 protocol. Note that the input-method-v1 protocol works better in many cases.</_long>
+			<default>false</default>
+		</option>
+		<option name="enable_opaque_region_damage_optimizations" type="bool">
+			<_short>Enable certain damage optimizations which are based on a surfaces' opaque regions.</_short>
+			<_long>Enable certain damage optimizations which are based on a surfaces' opaque regions. In some cases, this optimization might give unexpected results (i.e background app stops updating) even though this is fine according to Wayland's protocol.</_long>
+			<default>false</default>
+		</option>
 	</plugin>
 </wayfire>


### PR DESCRIPTION
This makes the long options appear in tooltips and adds a short field for the option name, in wcm.