### PR TITLE
render-manager: Don't call paint when the session is not active

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -396,6 +396,11 @@ struct swapchain_damage_manager_t
      */
     void schedule_repaint()
     {
+        if (!wf::get_core().session->active)
+        {
+            return;
+        }
+
         wlr_output_schedule_frame(output);
         force_next_frame = true;
     }
@@ -957,6 +962,11 @@ class wf::render_manager::impl
 
         on_frame.set_callback([&] (void*)
         {
+            if (!wf::get_core().session->active)
+            {
+                return;
+            }
+
             delay_manager->start_frame();
 
             auto repaint_delay = delay_manager->get_delay();

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -205,7 +205,7 @@ wf::touch_interaction_t& wf::scene::wlr_surface_node_t::touch_interaction()
 
 void wf::scene::wlr_surface_node_t::send_frame_done(bool delay_until_vblank)
 {
-    if (!surface)
+    if (!wf::get_core().session->active || !surface)
     {
         return;
     }


### PR DESCRIPTION
When running wayfire on one tty and having clients that damage constantly, switching to another tty causes wayfire to consume 100% cpu. This patch disconnects the paint handler when the session is not active and reconnects it when the session becomes active again.