### PR TITLE
move: Use post input signal for touch move grabs

### DIFF
--- a/plugins/single_plugins/move.cpp
+++ b/plugins/single_plugins/move.cpp
@@ -144,8 +144,8 @@ class wayfire_move : public wf::per_output_plugin_instance_t,
         }
     };
 
-    wf::signal::connection_t<wf::input_event_signal<wlr_touch_down_event>> on_raw_touch_down =
-        [=] (wf::input_event_signal<wlr_touch_down_event> *ev)
+    wf::signal::connection_t<wf::post_input_event_signal<wlr_touch_down_event>> on_raw_touch_down =
+        [=] (wf::post_input_event_signal<wlr_touch_down_event> *ev)
     {
         if (ev->event->touch_id == 0)
         {


### PR DESCRIPTION
Without this, touch fingers are not set yet which causes a visual jump when attempting to move drag a window with touchscreen devices. Use post signal so that the fingers are properly detected and the correct coordinates are used in the first place.

Fixes #2505.