### PR TITLE
render-manager: Don't paint when session is not active

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -957,6 +957,13 @@ class wf::render_manager::impl
 
         on_frame.set_callback([&] (void*)
         {
+            /* If the session is not active, don't paint.
+             * This is the case when e.g. switching to another tty */
+            if (!wf::get_core().session->active)
+            {
+                return;
+            }
+
             delay_manager->start_frame();
 
             auto repaint_delay = delay_manager->get_delay();


### PR DESCRIPTION
This can happen when switching to another tty. A test is to run glxgears in a drm session with xwayland, then switch to another tty and run top. The wayfire cpu usage is 100+%. However with this patch, when the session is inactive, the cpu usage is negligible.

One note is that patches were pushed to seatd recently which make the session->active state reliable. At the time of this writing, seatd does not have a release containing these patches, so for this to work reliably, seatd git master is recommended.