### PR TITLE
Edge swipe extra

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -227,6 +227,13 @@
 				<min>0.1</min>
 				<max>5.0</max>
 			</option>
+			<option name="edge_swipe_section_length" type="double">
+				<_short>Touchscreen edge swipe section length</_short>
+				<_long>Split the edge swipe in to 3 sections. If 0.0, the full length of the edge will be recognized as edge-swipe. With 0.1, 10% -> edge-s1-swipe, 80% -> edge-swipe, 10% edge-s2-swipe</_long>
+				<default>0.0</default>
+				<min>0.0</min>
+				<max>0.4</max>
+			</option>
 			<option name="touchpad_scroll_speed" type="double">
 				<_short>Touchpad scroll speed</_short>
 				<_long>Changes the touchpad scroll factor.  Scroll speed will be scaled by the given value, which must be non-negative.</_long>

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -535,14 +535,41 @@ void wf::touch_interface_t::add_default_gestures()
 
     auto ack_edge_swipe = [esw_ptr, this] ()
     {
-        uint32_t possible_edges = find_swipe_edges(finger_state.get_center().origin);
+        wf::touch::point_t point = finger_state.get_center().origin;
+        uint32_t possible_edges = find_swipe_edges(point);
         uint32_t direction = wf_touch_to_wf_dir(esw_ptr->target_direction);
-
+        auto output   = wf::get_core().seat->get_active_output();
+        auto geometry = output->get_layout_geometry();
+        touch_gesture_type_t edgeType = GESTURE_TYPE_NONE;
+        
         possible_edges &= direction;
+
         if (possible_edges)
         {
+            if ((direction == GESTURE_DIRECTION_LEFT || direction == GESTURE_DIRECTION_RIGHT))
+            {
+                if (point.y <= (geometry.height * 0.2))
+                    edgeType = GESTURE_TYPE_EDGE_S1_SWIPE;
+                else if (edgeType == GESTURE_TYPE_NONE && (point.y > (geometry.height * 0.2))
+                            && (point.y < (geometry.height * 0.8)))
+                    edgeType = GESTURE_TYPE_EDGE_SWIPE;
+                else if (edgeType == GESTURE_TYPE_NONE && point.y >= (geometry.height * 0.8))
+                    edgeType = GESTURE_TYPE_EDGE_S2_SWIPE;
+            }
+
+            if ((direction == GESTURE_DIRECTION_UP || direction == GESTURE_DIRECTION_DOWN))
+            {
+                if (point.x <= (geometry.width * 0.2))
+                    edgeType = GESTURE_TYPE_EDGE_S1_SWIPE;
+                else if (edgeType == GESTURE_TYPE_NONE && (point.x > (geometry.width * 0.2))
+                            && (point.x < (geometry.width * 0.8)))
+                    edgeType = GESTURE_TYPE_EDGE_SWIPE;
+                else if (edgeType == GESTURE_TYPE_NONE && point.x >= (geometry.width * 0.8))
+                    edgeType = GESTURE_TYPE_EDGE_S2_SWIPE;
+            }
+
             wf::touchgesture_t gesture{
-                GESTURE_TYPE_EDGE_SWIPE,
+                edgeType,
                 direction,
                 esw_ptr->cnt_fingers
             };

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -535,6 +535,8 @@ void wf::touch_interface_t::add_default_gestures()
 
     auto ack_edge_swipe = [esw_ptr, this] ()
     {
+        wf::option_wrapper_t<double> edge_swipe_section_length{"input/edge_swipe_section_length"};
+        double main_edge_section = 1.0 - edge_swipe_section_length;
         wf::touch::point_t point = finger_state.get_center().origin;
         uint32_t possible_edges = find_swipe_edges(point);
         uint32_t direction = wf_touch_to_wf_dir(esw_ptr->target_direction);
@@ -546,25 +548,26 @@ void wf::touch_interface_t::add_default_gestures()
 
         if (possible_edges)
         {
-            if ((direction == GESTURE_DIRECTION_LEFT || direction == GESTURE_DIRECTION_RIGHT))
+            if (main_edge_section == 1.0)
             {
-                if (point.y <= (geometry.height * 0.2))
+                edgeType = GESTURE_TYPE_EDGE_SWIPE;
+            } else if ((direction == GESTURE_DIRECTION_LEFT || direction == GESTURE_DIRECTION_RIGHT))
+            {
+                if (point.y <= (geometry.height * edge_swipe_section_length))
                     edgeType = GESTURE_TYPE_EDGE_S1_SWIPE;
-                else if (edgeType == GESTURE_TYPE_NONE && (point.y > (geometry.height * 0.2))
-                            && (point.y < (geometry.height * 0.8)))
+                else if (edgeType == GESTURE_TYPE_NONE && (point.y > (geometry.height * edge_swipe_section_length))
+                            && (point.y < (geometry.height * main_edge_section)))
                     edgeType = GESTURE_TYPE_EDGE_SWIPE;
-                else if (edgeType == GESTURE_TYPE_NONE && point.y >= (geometry.height * 0.8))
+                else if (edgeType == GESTURE_TYPE_NONE && point.y >= (geometry.height * main_edge_section))
                     edgeType = GESTURE_TYPE_EDGE_S2_SWIPE;
-            }
-
-            if ((direction == GESTURE_DIRECTION_UP || direction == GESTURE_DIRECTION_DOWN))
+            } else if ((direction == GESTURE_DIRECTION_UP || direction == GESTURE_DIRECTION_DOWN))
             {
-                if (point.x <= (geometry.width * 0.2))
+                if (point.x <= (geometry.width * edge_swipe_section_length))
                     edgeType = GESTURE_TYPE_EDGE_S1_SWIPE;
-                else if (edgeType == GESTURE_TYPE_NONE && (point.x > (geometry.width * 0.2))
-                            && (point.x < (geometry.width * 0.8)))
+                else if (edgeType == GESTURE_TYPE_NONE && (point.x > (geometry.width * edge_swipe_section_length))
+                            && (point.x < (geometry.width * main_edge_section)))
                     edgeType = GESTURE_TYPE_EDGE_SWIPE;
-                else if (edgeType == GESTURE_TYPE_NONE && point.x >= (geometry.width * 0.8))
+                else if (edgeType == GESTURE_TYPE_NONE && point.x >= (geometry.width * main_edge_section))
                     edgeType = GESTURE_TYPE_EDGE_S2_SWIPE;
             }
 


### PR DESCRIPTION
The extra edge-swipe types are configurable and it should not break any existing configs. If edge_swipe_section_length is set to 0.0 (default) everything works as before.
Related wf-config pr https://github.com/WayfireWM/wf-config/pull/73