### PR TITLE
core: Add legacy wayland drm option

### DIFF
--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -84,6 +84,7 @@ extern "C"
 #define static
 #include <wlr/backend.h>
 #include <wlr/backend/drm.h>
+#include <wlr/types/wlr_drm.h>
 #if WLR_HAS_X11_BACKEND
     #include <wlr/backend/x11.h>
 #endif

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -94,6 +94,13 @@ void wf::compositor_core_impl_t::init()
     /* Needed for subsurfaces */
     wlr_subcompositor_create(display);
 
+    /* Legacy DRM */
+    if (runtime_config.legacy_wl_drm &&
+        wlr_renderer_get_dmabuf_texture_formats(renderer))
+    {
+        wlr_drm_create(display, renderer);
+    }
+
     protocols.data_device = wlr_data_device_manager_create(display);
     protocols.primary_selection_v1 =
         wlr_primary_selection_v1_device_manager_create(display);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -272,6 +272,7 @@ int main(int argc, char *argv[])
         {"debug", optional_argument, NULL, 'd'},
         {"damage-debug", no_argument, NULL, 'D'},
         {"damage-rerender", no_argument, NULL, 'R'},
+        {"legacy-wl-drm", no_argument, NULL, 'l'},
         {"help", no_argument, NULL, 'h'},
         {"version", no_argument, NULL, 'v'},
         {0, 0, NULL, 0}
@@ -282,7 +283,7 @@ int main(int argc, char *argv[])
     std::vector<std::string> extended_debug_categories;
 
     int c, i;
-    while ((c = getopt_long(argc, argv, "c:B:d::DhRv", opts, &i)) != -1)
+    while ((c = getopt_long(argc, argv, "c:B:d::DhRlv", opts, &i)) != -1)
     {
         switch (c)
         {
@@ -300,6 +301,10 @@ int main(int argc, char *argv[])
 
           case 'R':
             runtime_config.no_damage_track = true;
+            break;
+
+          case 'l':
+            runtime_config.legacy_wl_drm = true;
             break;
 
           case 'h':

--- a/src/main.hpp
+++ b/src/main.hpp
@@ -4,6 +4,7 @@
 extern struct wf_runtime_config
 {
     bool no_damage_track = false;
+    bool legacy_wl_drm   = false;
     bool damage_debug    = false;
 } runtime_config;
 


### PR DESCRIPTION
This can be used to work around broken drivers that accelerate the desktop but not the wayland clients.