### PR TITLE
Enable session-lock plugin by default

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -7,7 +7,7 @@
 		<option name="plugins" type="string">
 			<_short>Plugins</_short>
 			<_long>Loads the specified plugins, space-separated list.</_long>
-			<default>alpha animate autostart command cube decoration expo fast-switcher fisheye foreign-toplevel grid gtk-shell idle invert move oswitch place resize shortcuts-inhibit switcher vswitch wayfire-shell window-rules wobbly wrot zoom</default>
+			<default>alpha animate autostart command cube decoration expo fast-switcher fisheye foreign-toplevel grid gtk-shell idle invert move oswitch place resize session-lock shortcuts-inhibit switcher vswitch wayfire-shell window-rules wobbly wrot zoom</default>
 		</option>
 		<option name="close_top_view" type="activator">
 			<_short>Close view</_short>

--- a/wayfire.ini
+++ b/wayfire.ini
@@ -64,6 +64,7 @@ plugins = \
   oswitch \
   place \
   resize \
+  session-lock \
   shortcuts-inhibit \
   switcher \
   vswitch \


### PR DESCRIPTION
### What is this change:

Adding the `session-lock` plugin as a default one to the [wayfire.ini](https://github.com/WayfireWM/wayfire/blob/master/wayfire.ini) and the [core.xml](https://github.com/WayfireWM/wayfire/blob/master/metadata/core.xml) config.

Done as part of the #2360 discussion.

### How it was validated:

Built Wayfire with changes from this PR on a VM. Got successful locking results using both [swaylock](https://github.com/swaywm/swaylock) and [waylock](https://github.com/ifreund/waylock) tools.

Please, let me know if additional validation results are needed.