### PR TITLE
Port to wlroots 0.18.x

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:latest
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake libdisplay-info-dev hwdata-dev nlohmann-json
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake libdisplay-info-dev hwdata-dev nlohmann-json
+    - run: git clone https://gitlab.freedesktop.org/wayland/wayland && cd wayland && git checkout 1.23.0 && meson setup build -Ddocumentation=false -Dtests=false --prefix=/usr && ninja -C build && ninja -C build install && cd .. && rm -rf wayland
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:latest
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake libdisplay-info-dev hwdata-dev nlohmann-json
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake libdisplay-info-dev hwdata-dev nlohmann-json
     - run: git clone https://gitlab.freedesktop.org/wayland/wayland && cd wayland && git checkout 1.23.0 && meson setup build -Ddocumentation=false -Dtests=false --prefix=/usr && ninja -C build && ninja -C build install && cd .. && rm -rf wayland
+    - run: git clone https://gitlab.freedesktop.org/mesa/drm && cd drm && meson setup build --prefix=/usr && ninja -C build && ninja -C build install && cd .. && rm -rf drm
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive

--- a/meson.build
+++ b/meson.build
@@ -42,11 +42,11 @@ if get_option('use_system_wlroots').disabled()
 
 elif get_option('use_system_wlroots').enabled()
 	use_system_wlroots = true
-	wlroots = dependency('wlroots', version: ['>=0.18.0', '<0.19.0'], required: true)
+	wlroots = dependency('wlroots-0.18', version: ['>=0.18.0', '<0.19.0'], required: true)
 
 elif get_option('use_system_wlroots').auto()
 	message( 'SEARCHING FOR WLROOTS' )
-	wlroots = dependency('wlroots', version: ['>=0.18.0', '<0.19.0'], required: false)
+	wlroots = dependency('wlroots-0.18', version: ['>=0.18.0', '<0.19.0'], required: false)
 	use_system_wlroots = true
 	if not wlroots.found()
 		use_system_wlroots = false

--- a/meson.build
+++ b/meson.build
@@ -42,11 +42,11 @@ if get_option('use_system_wlroots').disabled()
 
 elif get_option('use_system_wlroots').enabled()
 	use_system_wlroots = true
-	wlroots = dependency('wlroots', version: ['>=0.17.0', '<0.18.0'], required: true)
+	wlroots = dependency('wlroots', version: ['>=0.18.0', '<0.19.0'], required: true)
 
 elif get_option('use_system_wlroots').auto()
 	message( 'SEARCHING FOR WLROOTS' )
-	wlroots = dependency('wlroots', version: ['>=0.17.0', '<0.18.0'], required: false)
+	wlroots = dependency('wlroots', version: ['>=0.18.0', '<0.19.0'], required: false)
 	use_system_wlroots = true
 	if not wlroots.found()
 		use_system_wlroots = false

--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -272,7 +272,7 @@ class wayfire_cube : public wf::per_output_plugin_instance_t, public wf::pointer
 
     void handle_pointer_button(const wlr_pointer_button_event& event) override
     {
-        if (event.state == WLR_BUTTON_RELEASED)
+        if (event.state == WL_POINTER_BUTTON_STATE_RELEASED)
         {
             input_ungrabbed();
         }
@@ -280,7 +280,7 @@ class wayfire_cube : public wf::per_output_plugin_instance_t, public wf::pointer
 
     void handle_pointer_axis(const wlr_pointer_axis_event& event) override
     {
-        if (event.orientation == WLR_AXIS_ORIENTATION_VERTICAL)
+        if (event.orientation == WL_POINTER_AXIS_VERTICAL_SCROLL)
         {
             pointer_scrolled(event.delta);
         }

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -246,7 +246,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
             return;
         }
 
-        handle_action(layout.handle_press_event(ev.state == WLR_BUTTON_PRESSED));
+        handle_action(layout.handle_press_event(ev.state == WL_POINTER_BUTTON_STATE_PRESSED));
     }
 
     void handle_action(wf::decor::decoration_layout_t::action_response_t action)

--- a/plugins/ipc-rules/ipc-input-methods.hpp
+++ b/plugins/ipc-rules/ipc-input-methods.hpp
@@ -55,9 +55,20 @@ class ipc_rules_input_methods_t
         for (auto& device : wf::get_core().get_input_devices())
         {
             nlohmann::json d;
-            d["id"]   = (intptr_t)device->get_wlr_handle();
-            d["name"] = nonull(device->get_wlr_handle()->name);
-            d["type"] = wlr_input_device_type_to_string(device->get_wlr_handle()->type);
+            d["id"]     = (intptr_t)device->get_wlr_handle();
+            d["name"]   = nonull(device->get_wlr_handle()->name);
+            d["vendor"] = "unknown";
+            d["product"] = "unknown";
+            if (wlr_input_device_is_libinput(device->get_wlr_handle()))
+            {
+                if (auto libinput_handle = wlr_libinput_get_device_handle(device->get_wlr_handle()))
+                {
+                    d["vendor"]  = libinput_device_get_id_vendor(libinput_handle);
+                    d["product"] = libinput_device_get_id_product(libinput_handle);
+                }
+            }
+
+            d["type"]    = wlr_input_device_type_to_string(device->get_wlr_handle()->type);
             d["enabled"] = device->is_enabled();
             response.push_back(d);
         }

--- a/plugins/ipc-rules/ipc-input-methods.hpp
+++ b/plugins/ipc-rules/ipc-input-methods.hpp
@@ -35,7 +35,7 @@ class ipc_rules_input_methods_t
           case WLR_INPUT_DEVICE_TOUCH:
             return "touch";
 
-          case WLR_INPUT_DEVICE_TABLET_TOOL:
+          case WLR_INPUT_DEVICE_TABLET:
             return "tablet_tool";
 
           case WLR_INPUT_DEVICE_TABLET_PAD:
@@ -55,10 +55,14 @@ class ipc_rules_input_methods_t
         for (auto& device : wf::get_core().get_input_devices())
         {
             nlohmann::json d;
-            d["id"]     = (intptr_t)device->get_wlr_handle();
-            d["name"]   = nonull(device->get_wlr_handle()->name);
-            d["vendor"] = device->get_wlr_handle()->vendor;
-            d["product"] = device->get_wlr_handle()->product;
+            d["id"]   = (intptr_t)device->get_wlr_handle();
+            d["name"] = nonull(device->get_wlr_handle()->name);
+            if (auto touch_device = wlr_tablet_from_input_device(device->get_wlr_handle()))
+            {
+                d["vendor"]  = touch_device->usb_vendor_id;
+                d["product"] = touch_device->usb_product_id;
+            }
+
             d["type"]    = wlr_input_device_type_to_string(device->get_wlr_handle()->type);
             d["enabled"] = device->is_enabled();
             response.push_back(d);

--- a/plugins/ipc-rules/ipc-input-methods.hpp
+++ b/plugins/ipc-rules/ipc-input-methods.hpp
@@ -57,13 +57,7 @@ class ipc_rules_input_methods_t
             nlohmann::json d;
             d["id"]   = (intptr_t)device->get_wlr_handle();
             d["name"] = nonull(device->get_wlr_handle()->name);
-            if (auto tablet_device = wlr_tablet_from_input_device(device->get_wlr_handle()))
-            {
-                d["vendor"]  = tablet_device->usb_vendor_id;
-                d["product"] = tablet_device->usb_product_id;
-            }
-
-            d["type"]    = wlr_input_device_type_to_string(device->get_wlr_handle()->type);
+            d["type"] = wlr_input_device_type_to_string(device->get_wlr_handle()->type);
             d["enabled"] = device->is_enabled();
             response.push_back(d);
         }

--- a/plugins/ipc-rules/ipc-input-methods.hpp
+++ b/plugins/ipc-rules/ipc-input-methods.hpp
@@ -57,10 +57,10 @@ class ipc_rules_input_methods_t
             nlohmann::json d;
             d["id"]   = (intptr_t)device->get_wlr_handle();
             d["name"] = nonull(device->get_wlr_handle()->name);
-            if (auto touch_device = wlr_tablet_from_input_device(device->get_wlr_handle()))
+            if (auto tablet_device = wlr_tablet_from_input_device(device->get_wlr_handle()))
             {
-                d["vendor"]  = touch_device->usb_vendor_id;
-                d["product"] = touch_device->usb_product_id;
+                d["vendor"]  = tablet_device->usb_vendor_id;
+                d["product"] = tablet_device->usb_product_id;
             }
 
             d["type"]    = wlr_input_device_type_to_string(device->get_wlr_handle()->type);

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -63,7 +63,7 @@ class ipc_rules_utility_methods_t
         if (!headless_backend)
         {
             auto& core = wf::get_core();
-            headless_backend = wlr_headless_backend_create(core.display);
+            headless_backend = wlr_headless_backend_create(core.ev_loop);
             wlr_multi_backend_add(core.backend, headless_backend);
             wlr_backend_start(headless_backend);
         }

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -94,7 +94,7 @@ class headless_input_backend_t
     headless_input_backend_t()
     {
         auto& core = wf::get_core();
-        backend = wlr_headless_backend_create(core.display);
+        backend = wlr_headless_backend_create(core.ev_loop);
         wlr_multi_backend_add(core.backend, backend);
 
         wlr_pointer_init(&pointer, &pointer_impl, "stipc_pointer");
@@ -140,7 +140,7 @@ class headless_input_backend_t
         wlr_keyboard_notify_key(&keyboard, &ev);
     }
 
-    void do_button(uint32_t button, wlr_button_state state)
+    void do_button(uint32_t button, wl_pointer_button_state state)
     {
         wlr_pointer_button_event ev;
         ev.pointer   = &pointer;
@@ -479,12 +479,12 @@ class stipc_plugin_t : public wf::plugin_interface_t
                 input->do_key(KEY_LEFTMETA, WL_KEYBOARD_KEY_STATE_PRESSED);
             }
 
-            input->do_button(button->code, WLR_BUTTON_PRESSED);
+            input->do_button(button->code, WL_POINTER_BUTTON_STATE_PRESSED);
         }
 
         if ((mode == "release") || (mode == "full"))
         {
-            input->do_button(button->code, WLR_BUTTON_RELEASED);
+            input->do_button(button->code, WL_POINTER_BUTTON_STATE_RELEASED);
             if (button->modifier)
             {
                 input->do_key(KEY_LEFTMETA, WL_KEYBOARD_KEY_STATE_RELEASED);

--- a/plugins/single_plugins/alpha.cpp
+++ b/plugins/single_plugins/alpha.cpp
@@ -151,7 +151,7 @@ class wayfire_alpha : public wf::plugin_interface_t
             return false;
         }
 
-        if (ev->orientation == WLR_AXIS_ORIENTATION_VERTICAL)
+        if (ev->orientation == WL_POINTER_AXIS_VERTICAL_SCROLL)
         {
             update_alpha(view, ev->delta);
 

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -185,7 +185,8 @@ class wayfire_command : public wf::plugin_interface_t
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_button_event>> on_button_event =
         [=] (wf::input_event_signal<wlr_pointer_button_event> *ev)
     {
-        if ((ev->event->button == repeat.pressed_button) && (ev->event->state == WLR_BUTTON_RELEASED))
+        if ((ev->event->button == repeat.pressed_button) &&
+            (ev->event->state == WL_POINTER_BUTTON_STATE_RELEASED))
         {
             reset_repeat();
         }
@@ -194,7 +195,8 @@ class wayfire_command : public wf::plugin_interface_t
     wf::signal::connection_t<wf::input_event_signal<wlr_keyboard_key_event>> on_key_event =
         [=] (wf::input_event_signal<wlr_keyboard_key_event> *ev)
     {
-        if ((ev->event->keycode == repeat.pressed_key) && (ev->event->state == WLR_KEY_RELEASED))
+        if ((ev->event->keycode == repeat.pressed_key) &&
+            (ev->event->state == WL_KEYBOARD_KEY_STATE_RELEASED))
         {
             reset_repeat();
         }
@@ -203,7 +205,8 @@ class wayfire_command : public wf::plugin_interface_t
     wf::signal::connection_t<wf::input_event_signal<wlr_keyboard_key_event>> on_key_event_release =
         [=] (wf::input_event_signal<wlr_keyboard_key_event> *ev)
     {
-        if ((ev->event->keycode == repeat.pressed_key) && (ev->event->state == WLR_KEY_RELEASED))
+        if ((ev->event->keycode == repeat.pressed_key) &&
+            (ev->event->state == WL_KEYBOARD_KEY_STATE_RELEASED))
         {
             repeat.callback();
             repeat.pressed_key = repeat.pressed_button = 0;
@@ -214,7 +217,8 @@ class wayfire_command : public wf::plugin_interface_t
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_button_event>> on_button_event_release =
         [=] (wf::input_event_signal<wlr_pointer_button_event> *ev)
     {
-        if ((ev->event->button == repeat.pressed_button) && (ev->event->state == WLR_BUTTON_RELEASED))
+        if ((ev->event->button == repeat.pressed_button) &&
+            (ev->event->state == WL_POINTER_BUTTON_STATE_RELEASED))
         {
             repeat.callback();
             repeat.pressed_key = repeat.pressed_button = 0;

--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -138,7 +138,7 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
     wf::signal::connection_t<wf::input_event_signal<wlr_pointer_button_event>> on_raw_pointer_button =
         [=] (wf::input_event_signal<wlr_pointer_button_event> *ev)
     {
-        if (ev->event->state == WLR_BUTTON_PRESSED)
+        if (ev->event->state == WL_POINTER_BUTTON_STATE_PRESSED)
         {
             last_input_press_position = get_global_input_coords();
         }
@@ -198,7 +198,7 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
 
     void handle_pointer_button(const wlr_pointer_button_event& event) override
     {
-        if (event.state != WLR_BUTTON_RELEASED)
+        if (event.state != WL_POINTER_BUTTON_STATE_RELEASED)
         {
             return;
         }

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -112,7 +112,8 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
 
     void handle_pointer_button(const wlr_pointer_button_event& event) override
     {
-        if ((event.state == WLR_BUTTON_RELEASED) && was_client_request && (event.button == BTN_LEFT))
+        if ((event.state == WL_POINTER_BUTTON_STATE_RELEASED) && was_client_request &&
+            (event.button == BTN_LEFT))
         {
             return input_pressed(event.state);
         }

--- a/plugins/single_plugins/wrot.cpp
+++ b/plugins/single_plugins/wrot.cpp
@@ -214,7 +214,7 @@ class wf_wrot : public wf::per_output_plugin_instance_t, public wf::pointer_inte
 
     void handle_pointer_button(const wlr_pointer_button_event& event) override
     {
-        if (event.state == WLR_BUTTON_RELEASED)
+        if (event.state == WL_POINTER_BUTTON_STATE_RELEASED)
         {
             input_released();
         }

--- a/plugins/single_plugins/zoom.cpp
+++ b/plugins/single_plugins/zoom.cpp
@@ -57,7 +57,7 @@ class wayfire_zoom_screen : public wf::per_output_plugin_instance_t
             return false;
         }
 
-        if (ev->orientation != WLR_AXIS_ORIENTATION_VERTICAL)
+        if (ev->orientation != WL_POINTER_AXIS_VERTICAL_SCROLL)
         {
             return false;
         }

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -332,7 +332,7 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
 
     void handle_pointer_button(const wlr_pointer_button_event& event) override
     {
-        if (event.state == WLR_BUTTON_RELEASED)
+        if (event.state == WL_POINTER_BUTTON_STATE_RELEASED)
         {
             stop_controller(false);
         }

--- a/proto/meson.build
+++ b/proto/meson.build
@@ -27,7 +27,7 @@ server_protocols = [
     [wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
     [wl_protocol_dir, 'unstable/pointer-constraints/pointer-constraints-unstable-v1.xml'],
     [wl_protocol_dir, 'unstable/relative-pointer/relative-pointer-unstable-v1.xml'],
-    [wl_protocol_dir, 'unstable/tablet/tablet-unstable-v2.xml'],
+    [wl_protocol_dir, 'stable/tablet/tablet-v2.xml'],
     [wl_protocol_dir, 'unstable/keyboard-shortcuts-inhibit/keyboard-shortcuts-inhibit-unstable-v1.xml'],
     [wl_protocol_dir, 'unstable/input-method/input-method-unstable-v1.xml'],
     [wl_protocol_dir, 'staging/ext-session-lock/ext-session-lock-v1.xml'],

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -38,6 +38,7 @@ extern "C"
 #include <wlr/types/wlr_damage_ring.h>
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/util/region.h>
+#include <wlr/util/transform.h>
 #include <wlr/types/wlr_screencopy_v1.h>
 #include <wlr/types/wlr_export_dmabuf_v1.h>
 #include <wlr/types/wlr_keyboard_shortcuts_inhibit_v1.h>
@@ -112,7 +113,7 @@ extern "C"
     #include <wlr/types/wlr_pointer_constraints_v1.h>
 #endif
 #include <wlr/types/wlr_cursor.h>
-#if __has_include(<tablet-unstable-v2-protocol.h>)
+#if __has_include(<tablet-v2-protocol.h>)
     #include <wlr/types/wlr_tablet_v2.h>
 #endif
 #include <wlr/types/wlr_tablet_tool.h>
@@ -131,7 +132,6 @@ extern "C"
 #include <wlr/types/wlr_virtual_pointer_v1.h>
 #include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
-#include <wlr/types/wlr_input_inhibitor.h>
 #define delete delete_
 #include <wlr/types/wlr_input_method_v2.h>
 #undef delete

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -96,7 +96,7 @@ void wf::compositor_core_impl_t::init()
 
     /* Legacy DRM */
     if (runtime_config.legacy_wl_drm &&
-        wlr_renderer_get_dmabuf_texture_formats(renderer))
+        wlr_renderer_get_texture_formats(renderer, WLR_BUFFER_CAP_DMABUF))
     {
         wlr_drm_create(display, renderer);
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -137,20 +137,6 @@ void wf::compositor_core_impl_t::init()
         LOGE("Failed to create wlr_drm_lease_device_v1; VR will not be available!");
     }
 
-    /* input-inhibit setup */
-    protocols.input_inhibit = wlr_input_inhibit_manager_create(display);
-    input_inhibit_activated.set_callback([&] (void*)
-    {
-        input->set_exclusive_focus(protocols.input_inhibit->active_client);
-    });
-    input_inhibit_activated.connect(&protocols.input_inhibit->events.activate);
-
-    input_inhibit_deactivated.set_callback([&] (void*)
-    {
-        input->set_exclusive_focus(nullptr);
-    });
-    input_inhibit_deactivated.connect(&protocols.input_inhibit->events.deactivate);
-
     /* idle-inhibit setup */
     protocols.idle_notifier = wlr_idle_notifier_v1_create(display);
     protocols.idle_inhibit  = wlr_idle_inhibit_v1_create(display);

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -621,6 +621,8 @@ struct output_layout_output_t
             {
                 /* Commit the enabling of the output */
                 wlr_output_commit_state(handle, &state);
+                wlr_output_state_finish(&state);
+                wlr_output_state_init(&state);
 
                 return;
             }
@@ -642,6 +644,8 @@ struct output_layout_output_t
         }
 
         wlr_output_commit_state(handle, &state);
+        wlr_output_state_finish(&state);
+        wlr_output_state_init(&state);
 
         const bool adaptive_sync_enabled = (handle->adaptive_sync_status == WLR_OUTPUT_ADAPTIVE_SYNC_ENABLED);
 
@@ -655,9 +659,11 @@ struct output_layout_output_t
             } else
             {
                 LOGE("Failed to change adaptive sync on output: ", handle->name);
-                wlr_output_state_set_adaptive_sync_enabled(&state, adaptive_sync_enabled);
             }
         }
+
+        wlr_output_state_finish(&state);
+        wlr_output_state_init(&state);
 
         if (current_state.depth != current_bit_depth)
         {
@@ -666,6 +672,7 @@ struct output_layout_output_t
                 wlr_output_state_set_render_format(&state, fmt);
                 if (wlr_output_test_state(handle, &state))
                 {
+                    wlr_output_state_set_render_format(&state, fmt);
                     wlr_output_commit_state(handle, &state);
                     current_bit_depth = current_state.depth;
                     LOGD("Set output format to ", get_format_name(fmt), " on output ", handle->name);
@@ -675,6 +682,9 @@ struct output_layout_output_t
                 LOGD("Failed to set output format ", get_format_name(fmt), " on output ", handle->name);
             }
         }
+
+        wlr_output_state_finish(&state);
+        wlr_output_state_init(&state);
     }
 
     /* Mirroring implementation */
@@ -697,6 +707,8 @@ struct output_layout_output_t
 
         wlr_render_pass_submit(pass);
         wlr_output_commit_state(handle, &state);
+        wlr_output_state_finish(&state);
+        wlr_output_state_init(&state);
     }
 
     /* Load output contents and render them */
@@ -737,6 +749,8 @@ struct output_layout_output_t
         if (!enabled)
         {
             wlr_output_commit_state(handle, &state);
+            wlr_output_state_finish(&state);
+            wlr_output_state_init(&state);
         }
     }
 
@@ -917,6 +931,8 @@ struct output_layout_output_t
             }
 
             wlr_output_commit_state(handle, &this->state);
+            wlr_output_state_finish(&this->state);
+            wlr_output_state_init(&this->state);
 
             ensure_wayfire_output(get_effective_size());
             output->render->damage_whole();

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -655,6 +655,7 @@ struct output_layout_output_t
             } else
             {
                 LOGE("Failed to change adaptive sync on output: ", handle->name);
+                wlr_output_state_set_adaptive_sync_enabled(&state, adaptive_sync_enabled);
             }
         }
 

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -655,7 +655,6 @@ struct output_layout_output_t
             } else
             {
                 LOGE("Failed to change adaptive sync on output: ", handle->name);
-                // wlr_output_rollback(handle);
             }
         }
 

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -30,7 +30,7 @@ static std::unique_ptr<wf::input_device_impl_t> create_wf_device_for_device(
       case WLR_INPUT_DEVICE_POINTER:
         return std::make_unique<wf::pointing_device_t>(device);
 
-      case WLR_INPUT_DEVICE_TABLET_TOOL:
+      case WLR_INPUT_DEVICE_TABLET:
         return std::make_unique<wf::tablet_t>(
             wf::get_core_impl().seat->priv->cursor->cursor, device);
 

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -102,7 +102,7 @@ void wf::pointer_t::send_leave_to_focus(wf::scene::node_ptr old_focus)
                 wlr_pointer_button_event event;
                 event.pointer   = NULL;
                 event.button    = button;
-                event.state     = WLR_BUTTON_RELEASED;
+                event.state     = WL_POINTER_BUTTON_STATE_RELEASED;
                 event.time_msec = wf::get_current_time();
                 old_focus->pointer_interaction().handle_pointer_button(event);
             }
@@ -213,7 +213,7 @@ void wf::pointer_t::handle_pointer_button(wlr_pointer_button_event *ev,
     seat->priv->break_mod_bindings();
     bool handled_in_binding = (mode != input_event_processing_mode_t::FULL);
 
-    if (ev->state == WLR_BUTTON_PRESSED)
+    if (ev->state == WL_POINTER_BUTTON_STATE_PRESSED)
     {
         count_pressed_buttons++;
         if (count_pressed_buttons == 1)
@@ -266,12 +266,12 @@ void wf::pointer_t::send_button(wlr_pointer_button_event *ev, bool has_binding)
 
     if (cursor_focus)
     {
-        if ((ev->state == WLR_BUTTON_PRESSED) && cursor_focus)
+        if ((ev->state == WL_POINTER_BUTTON_STATE_PRESSED) && cursor_focus)
         {
             LOGC(POINTER, "normal button press ", ev->button);
             this->currently_sent_buttons.insert(ev->button);
             cursor_focus->pointer_interaction().handle_pointer_button(*ev);
-        } else if ((ev->state == WLR_BUTTON_RELEASED) &&
+        } else if ((ev->state == WL_POINTER_BUTTON_STATE_RELEASED) &&
                    (currently_sent_buttons.count(ev->button) || cursor_focus->wants_raw_input()))
         {
             LOGC(POINTER, "normal button release ", ev->button);
@@ -355,7 +355,7 @@ void wf::pointer_t::handle_pointer_axis(wlr_pointer_axis_event *ev,
     }
 
     /* Calculate speed settings */
-    double mult = ev->source == WLR_AXIS_SOURCE_FINGER ?
+    double mult = ev->source == WL_POINTER_AXIS_SOURCE_FINGER ?
         wf::pointing_device_t::config.touchpad_scroll_speed :
         wf::pointing_device_t::config.mouse_scroll_speed;
 

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -338,7 +338,7 @@ wf::seat_t::seat_t(wl_display *display, std::string name) : seat(wlr_seat_create
 
           case WLR_INPUT_DEVICE_TOUCH:
           case WLR_INPUT_DEVICE_POINTER:
-          case WLR_INPUT_DEVICE_TABLET_TOOL:
+          case WLR_INPUT_DEVICE_TABLET:
             this->priv->cursor->add_new_device(ev->device->get_wlr_handle());
             break;
 

--- a/src/core/seat/tablet.cpp
+++ b/src/core/seat/tablet.cpp
@@ -519,7 +519,7 @@ void wf::tablet_pad_t::select_default_tool()
             return;
         }
 
-        if (dev->get_wlr_handle()->type != WLR_INPUT_DEVICE_TABLET_TOOL)
+        if (dev->get_wlr_handle()->type != WLR_INPUT_DEVICE_TABLET)
         {
             continue;
         }

--- a/src/core/wm.cpp
+++ b/src/core/wm.cpp
@@ -78,7 +78,7 @@ void wayfire_focus::init()
     on_pointer_button = [=] (wf::input_event_signal<wlr_pointer_button_event> *ev)
     {
         if ((ev->mode == wf::input_event_processing_mode_t::IGNORE) ||
-            (ev->event->state != WLR_BUTTON_PRESSED))
+            (ev->event->state != WL_POINTER_BUTTON_STATE_PRESSED))
         {
             return;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -379,7 +379,7 @@ int main(int argc, char *argv[])
     /** TODO: move this to core_impl constructor */
     core.display = display;
     core.ev_loop = wl_display_get_event_loop(core.display);
-    core.backend = wlr_backend_autocreate(core.display, &core.session);
+    core.backend = wlr_backend_autocreate(core.ev_loop, &core.session);
 
     int drm_fd = wlr_backend_get_drm_fd(core.backend);
     if (drm_fd < 0)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,6 +37,7 @@ static void print_help()
         " -D,  --damage-debug      enable additional debug for damaged regions" <<
         std::endl;
     std::cout << " -R,  --damage-rerender   rerender damaged regions" << std::endl;
+    std::cout << " -l,  --legacy-wl-drm     use legacy drm for wayland clients" << std::endl;
     std::cout << " -v,  --version           print version and exit" << std::endl;
     exit(0);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -147,7 +147,7 @@ public_api_requirements = [
     wayland_server,
     pixman,
     # These might be subprojects so we need to pass them as strings
-    'wlroots',
+    'wlroots-0.18',
     'wf-config',
 ]
 

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -1100,9 +1100,9 @@ class wf::render_manager::impl
         }
     }
 
-    void update_bound_output()
+    void update_bound_output(wlr_buffer *buffer)
     {
-        int current_fb = wlr_gles2_renderer_get_current_fbo(output->handle->renderer);
+        int current_fb = wlr_gles2_renderer_get_buffer_fbo(output->handle->renderer, buffer);
         bind_output(current_fb);
 
         postprocessing->set_output_framebuffer(current_fb);
@@ -1137,10 +1137,8 @@ class wf::render_manager::impl
         }
 
         /* Part 2: call the renderer, which sets swap_damage and draws the scenegraph */
-        wlr_renderer_begin_with_buffer(output->handle->renderer, next_frame->buffer);
-        update_bound_output();
+        update_bound_output(next_frame->buffer);
         render_output();
-        wlr_renderer_end(wf::get_core().renderer);
 
         /* Part 3: overlay effects */
         effects->run_effects(OUTPUT_EFFECT_OVERLAY);
@@ -1164,9 +1162,8 @@ class wf::render_manager::impl
          * We render software cursors after everything else
          * for consistency with hardware cursor planes */
         OpenGL::render_begin();
-        wlr_renderer_begin_with_buffer(output->handle->renderer, next_frame->buffer);
-        wlr_output_render_software_cursors(output->handle, swap_damage.to_pixman());
-        wlr_renderer_end(wf::get_core().renderer);
+        wlr_output_add_software_cursors_to_render_pass(output->handle, next_frame->render_pass,
+            swap_damage.to_pixman());
         OpenGL::render_end();
 
         /* Part 6: finalize frame: swap buffers, send frame_done, etc */

--- a/src/view/wlr-subsurface-controller.cpp
+++ b/src/view/wlr-subsurface-controller.cpp
@@ -90,6 +90,9 @@ bool wf::wlr_subsurface_root_node_t::update_offset(bool apply_damage)
     } else if (changed)
     {
         set_offset(offset);
+    } else if (apply_damage)
+    {
+        scene::damage_node(this, get_bounding_box());
     }
 
     return changed;

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -395,8 +395,8 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
 
         wlr_output_state state;
         wlr_output_state_init(&state);
-        wlr_presentation_surface_scanned_out_on_output(wlr_surf, output->handle);
         wlr_output_state_set_buffer(&state, &wlr_surf->buffer->base);
+        wlr_presentation_surface_scanned_out_on_output(wlr_surf, output->handle);
 
         if (wlr_output_commit_state(output->handle, &state))
         {

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -361,8 +361,7 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
     {
         if (self->surface)
         {
-            wlr_presentation_surface_scanned_out_on_output(wf::get_core_impl().protocols.presentation,
-                self->surface, output->handle);
+            wlr_presentation_surface_scanned_out_on_output(self->surface, output->handle);
         }
     }
 
@@ -394,15 +393,18 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
             return direct_scanout::OCCLUSION;
         }
 
-        wlr_presentation_surface_scanned_out_on_output(
-            wf::get_core().protocols.presentation, wlr_surf, output->handle);
-        wlr_output_attach_buffer(output->handle, &wlr_surf->buffer->base);
+        wlr_output_state state;
+        wlr_output_state_init(&state);
+        wlr_presentation_surface_scanned_out_on_output(wlr_surf, output->handle);
+        wlr_output_state_set_buffer(&state, &wlr_surf->buffer->base);
 
-        if (wlr_output_commit(output->handle))
+        if (wlr_output_commit_state(output->handle, &state))
         {
+            wlr_output_state_finish(&state);
             return direct_scanout::SUCCESS;
         } else
         {
+            wlr_output_state_finish(&state);
             return direct_scanout::OCCLUSION;
         }
     }

--- a/src/view/wlr-surface-pointer-interaction.hpp
+++ b/src/view/wlr-surface-pointer-interaction.hpp
@@ -222,7 +222,7 @@ class wlr_surface_pointer_interaction_t final : public wf::pointer_interaction_t
     {
         auto seat = wf::get_core_impl().get_current_seat();
         wlr_seat_pointer_notify_axis(seat, ev.time_msec, ev.orientation,
-            ev.delta, ev.delta_discrete, ev.source);
+            ev.delta, ev.delta_discrete, ev.source, WL_POINTER_AXIS_RELATIVE_DIRECTION_IDENTICAL);
     }
 
     void handle_pointer_leave() final

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -433,7 +433,7 @@ static wf::wl_listener_wrapper on_xdg_created;
 
 void wf::init_xdg_shell()
 {
-    xdg_handle = wlr_xdg_shell_create(wf::get_core().display, 6);
+    xdg_handle = wlr_xdg_shell_create(wf::get_core().display, XDG_TOPLEVEL_STATE_SUSPENDED_SINCE_VERSION);
     if (xdg_handle)
     {
         on_xdg_created.set_callback([&] (void *data)

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -408,7 +408,7 @@ class xdg_popup_controller_t
             view->destroy();
             delete this;
         });
-        on_destroy.connect(&popup->base->events.destroy);
+        on_destroy.connect(&popup->events.destroy);
         view = wayfire_xdg_popup::create(popup);
     }
 

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -433,21 +433,22 @@ static wf::wl_listener_wrapper on_xdg_created;
 
 void wf::init_xdg_shell()
 {
-    xdg_handle = wlr_xdg_shell_create(wf::get_core().display, 3);
+    xdg_handle = wlr_xdg_shell_create(wf::get_core().display, 6);
     if (xdg_handle)
     {
         on_xdg_created.set_callback([&] (void *data)
         {
-            auto surf = static_cast<wlr_xdg_surface*>(data);
+            auto surf = static_cast<wlr_xdg_toplevel*>(data);
             wf::new_xdg_surface_signal new_xdg_surf;
-            new_xdg_surf.surface = surf;
-            wf::get_core().emit(&new_xdg_surf);
-            if (new_xdg_surf.use_default_implementation && (surf->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL))
+            new_xdg_surf.surface = surf->base;
+            wf::get_core().emit(
+                &new_xdg_surf);
+            if (new_xdg_surf.use_default_implementation && (surf->base->role == WLR_XDG_SURFACE_ROLE_TOPLEVEL))
             {
-                default_handle_new_xdg_toplevel(surf->toplevel);
+                default_handle_new_xdg_toplevel(surf);
             }
         });
-        on_xdg_created.connect(&xdg_handle->events.new_surface);
+        on_xdg_created.connect(&xdg_handle->events.new_toplevel);
     }
 }
 

--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -49,7 +49,7 @@ wf::xdg_toplevel_view_base_t::xdg_toplevel_view_base_t(wlr_xdg_toplevel *topleve
         wf::view_implementation::emit_ping_timeout_signal(self());
     });
 
-    on_destroy.connect(&xdg_toplevel->base->events.destroy);
+    on_destroy.connect(&xdg_toplevel->events.destroy);
     on_new_popup.connect(&xdg_toplevel->base->events.new_popup);
     on_ping_timeout.connect(&xdg_toplevel->base->events.ping_timeout);
     on_set_title.connect(&xdg_toplevel->events.set_title);

--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -556,7 +556,7 @@ class xdg_toplevel_controller_t
     xdg_toplevel_controller_t(wlr_xdg_toplevel *toplevel)
     {
         on_destroy.set_callback([=] (auto) { delete this; });
-        on_destroy.connect(&toplevel->base->events.destroy);
+        on_destroy.connect(&toplevel->events.destroy);
         view = wf::xdg_toplevel_view_t::create(toplevel);
 
         on_map.set_callback([=] (void*)

--- a/src/view/xdg-shell/xdg-toplevel.cpp
+++ b/src/view/xdg-shell/xdg-toplevel.cpp
@@ -72,9 +72,6 @@ void wf::xdg_toplevel_t::commit()
         const int configure_width  = std::max(1, desired_size.width);
         const int configure_height = std::max(1, desired_size.height);
         this->target_configure = wlr_xdg_toplevel_set_size(this->toplevel, configure_width, configure_height);
-    } else
-    {
-        wlr_xdg_toplevel_set_size(this->toplevel, current_size.width, current_size.height);
     }
 
     if (_current.tiled_edges != _pending.tiled_edges)

--- a/src/view/xdg-shell/xdg-toplevel.cpp
+++ b/src/view/xdg-shell/xdg-toplevel.cpp
@@ -71,7 +71,6 @@ void wf::xdg_toplevel_t::commit()
         wait_for_client = true;
         const int configure_width  = std::max(1, desired_size.width);
         const int configure_height = std::max(1, desired_size.height);
-        LOGI("setting size: ", configure_width, "x", configure_height);
         this->target_configure = wlr_xdg_toplevel_set_size(this->toplevel, configure_width, configure_height);
     } else
     {

--- a/src/view/xdg-shell/xdg-toplevel.cpp
+++ b/src/view/xdg-shell/xdg-toplevel.cpp
@@ -155,6 +155,12 @@ void wf::xdg_toplevel_t::handle_surface_commit()
 {
     pending_state.merge_state(toplevel->base->surface);
 
+    if (this->toplevel->base->initial_commit)
+    {
+        wlr_xdg_surface_schedule_configure(this->toplevel->base);
+        return;
+    }
+
     const bool is_committed = wf::get_core().tx_manager->is_object_committed(shared_from_this());
     if (is_committed)
     {

--- a/src/view/xdg-shell/xdg-toplevel.cpp
+++ b/src/view/xdg-shell/xdg-toplevel.cpp
@@ -71,7 +71,11 @@ void wf::xdg_toplevel_t::commit()
         wait_for_client = true;
         const int configure_width  = std::max(1, desired_size.width);
         const int configure_height = std::max(1, desired_size.height);
+        LOGI("setting size: ", configure_width, "x", configure_height);
         this->target_configure = wlr_xdg_toplevel_set_size(this->toplevel, configure_width, configure_height);
+    } else
+    {
+        wlr_xdg_toplevel_set_size(this->toplevel, current_size.width, current_size.height);
     }
 
     if (_current.tiled_edges != _pending.tiled_edges)

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -297,7 +297,10 @@ void wf::xwayland_bring_to_front(wlr_surface *surface)
 
     if (wlr_xwayland_surface *xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface))
     {
-        wlr_xwayland_surface_restack(xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
+        if (!xwayland_surface->override_redirect)
+        {
+            wlr_xwayland_surface_restack(xwayland_surface, NULL, XCB_STACK_MODE_ABOVE);
+        }
     }
 
 #endif


### PR DESCRIPTION
Gotchas:

wl_drm was dropped, so clients must update. A notable one is libva, which stopped working with wlroots 0.18 until upgrading libva.

wlr_input_inhibit was dropped and as of now, there is no replacement.

Possibilities:

[linux-drm-syncobj-v1](https://github.com/swaywm/sway/pull/8156/commits/4267b822223c3b215a68b29ae020dc4067ad2e8c)