### PR TITLE
Add wlroots to DesktopNames

### DIFF
--- a/wayfire.desktop
+++ b/wayfire.desktop
@@ -4,4 +4,4 @@ Exec=wayfire
 TryExec=wayfire
 Icon=
 Type=Application
-DesktopNames=Wayfire
+DesktopNames=Wayfire;wlroots


### PR DESCRIPTION
For convenience of making units or autostart entries common for all wlroots compositors