### PR TITLE
ipc: Use AF_INET to accept remote connections

### DIFF
--- a/metadata/ipc.xml
+++ b/metadata/ipc.xml
@@ -4,5 +4,10 @@
 		<_short>IPC protocol</_short>
 		<_long>Allow external programs to interact with Wayfire plugins.</_long>
 		<category>Utility</category>
+		<option name="port" type="int">
+			<_short>Starting port</_short>
+			<_long>Sets the port number that the first instance of wayfire will use for IPC. Each subsequent instance will increment the port number by one.</_long>
+			<default>7777</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/ipc/ipc.hpp
+++ b/plugins/ipc/ipc.hpp
@@ -6,6 +6,7 @@
 #include <wayland-server.h>
 #include <wayfire/plugins/common/shared-core-data.hpp>
 #include "ipc-method-repository.hpp"
+#include <netinet/in.h>
 
 namespace wf
 {
@@ -44,7 +45,7 @@ class server_t
 {
   public:
     server_t();
-    void init(std::string socket_path);
+    void init(int port);
     ~server_t();
 
   private:
@@ -60,8 +61,8 @@ class server_t
     /**
      * Setup a socket at the given address, and set it as CLOEXEC and non-blocking.
      */
-    int setup_socket(const char *address);
-    sockaddr_un saddr;
+    int setup_socket(int port);
+    sockaddr_in saddr;
     wl_event_source *source;
     std::vector<std::unique_ptr<client_t>> clients;
 


### PR DESCRIPTION
Locally, this should change nothing, with the corresponding pywayfire patch. Remotely, you can set WAYFIRE_IPC_IP nd WAYFIRE_IPC_PORT to connect with a pywayfire script.