### PR TITLE
Input method: update input method popup positions on text input commit

### DIFF
--- a/plugins/protocols/input-method-v1.cpp
+++ b/plugins/protocols/input-method-v1.cpp
@@ -773,6 +773,10 @@ class wayfire_input_method_v1 : public wf::plugin_interface_t, public wf::text_i
         if (current_im_context && (current_im_context->text_input == im_text_inputs_v3[input].get()))
         {
             current_im_context->handle_text_input_v3_commit();
+
+            wf::text_input_commit_signal data;
+            data.cursor_rect = input->current.cursor_rectangle;
+            emit(&data);
         }
     }
 

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'08'26;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'10'01;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -810,6 +810,15 @@ struct view_system_bell_signal
 {
     wayfire_view view;
 };
+
+/**
+ * on: input method relay
+ * when: A text input commits
+ */
+struct text_input_commit_signal
+{
+    wlr_box cursor_rect;
+};
 }
 
 #endif

--- a/src/api/wayfire/unstable/wlr-text-input-v3-popup.hpp
+++ b/src/api/wayfire/unstable/wlr-text-input-v3-popup.hpp
@@ -7,7 +7,7 @@
 
 namespace wf
 {
-class text_input_v3_im_relay_interface_t
+class text_input_v3_im_relay_interface_t : public wf::signal::provider_t
 {
   public:
     virtual wlr_text_input_v3 *find_focused_text_input_v3() = 0;
@@ -33,10 +33,12 @@ class text_input_v3_popup : public wf::view_interface_t
     void map();
     void unmap();
     void update_geometry();
+    void update_cursor_rect(wlr_box*);
     ~text_input_v3_popup();
 
   private:
     wf::geometry_t geometry{0, 0, 0, 0};
+    wlr_box old_cursor_rect{0, 0, 0, 0};
     std::shared_ptr<wf::scene::wlr_surface_node_t> main_surface;
     std::shared_ptr<wf::scene::translation_node_t> surface_root_node;
 
@@ -44,6 +46,11 @@ class text_input_v3_popup : public wf::view_interface_t
     {
         return nullptr;
     }
+
+    wf::signal::connection_t<wf::text_input_commit_signal> on_text_input_commit = [=] (auto s)
+    {
+        update_cursor_rect(&s->cursor_rect);
+    };
 
     wf::wl_listener_wrapper on_map;
     wf::wl_listener_wrapper on_unmap;

--- a/src/core/seat/input-method-popup.cpp
+++ b/src/core/seat/input-method-popup.cpp
@@ -65,6 +65,7 @@ void wf::text_input_v3_popup::map()
 
     damage();
     emit_view_map();
+    relay->connect(&on_text_input_commit);
 }
 
 void wf::text_input_v3_popup::unmap()
@@ -82,6 +83,7 @@ void wf::text_input_v3_popup::unmap()
     priv->set_mapped(nullptr);
     priv->set_enabled(false);
     on_commit.disconnect();
+    relay->disconnect(&on_text_input_commit);
 }
 
 std::string wf::text_input_v3_popup::get_app_id()
@@ -92,6 +94,21 @@ std::string wf::text_input_v3_popup::get_app_id()
 std::string wf::text_input_v3_popup::get_title()
 {
     return "input-method-popup";
+}
+
+void wf::text_input_v3_popup::update_cursor_rect(wlr_box *cursor_rect)
+{
+    if (old_cursor_rect == *cursor_rect)
+    {
+        return;
+    }
+
+    if (is_mapped())
+    {
+        update_geometry();
+    }
+
+    old_cursor_rect = *cursor_rect;
 }
 
 void wf::text_input_v3_popup::update_geometry()

--- a/src/core/seat/input-method-relay.cpp
+++ b/src/core/seat/input-method-relay.cpp
@@ -412,6 +412,10 @@ wf::text_input::text_input(wf::input_method_relay *rel, wlr_text_input_v3 *in) :
         }
 
         relay->send_im_state(input);
+
+        wf::text_input_commit_signal sigdata;
+        sigdata.cursor_rect = input->current.cursor_rectangle;
+        relay->emit(&sigdata);
     });
 
     on_text_input_disable.set_callback([&] (void *data)


### PR DESCRIPTION
A text input `commit` may come with a `set_cursor_rectangle` request, and we need to update the input method popup to follow the text cursor on the client side.

Previously we run the update on popup surface commit, but events may come out of order, i.e. the input method draws a new surface buffer as soon as it commits the input string, and then the client window will take some time to process the committed string and figure out the new position of cursor.