### PR TITLE
transactions: Use correct geometry when adjusting for gravity

### DIFF
--- a/src/view/xdg-shell/xdg-toplevel.cpp
+++ b/src/view/xdg-shell/xdg-toplevel.cpp
@@ -201,7 +201,7 @@ void wf::xdg_toplevel_t::handle_surface_commit()
         return;
     }
 
-    adjust_geometry_for_gravity(_pending, toplevel_size);
+    adjust_geometry_for_gravity(_pending, wf::dimensions(pending().geometry));
     LOGC(VIEWS, "Client-initiated resize to geometry ", pending().geometry);
     auto tx = wf::txn::transaction_t::create();
     tx->add_object(shared_from_this());


### PR DESCRIPTION
It is apparent from the comment following this line, that this was the intention. This fixes a decoration sizing bug with ignore_views matching 'maximized is true'. This can be seen when toggling maximized for apps such as wcm.