### PR TITLE
touch: make EDGE_SWIPE_THRESHOLD configurable

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -227,6 +227,13 @@
 				<min>0.1</min>
 				<max>5.0</max>
 			</option>
+			<option name="edge_swipe_threshold" type="int">
+				<_short>Touchscreen edge swipe threshold</_short>
+				<_long>Change the threshold of the built-in edge swipe detection. Higher values mean that a bigger area on the edge is used to trigger the edge swipe.</_long>
+				<default>10</default>
+				<min>5</min>
+				<max>50</max>
+			</option>
 			<option name="touchpad_scroll_speed" type="double">
 				<_short>Touchpad scroll speed</_short>
 				<_long>Changes the touchpad scroll factor.  Scroll speed will be scaled by the given value, which must be non-negative.</_long>

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -309,7 +309,6 @@ void wf::touch_interface_t::update_cursor_state()
 }
 
 // Swipe params
-constexpr static int EDGE_SWIPE_THRESHOLD  = 10;
 constexpr static double MIN_SWIPE_DISTANCE = 30;
 constexpr static double MAX_SWIPE_DISTANCE = 450;
 constexpr static double SWIPE_INCORRECT_DRAG_TOLERANCE = 150;
@@ -427,24 +426,25 @@ static uint32_t find_swipe_edges(wf::touch::point_t point)
 {
     auto output   = wf::get_core().seat->get_active_output();
     auto geometry = output->get_layout_geometry();
+    wf::option_wrapper_t<int> edge_swipe_threshold{"input/edge_swipe_threshold"};
 
     uint32_t edge_directions = 0;
-    if (point.x <= geometry.x + EDGE_SWIPE_THRESHOLD)
+    if (point.x <= geometry.x + edge_swipe_threshold)
     {
         edge_directions |= wf::GESTURE_DIRECTION_RIGHT;
     }
 
-    if (point.x >= geometry.x + geometry.width - EDGE_SWIPE_THRESHOLD)
+    if (point.x >= geometry.x + geometry.width - edge_swipe_threshold)
     {
         edge_directions |= wf::GESTURE_DIRECTION_LEFT;
     }
 
-    if (point.y <= geometry.y + EDGE_SWIPE_THRESHOLD)
+    if (point.y <= geometry.y + edge_swipe_threshold)
     {
         edge_directions |= wf::GESTURE_DIRECTION_DOWN;
     }
 
-    if (point.y >= geometry.y + geometry.height - EDGE_SWIPE_THRESHOLD)
+    if (point.y >= geometry.y + geometry.height - edge_swipe_threshold)
     {
         edge_directions |= wf::GESTURE_DIRECTION_UP;
     }


### PR DESCRIPTION
On mobile device with High-DPI screens and different scaling it would make sense to make that value configurable.