### PR TITLE
Input device updates

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ pixman         = dependency('pixman-1')
 xkbcommon      = dependency('xkbcommon')
 libdl          = meson.get_compiler('cpp').find_library('dl')
 json           = dependency('nlohmann_json', version: '>= 3.11.2')
+udev           = dependency('libudev')
 
 # We're not to use system wlroots: So we'll use the subproject
 if get_option('use_system_wlroots').disabled()

--- a/metadata/input-device.xml
+++ b/metadata/input-device.xml
@@ -6,6 +6,8 @@
       <default></default>
     </option>
     <option name="calibration" type="string">
+      <_short>Calibration matrix</_short>
+      <_long>Calibration matrix for touch devices, uses udev/libinput format (2x3 matrix, 6 floats separated by space).</_long>
       <default></default>
     </option>
   </object>

--- a/metadata/input-device.xml
+++ b/metadata/input-device.xml
@@ -5,5 +5,8 @@
     <option name="output" type="string">
       <default></default>
     </option>
+    <option name="calibration" type="string">
+      <default></default>
+    </option>
   </object>
 </wayfire>

--- a/src/api/wayfire/config-backend.hpp
+++ b/src/api/wayfire/config-backend.hpp
@@ -45,8 +45,8 @@ class config_backend_t
     /**
      * Find the output section for a given input device.
      *
-     * The returned section must be a valid output object as
-     * described in input-device.xml
+     * The returned section must be a valid config object as described
+     * in <@prefix>.xml (typically input.xml or input-device.xml).
      */
     virtual std::shared_ptr<config::section_t> get_input_device_section(
         std::string const & prefix, wlr_input_device *device);

--- a/src/api/wayfire/config-backend.hpp
+++ b/src/api/wayfire/config-backend.hpp
@@ -49,7 +49,7 @@ class config_backend_t
      * described in input-device.xml
      */
     virtual std::shared_ptr<config::section_t> get_input_device_section(
-        wlr_input_device *device);
+        std::string const & prefix, wlr_input_device *device);
 
     virtual ~config_backend_t() = default;
 

--- a/src/api/wayfire/debug.hpp
+++ b/src/api/wayfire/debug.hpp
@@ -42,29 +42,31 @@ namespace log
 enum class logging_category : size_t
 {
     // Transactions - general
-    TXN     = 0,
+    TXN           = 0,
     // Transactions - individual objects
-    TXNI    = 1,
+    TXNI          = 1,
     // Views - events
-    VIEWS   = 2,
+    VIEWS         = 2,
     // Wlroots messages
-    WLR     = 3,
+    WLR           = 3,
     // Direct scanout
-    SCANOUT = 4,
+    SCANOUT       = 4,
     // Pointer events
-    POINTER = 5,
+    POINTER       = 5,
     // Workspace set events
-    WSET    = 6,
+    WSET          = 6,
     // Keyboard-related events
-    KBD     = 7,
+    KBD           = 7,
     // Xwayland-related events
-    XWL     = 8,
+    XWL           = 8,
     // Layer-shell-related events
-    LSHELL  = 9,
+    LSHELL        = 9,
     // Input-Method-related events
-    IM      = 10,
+    IM            = 10,
     // Rendering-related events
-    RENDER  = 11,
+    RENDER        = 11,
+    // Input-device-related events
+    INPUT_DEVICES = 12,
     TOTAL,
 };
 

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2024'12'20;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2025'02'18;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -228,7 +228,7 @@ void wf::compositor_core_impl_t::post_init()
     seat->focus_output(wo);
 
     // Refresh device mappings when we have all outputs and devices
-    input->refresh_device_mappings();
+    input->configure_input_devices();
 
     // Start processing cursor events
     seat->priv->cursor->setup_listeners();

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -44,7 +44,7 @@ static struct udev_property_and_desc
 };
 
 std::shared_ptr<config::section_t> wf::config_backend_t::get_input_device_section(
-    wlr_input_device *device)
+    std::string const & prefix, wlr_input_device *device)
 {
     auto& config = wf::get_core().config;
     std::shared_ptr<wf::config::section_t> section;
@@ -65,7 +65,7 @@ std::shared_ptr<config::section_t> wf::config_backend_t::get_input_device_sectio
                         continue;
                     }
 
-                    std::string name = std::string("input-device:") + nonull(value);
+                    std::string name = prefix + ":" + nonull(value);
                     LOGC(INPUT_DEVICES, "Checking for config section [", name, "] ",
                         pd.property_name, " (", pd.description, ")");
                     section = config.get_section(name);
@@ -80,7 +80,7 @@ std::shared_ptr<config::section_t> wf::config_backend_t::get_input_device_sectio
     }
 
     std::string name = nonull(device->name);
-    name = "input-device:" + name;
+    name = prefix + ":" + name;
     LOGC(INPUT_DEVICES, "Checking for config section [", name, "]");
     section = config.get_section(name);
     if (section)
@@ -90,7 +90,7 @@ std::shared_ptr<config::section_t> wf::config_backend_t::get_input_device_sectio
     }
 
     config.merge_section(
-        config.get_section("input-device")->clone_with_name(name));
+        config.get_section(prefix)->clone_with_name(name));
 
     LOGC(INPUT_DEVICES, "Using config section [", name, "]");
     return config.get_section(name);

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -5,6 +5,7 @@
 #include "wayfire/signal-definitions.hpp"
 #include <wayfire/util/log.hpp>
 #include <wayfire/config-backend.hpp>
+#include <libudev.h>
 
 void wf::plugin_interface_t::fini()
 {}
@@ -27,18 +28,71 @@ std::shared_ptr<config::section_t> wf::config_backend_t::get_output_section(
     return config.get_section(name);
 }
 
+static struct udev_property_and_desc
+{
+    char const *property_name;
+    char const *description;
+} properties_and_descs[] =
+{
+    {"ID_PATH", "stable physical connection path"},
+    {"ID_SERIAL", "stable vendor+pn+sn info"},
+    {"LIBINPUT_DEVICE_GROUP", "stable libinput info"},
+    // sometimes it contains info "by path", sometimes "by id"
+    {"DEVPATH", "unstable devpath"},
+    // used for debugging, to find DEVPATH and match the right
+    // device in `udevadm info --tree`
+};
+
 std::shared_ptr<config::section_t> wf::config_backend_t::get_input_device_section(
     wlr_input_device *device)
 {
-    std::string name = nonull(device->name);
-    name = "input-device:" + name;
     auto& config = wf::get_core().config;
-    if (!config.get_section(name))
+    std::shared_ptr<wf::config::section_t> section;
+
+    if (wlr_input_device_is_libinput(device))
     {
-        config.merge_section(
-            config.get_section("input-device")->clone_with_name(name));
+        auto libinput_dev = wlr_libinput_get_device_handle(device);
+        if (libinput_dev)
+        {
+            udev_device *udev_dev = libinput_device_get_udev_device(libinput_dev);
+            if (udev_dev)
+            {
+                for (struct udev_property_and_desc const & pd : properties_and_descs)
+                {
+                    const char *value = udev_device_get_property_value(udev_dev, pd.property_name);
+                    if (value == nullptr)
+                    {
+                        continue;
+                    }
+
+                    std::string name = std::string("input-device:") + nonull(value);
+                    LOGC(INPUT_DEVICES, "Checking for config section [", name, "] ",
+                        pd.property_name, " (", pd.description, ")");
+                    section = config.get_section(name);
+                    if (section)
+                    {
+                        LOGC(INPUT_DEVICES, "Using config section [", name, "] for ", nonull(device->name));
+                        return section;
+                    }
+                }
+            }
+        }
     }
 
+    std::string name = nonull(device->name);
+    name = "input-device:" + name;
+    LOGC(INPUT_DEVICES, "Checking for config section [", name, "]");
+    section = config.get_section(name);
+    if (section)
+    {
+        LOGC(INPUT_DEVICES, "Using config section [", name, "]");
+        return section;
+    }
+
+    config.merge_section(
+        config.get_section("input-device")->clone_with_name(name));
+
+    LOGC(INPUT_DEVICES, "Using config section [", name, "]");
     return config.get_section(name);
 }
 

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -55,8 +55,9 @@ void wf::input_manager_t::handle_new_input(wlr_input_device *dev)
     configure_input_devices();
 }
 
-void wf::input_manager_t::configure_input_device(wlr_input_device *dev)
+void wf::input_manager_t::configure_input_device(std::unique_ptr<wf::input_device_impl_t> & device)
 {
+    auto dev     = device->get_wlr_handle();
     auto cursor  = wf::get_core().get_wlr_cursor();
     auto section =
         wf::get_core().config_backend->get_input_device_section(dev);
@@ -76,6 +77,12 @@ void wf::input_manager_t::configure_input_device(wlr_input_device *dev)
         {
             mapped_output = nonull(dev->name);
         }
+    }
+
+    auto cal = section->get_option("calibration")->get_value_str();
+    if (!cal.empty())
+    {
+        device->calibrate_touch_device(cal);
     }
 
     auto wo = wf::get_core().output_layout->find_output(mapped_output);
@@ -101,7 +108,7 @@ void wf::input_manager_t::configure_input_devices()
 
     for (auto& device : this->input_devices)
     {
-        configure_input_device(device->get_wlr_handle());
+        configure_input_device(device);
     }
 }
 

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -4,14 +4,11 @@
 #include "wayfire/core.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include "../core-impl.hpp"
-#include "../../output/output-impl.hpp"
-#include "touch.hpp"
 #include "keyboard.hpp"
 #include "cursor.hpp"
 #include "input-manager.hpp"
 #include "wayfire/output-layout.hpp"
 #include "wayfire/view.hpp"
-#include "wayfire/workspace-set.hpp"
 #include <wayfire/util/log.hpp>
 #include <wayfire/debug.hpp>
 
@@ -62,6 +59,12 @@ void wf::input_manager_t::configure_input_device(std::unique_ptr<wf::input_devic
     auto section =
         wf::get_core().config_backend->get_input_device_section("input-device", dev);
 
+    auto calibration_matrix = section->get_option("calibration")->get_value_str();
+    if (!calibration_matrix.empty())
+    {
+        device->calibrate_touch_device(calibration_matrix);
+    }
+
     auto mapped_output = section->get_option("output")->get_value_str();
     if (mapped_output.empty())
     {
@@ -77,12 +80,6 @@ void wf::input_manager_t::configure_input_device(std::unique_ptr<wf::input_devic
         {
             mapped_output = nonull(dev->name);
         }
-    }
-
-    auto cal = section->get_option("calibration")->get_value_str();
-    if (!cal.empty())
-    {
-        device->calibrate_touch_device(cal);
     }
 
     auto wo = wf::get_core().output_layout->find_output(mapped_output);

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -60,7 +60,7 @@ void wf::input_manager_t::configure_input_device(std::unique_ptr<wf::input_devic
     auto dev     = device->get_wlr_handle();
     auto cursor  = wf::get_core().get_wlr_cursor();
     auto section =
-        wf::get_core().config_backend->get_input_device_section(dev);
+        wf::get_core().config_backend->get_input_device_section("input-device", dev);
 
     auto mapped_output = section->get_option("output")->get_value_str();
     if (mapped_output.empty())
@@ -152,8 +152,6 @@ void load_locked_mods_from_config(xkb_mod_mask_t& locked_mods)
 
 wf::input_manager_t::input_manager_t()
 {
-    wf::pointing_device_t::config.load();
-
     load_locked_mods_from_config(locked_mods);
 
     input_device_created.set_callback([&] (void *data)

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -85,11 +85,11 @@ void wf::input_manager_t::configure_input_device(std::unique_ptr<wf::input_devic
     auto wo = wf::get_core().output_layout->find_output(mapped_output);
     if (wo)
     {
-        LOGD("Mapping input ", dev->name, " to output ", wo->to_string(), ".");
+        LOGC(INPUT_DEVICES, "Mapping input ", dev->name, " to output ", wo->to_string(), ".");
         wlr_cursor_map_input_to_output(cursor, dev, wo->handle);
     } else
     {
-        LOGD("Mapping input ", dev->name, " to output null.");
+        LOGC(INPUT_DEVICES, "Mapping input ", dev->name, " to output null.");
         wlr_cursor_map_input_to_output(cursor, dev, nullptr);
     }
 }

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -41,7 +41,7 @@ class input_manager_t
      * Map a single input device to output as specified in the
      * config file or by hints in the wlroots backend.
      */
-    void configure_input_device(wlr_input_device *dev);
+    void configure_input_device(std::unique_ptr<wf::input_device_impl_t> & device);
 
     /**
      * Go through all input devices and map them to outputs as specified in the

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -38,10 +38,16 @@ class input_manager_t
     uint32_t locked_mods = 0;
 
     /**
+     * Map a single input device to output as specified in the
+     * config file or by hints in the wlroots backend.
+     */
+    void configure_input_device(wlr_input_device *dev);
+
+    /**
      * Go through all input devices and map them to outputs as specified in the
      * config file or by hints in the wlroots backend.
      */
-    void refresh_device_mappings();
+    void configure_input_devices();
 
     input_manager_t();
     ~input_manager_t() = default;

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -121,14 +121,18 @@ void wf::keyboard_t::setup_listeners()
 wf::keyboard_t::keyboard_t(wlr_input_device *dev) :
     handle(wlr_keyboard_from_input_device(dev)), device(dev)
 {
-    model.load_option("input/xkb_model");
-    variant.load_option("input/xkb_variant");
-    layout.load_option("input/xkb_layout");
-    options.load_option("input/xkb_options");
-    rules.load_option("input/xkb_rules");
+    auto section =
+        wf::get_core().config_backend->get_input_device_section("input", dev);
+    auto section_name = section->get_name();
 
-    repeat_rate.load_option("input/kb_repeat_rate");
-    repeat_delay.load_option("input/kb_repeat_delay");
+    model.load_option(section_name + "/xkb_model");
+    variant.load_option(section_name + "/xkb_variant");
+    layout.load_option(section_name + "/xkb_layout");
+    options.load_option(section_name + "/xkb_options");
+    rules.load_option(section_name + "/xkb_rules");
+
+    repeat_rate.load_option(section_name + "/kb_repeat_rate");
+    repeat_delay.load_option(section_name + "/kb_repeat_delay");
 
     // When the configuration options change, mark them as dirty.
     // They are applied at the config-reloaded signal.

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -355,9 +355,8 @@ void wf::pointer_t::handle_pointer_axis(wlr_pointer_axis_event *ev,
     }
 
     /* Calculate speed settings */
-    double mult = ev->source == WL_POINTER_AXIS_SOURCE_FINGER ?
-        wf::pointing_device_t::config.touchpad_scroll_speed :
-        wf::pointing_device_t::config.mouse_scroll_speed;
+    wf::pointing_device_t *pd = (wf::pointing_device_t*)ev->pointer->base.data;
+    double mult = pd->get_scroll_speed(&ev->pointer->base, ev->source == WL_POINTER_AXIS_SOURCE_FINGER);
 
     ev->delta *= mult;
     ev->delta_discrete *= mult;

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -10,29 +10,28 @@ struct pointing_device_t : public input_device_impl_t
     pointing_device_t(wlr_input_device *dev);
     virtual ~pointing_device_t() = default;
 
+    void load_options();
     void update_options() override;
 
-    static struct config_t
-    {
-        wf::option_wrapper_t<bool> left_handed_mode;
-        wf::option_wrapper_t<bool> middle_emulation;
-        wf::option_wrapper_t<double> mouse_cursor_speed;
-        wf::option_wrapper_t<double> mouse_scroll_speed;
-        wf::option_wrapper_t<std::string> tablet_motion_mode;
-        wf::option_wrapper_t<double> touchpad_cursor_speed;
-        wf::option_wrapper_t<double> touchpad_scroll_speed;
-        wf::option_wrapper_t<std::string> touchpad_click_method;
-        wf::option_wrapper_t<std::string> touchpad_scroll_method;
-        wf::option_wrapper_t<std::string> touchpad_accel_profile;
-        wf::option_wrapper_t<std::string> mouse_accel_profile;
-        wf::option_wrapper_t<bool> touchpad_tap_enabled;
-        wf::option_wrapper_t<bool> touchpad_dwt_enabled;
-        wf::option_wrapper_t<bool> touchpad_dwmouse_enabled;
-        wf::option_wrapper_t<bool> touchpad_natural_scroll_enabled;
-        wf::option_wrapper_t<bool> mouse_natural_scroll_enabled;
-        wf::option_wrapper_t<bool> touchpad_drag_lock_enabled;
-        void load();
-    } config;
+    double get_scroll_speed(wlr_input_device *dev, bool touchpad);
+
+    wf::option_wrapper_t<bool> left_handed_mode;
+    wf::option_wrapper_t<bool> middle_emulation;
+    wf::option_wrapper_t<double> mouse_cursor_speed;
+    wf::option_wrapper_t<double> mouse_scroll_speed;
+    wf::option_wrapper_t<std::string> tablet_motion_mode;
+    wf::option_wrapper_t<double> touchpad_cursor_speed;
+    wf::option_wrapper_t<double> touchpad_scroll_speed;
+    wf::option_wrapper_t<std::string> touchpad_click_method;
+    wf::option_wrapper_t<std::string> touchpad_scroll_method;
+    wf::option_wrapper_t<std::string> touchpad_accel_profile;
+    wf::option_wrapper_t<std::string> mouse_accel_profile;
+    wf::option_wrapper_t<bool> touchpad_tap_enabled;
+    wf::option_wrapper_t<bool> touchpad_dwt_enabled;
+    wf::option_wrapper_t<bool> touchpad_dwmouse_enabled;
+    wf::option_wrapper_t<bool> touchpad_natural_scroll_enabled;
+    wf::option_wrapper_t<bool> mouse_natural_scroll_enabled;
+    wf::option_wrapper_t<bool> touchpad_drag_lock_enabled;
 };
 }
 

--- a/src/core/seat/seat-impl.hpp
+++ b/src/core/seat/seat-impl.hpp
@@ -34,7 +34,7 @@ class input_device_impl_t : public wf::input_device_t
      * Calibrate a touch device with a matrix. This function does nothing
      * if called with a device that is not a touch device.
      */
-    void calibrate_touch_device(std::string const & cal);
+    void calibrate_touch_device(const std::string& calibration_matrix);
 };
 
 class pointer_t;

--- a/src/core/seat/seat-impl.hpp
+++ b/src/core/seat/seat-impl.hpp
@@ -29,6 +29,12 @@ class input_device_impl_t : public wf::input_device_t
     {}
 
     bool is_im_keyboard = false;
+
+    /**
+     * Calibrate a touch device with a matrix. This function does nothing
+     * if called with a device that is not a touch device.
+     */
+    void calibrate_touch_device(std::string const & cal);
 };
 
 class pointer_t;

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -578,7 +578,7 @@ bool input_device_t::is_enabled()
     return mode == LIBINPUT_CONFIG_SEND_EVENTS_ENABLED;
 }
 
-void input_device_impl_t::calibrate_touch_device(std::string const & cal)
+void input_device_impl_t::calibrate_touch_device(const std::string& calibration_matrix)
 {
     wlr_input_device *dev = handle;
     if (!wlr_input_device_is_libinput(dev) || (dev->type != WLR_INPUT_DEVICE_TOUCH))
@@ -588,7 +588,7 @@ void input_device_impl_t::calibrate_touch_device(std::string const & cal)
 
     float m[6];
     auto libinput_dev = wlr_libinput_get_device_handle(dev);
-    if (sscanf(cal.c_str(), "%f %f %f %f %f %f",
+    if (sscanf(calibration_matrix.c_str(), "%f %f %f %f %f %f",
         &m[0], &m[1], &m[2], &m[3], &m[4], &m[5]) == 6)
     {
         enum libinput_config_status status;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -235,6 +235,10 @@ void parse_extended_debugging(const std::vector<std::string>& categories)
         {
             LOGD("Enabling extended debugging for render events");
             wf::log::enabled_categories.set((size_t)wf::log::logging_category::RENDER, 1);
+        } else if (cat == "input-devices")
+        {
+            LOGD("Enabling extended debugging for input-devices");
+            wf::log::enabled_categories.set((size_t)wf::log::logging_category::INPUT_DEVICES, 1);
         } else
         {
             LOGE("Unrecognized debugging category \"", cat, "\"");

--- a/src/meson.build
+++ b/src/meson.build
@@ -64,7 +64,8 @@ wayfire_sources = ['geometry.cpp',
 
 wayfire_dependencies = [wayland_server, wlroots, xkbcommon, libinput,
                        pixman, drm, egl, glesv2, glm, wf_protos, libdl,
-                       wfconfig, libinotify, backtrace, wfutils, xcb, wftouch, json]
+                       wfconfig, libinotify, backtrace, wfutils, xcb,
+                       wftouch, json, udev]
 
 if conf_data.get('BUILD_WITH_IMAGEIO')
     wayfire_dependencies += [jpeg, png]


### PR DESCRIPTION
- Adds the ability to configure input devices that might have matching names
- Refactor so hotplugging a device only refreshes the configuration for that device, not all devices
- Add calibration option for touch devices
- Add a way to configure multiple keyboards and mice with different settings