### PR TITLE
Wayfire.ini

### DIFF
--- a/wayfire.ini
+++ b/wayfire.ini
@@ -118,6 +118,9 @@ toggle = <super> <ctrl> KEY_F
 # Startup commands ─────────────────────────────────────────────────────────────
 
 [autostart]
+#Gtk+3 applications slow startup or .desktop files not opening
+#https://github.com/WayfireWM/wayfire/wiki/Tips-&-Tricks#gtk3-applications-slow-startup-or-desktop-files-not-opening
+0_env = dbus-update-activation-environment --systemd WAYLAND_DISPLAY DISPLAY XAUTHORITY
 
 # Automatically start background and panel.
 # Set to false if you want to override the default clients.


### PR DESCRIPTION
added dbus-update-activation-environment --systemd WAYLAND_DISPLAY DISPLAY XAUTHORITY to [autostart]

I think most people are using GTK apps and this command is almost mandatory.
Commenting it out is fine.  As long as it is included in the file so people are aware of it.  Right now it's buried in the wiki tips & tricks. 

Including it here should help people get their install on track faster. 