### PR TITLE
animate: allow 3rd party plugins to provide additional animations

### DIFF
--- a/plugins/animate/animate.cpp
+++ b/plugins/animate/animate.cpp
@@ -3,9 +3,9 @@
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/render-manager.hpp>
 #include <wayfire/workspace-set.hpp>
-#include <type_traits>
 #include <wayfire/core.hpp>
 #include "animate.hpp"
+#include "plugins/common/wayfire/plugins/common/shared-core-data.hpp"
 #include "system_fade.hpp"
 #include "basic_animations.hpp"
 #include "squeezimize.hpp"
@@ -20,60 +20,16 @@
 #include "wayfire/view.hpp"
 #include <wayfire/matcher.hpp>
 
-void animation_base::init(wayfire_view, wf::animation_description_t, wf_animation_type)
-{}
-bool animation_base::step()
-{
-    return false;
-}
-
-void animation_base::reverse()
-{}
-
-int animation_base::get_direction()
-{
-    return 1;
-}
-
-animation_base::~animation_base()
-{}
-
-static constexpr const char *animate_custom_data_fire     = "animation-hook-fire";
-static constexpr const char *animate_custom_data_zoom     = "animation-hook-zoom";
-static constexpr const char *animate_custom_data_fade     = "animation-hook-fade";
-static constexpr const char *animate_custom_data_minimize =
-    "animation-hook-minimize";
-
-static constexpr int HIDDEN = 0;
-static constexpr int SHOWN  = 1;
-
 /* Represents an animation running for a specific view
  * animation_t is which animation to use (i.e fire, zoom, etc). */
-struct animation_hook_base : public wf::custom_data_t
+class animation_hook : public wf::custom_data_t
 {
-    virtual void stop_hook(bool) = 0;
-    virtual void reverse(wf_animation_type) = 0;
-    virtual int get_direction() = 0;
-
-    animation_hook_base() = default;
-    virtual ~animation_hook_base() = default;
-    animation_hook_base(const animation_hook_base &) = default;
-    animation_hook_base(animation_hook_base &&) = default;
-    animation_hook_base& operator =(const animation_hook_base&) = default;
-    animation_hook_base& operator =(animation_hook_base&&) = default;
-};
-
-template<class animation_t>
-struct animation_hook : public animation_hook_base
-{
-    static_assert(std::is_base_of<animation_base, animation_t>::value,
-        "animation_type must be derived from animation_base!");
-
+  public:
     std::shared_ptr<wf::view_interface_t> view;
-    wf_animation_type type;
+    wf::animate::animation_type type;
     std::string name;
     wf::output_t *current_output = nullptr;
-    std::unique_ptr<animation_base> animation;
+    std::unique_ptr<wf::animate::animation_base_t> animation;
     std::shared_ptr<wf::unmapped_view_snapshot_node> unmapped_contents;
 
     void damage_whole_view()
@@ -123,15 +79,18 @@ struct animation_hook : public animation_hook_base
         set_output(view->get_output());
     };
 
-    animation_hook(wayfire_view view, wf::animation_description_t duration, wf_animation_type type,
+    animation_hook(wayfire_view view,
+        std::unique_ptr<wf::animate::animation_base_t> _animation,
+        wf::animation_description_t duration,
+        wf::animate::animation_type type,
         std::string name)
     {
         this->type = type;
         this->view = view->shared_from_this();
         this->name = name;
 
-        animation = std::make_unique<animation_t>();
-        animation->init(view, duration, type);
+        this->animation = std::move(_animation);
+        this->animation->init(view, duration, type);
 
         set_output(view->get_output());
         /* Animation is driven by the output render cycle the view is on.
@@ -139,13 +98,13 @@ struct animation_hook : public animation_hook_base
         view->connect(&on_set_output);
         wf::scene::set_node_enabled(view->get_root_node(), true);
 
-        if (type == ANIMATION_TYPE_UNMAP)
+        if (type == wf::animate::ANIMATION_TYPE_UNMAP)
         {
             set_unmapped_contents();
         }
     }
 
-    void stop_hook(bool detached) override
+    void stop_hook(bool detached)
     {
         view->erase_data(name);
     }
@@ -180,9 +139,9 @@ struct animation_hook : public animation_hook_base
         }
     }
 
-    void reverse(wf_animation_type type) override
+    void set_animation_type(wf::animate::animation_type new_type)
     {
-        if (type == ANIMATION_TYPE_UNMAP)
+        if (new_type == wf::animate::ANIMATION_TYPE_UNMAP)
         {
             set_unmapped_contents();
         } else
@@ -190,16 +149,13 @@ struct animation_hook : public animation_hook_base
             unset_unmapped_contents();
         }
 
-        this->type = type;
-        if (animation)
+        const bool direction_change =
+            (type & WF_ANIMATE_HIDING_ANIMATION) != (new_type & WF_ANIMATE_HIDING_ANIMATION);
+        this->type = new_type;
+        if (animation && direction_change)
         {
             animation->reverse();
         }
-    }
-
-    int get_direction() override
-    {
-        return animation->get_direction();
     }
 
     ~animation_hook()
@@ -223,48 +179,6 @@ struct animation_hook : public animation_hook_base
     animation_hook& operator =(animation_hook&&) = delete;
 };
 
-static void cleanup_views_on_output(wf::output_t *output)
-{
-    std::vector<std::shared_ptr<wf::view_interface_t>> all_views;
-    for (auto& view : wf::get_core().get_all_views())
-    {
-        all_views.push_back(view->shared_from_this());
-    }
-
-    for (auto& view : all_views)
-    {
-        auto wo = view->get_output();
-        if ((wo != output) && output)
-        {
-            continue;
-        }
-
-        if (view->has_data(animate_custom_data_fire))
-        {
-            view->get_data<animation_hook_base>(
-                animate_custom_data_fire)->stop_hook(true);
-        }
-
-        if (view->has_data(animate_custom_data_zoom))
-        {
-            view->get_data<animation_hook_base>(
-                animate_custom_data_zoom)->stop_hook(true);
-        }
-
-        if (view->has_data(animate_custom_data_fade))
-        {
-            view->get_data<animation_hook_base>(
-                animate_custom_data_fade)->stop_hook(true);
-        }
-
-        if (view->has_data(animate_custom_data_minimize))
-        {
-            view->get_data<animation_hook_base>(
-                animate_custom_data_minimize)->stop_hook(true);
-        }
-    }
-}
-
 class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_tracker_mixin_t<>
 {
     wf::option_wrapper_t<std::string> open_animation{"animate/open_animation"};
@@ -275,6 +189,9 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
     wf::option_wrapper_t<wf::animation_description_t> fade_duration{"animate/fade_duration"};
     wf::option_wrapper_t<wf::animation_description_t> zoom_duration{"animate/zoom_duration"};
     wf::option_wrapper_t<wf::animation_description_t> fire_duration{"animate/fire_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> squeezimize_duration{"animate/squeezimize_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> zap_duration{"animate/zap_duration"};
+    wf::option_wrapper_t<wf::animation_description_t> spin_duration{"animate/spin_duration"};
 
     wf::option_wrapper_t<wf::animation_description_t> startup_duration{"animate/startup_duration"};
 
@@ -283,10 +200,28 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
     wf::view_matcher_t zoom_enabled_for{"animate/zoom_enabled_for"};
     wf::view_matcher_t fire_enabled_for{"animate/fire_enabled_for"};
 
+    wf::shared_data::ref_ptr_t<wf::animate::animate_effects_registry_t> effects_registry;
+
+    template<class animation_t>
+    void register_effect(std::string name, wf::option_sptr_t<wf::animation_description_t> option)
+    {
+        effects_registry->register_effect(name, wf::animate::effect_description_t{
+            .generator = [] { return std::make_unique<animation_t>(); },
+            .default_duration = [option] { return option->get_value(); },
+        });
+    }
+
   public:
     void init() override
     {
         init_output_tracking();
+
+        register_effect<fade_animation>("fade", default_duration);
+        register_effect<zoom_animation>("zoom", default_duration);
+        register_effect<FireAnimation>("fire", default_duration);
+        register_effect<wf::zap::zap_animation>("zap", zap_duration);
+        register_effect<wf::spin::spin_animation>("spin", spin_duration);
+        register_effect<wf::squeezimize::squeezimize_animation>("squeezimize", squeezimize_duration);
     }
 
     void handle_new_output(wf::output_t *output) override
@@ -305,6 +240,46 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
     void fini() override
     {
         cleanup_views_on_output(nullptr);
+
+        effects_registry->unregister_effect("fade");
+        effects_registry->unregister_effect("zoom");
+        effects_registry->unregister_effect("fire");
+        effects_registry->unregister_effect("zap");
+        effects_registry->unregister_effect("spin");
+        effects_registry->unregister_effect("squeezimize");
+    }
+
+    void cleanup_views_on_output(wf::output_t *output)
+    {
+        std::vector<std::shared_ptr<wf::view_interface_t>> all_views;
+        for (auto& view : wf::get_core().get_all_views())
+        {
+            all_views.push_back(view->shared_from_this());
+        }
+
+        for (auto& view : all_views)
+        {
+            auto wo = view->get_output();
+            if ((wo != output) && output)
+            {
+                continue;
+            }
+
+            for (auto& anim : effects_registry->effects)
+            {
+                auto map_name = get_map_animation_cdata_name(anim.first);
+                if (view->has_data(map_name))
+                {
+                    view->get_data<animation_hook>(map_name)->stop_hook(false);
+                }
+
+                auto minimize_name = get_minimize_animation_cdata_name(anim.first);
+                if (view->has_data(minimize_name))
+                {
+                    view->get_data<animation_hook>(minimize_name)->stop_hook(false);
+                }
+            }
+        }
     }
 
     struct view_animation_t
@@ -336,158 +311,81 @@ class wayfire_animation : public wf::plugin_interface_t, private wf::per_output_
 
         if (animation_enabled_for.matches(view))
         {
-            return {anim_type, default_duration};
+            if (!effects_registry->effects.count(anim_type))
+            {
+                if ((std::string)anim_type != "none")
+                {
+                    LOGE("Unknown animation type: \"", (std::string)anim_type, "\"");
+                }
+
+                return {"none", wf::animation_description_t{0, {}, ""}};
+            }
+
+            return {
+                .animation_name = anim_type,
+                .duration = effects_registry->effects[anim_type].default_duration().value_or(default_duration)
+            };
         }
 
         return {"none", wf::animation_description_t{0, {}, ""}};
     }
 
-    bool try_reverse(wayfire_view view, wf_animation_type type, std::string name,
-        int visibility)
+    std::string get_map_animation_cdata_name(std::string animation_name)
     {
-        visibility = !visibility;
-        if (view->has_data(name))
-        {
-            auto data = view->get_data<animation_hook_base>(name);
-            if (data->get_direction() == visibility)
-            {
-                data->reverse(type);
-                return true;
-            }
-        }
-
-        return false;
+        return "animation-hook-" + animation_name;
     }
 
-    template<class animation_t>
-    void set_animation(wayfire_view view,
-        wf_animation_type type, wf::animation_description_t duration, std::string name)
+    std::string get_minimize_animation_cdata_name(std::string animation_name)
     {
-        name = "animation-hook-" + name;
+        return "animation-hook-" + animation_name + "-minimize";
+    }
 
-        if (type == ANIMATION_TYPE_MAP)
+    void set_animation(wayfire_view view, std::string animation_name,
+        wf::animate::animation_type type, wf::animation_description_t duration)
+    {
+        if (animation_name == "none")
         {
-            if (try_reverse(view, type, name, SHOWN))
-            {
-                return;
-            }
-
-            auto animation = get_animation_for_view(open_animation, view);
-            view->store_data(
-                std::make_unique<animation_hook<animation_t>>(view, duration, type,
-                    name), name);
-        } else if (type == ANIMATION_TYPE_UNMAP)
-        {
-            if (try_reverse(view, type, name, HIDDEN))
-            {
-                return;
-            }
-
-            auto animation = get_animation_for_view(close_animation, view);
-            view->store_data(
-                std::make_unique<animation_hook<animation_t>>(view, duration, type,
-                    name), name);
-        } else if (type & MINIMIZE_STATE_ANIMATION)
-        {
-            if (view->has_data(animate_custom_data_minimize))
-            {
-                view->get_data<animation_hook_base>(
-                    animate_custom_data_minimize)->reverse(type);
-                return;
-            }
-
-            view->store_data(
-                std::make_unique<animation_hook<animation_t>>(view, duration, type,
-                    animate_custom_data_minimize),
-                animate_custom_data_minimize);
+            return;
         }
+
+        auto cdata_name = (type & WF_ANIMATE_MINIMIZE_STATE_ANIMATION) ?
+            get_minimize_animation_cdata_name(animation_name) :
+            get_map_animation_cdata_name(animation_name);
+
+        auto& effect = effects_registry->effects[animation_name];
+        if (view->has_data(cdata_name))
+        {
+            view->get_data<animation_hook>(cdata_name)->set_animation_type(type);
+            return;
+        }
+
+        auto hook = std::make_unique<animation_hook>(view, effect.generator(),
+            duration, type, cdata_name);
+        view->store_data(std::move(hook), cdata_name);
     }
 
     /* TODO: enhance - add more animations */
     wf::signal::connection_t<wf::view_mapped_signal> on_view_mapped = [=] (wf::view_mapped_signal *ev)
     {
         auto animation = get_animation_for_view(open_animation, ev->view);
-
-        if (animation.animation_name == "fade")
-        {
-            set_animation<fade_animation>(ev->view, ANIMATION_TYPE_MAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "zoom")
-        {
-            set_animation<zoom_animation>(ev->view, ANIMATION_TYPE_MAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "fire")
-        {
-            set_animation<FireAnimation>(ev->view, ANIMATION_TYPE_MAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "zap")
-        {
-            set_animation<wf::zap::zap_animation>(ev->view, ANIMATION_TYPE_MAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "spin")
-        {
-            set_animation<wf::spin::spin_animation>(ev->view, ANIMATION_TYPE_MAP,
-                animation.duration, animation.animation_name);
-        }
+        set_animation(ev->view, animation.animation_name,
+            wf::animate::ANIMATION_TYPE_MAP, animation.duration);
     };
 
     wf::signal::connection_t<wf::view_pre_unmap_signal> on_view_pre_unmap =
         [=] (wf::view_pre_unmap_signal *ev)
     {
         auto animation = get_animation_for_view(close_animation, ev->view);
-
-        if (animation.animation_name == "fade")
-        {
-            set_animation<fade_animation>(ev->view, ANIMATION_TYPE_UNMAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "zoom")
-        {
-            set_animation<zoom_animation>(ev->view, ANIMATION_TYPE_UNMAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "fire")
-        {
-            set_animation<FireAnimation>(ev->view, ANIMATION_TYPE_UNMAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "zap")
-        {
-            set_animation<wf::zap::zap_animation>(ev->view, ANIMATION_TYPE_UNMAP,
-                animation.duration, animation.animation_name);
-        } else if (animation.animation_name == "spin")
-        {
-            set_animation<wf::spin::spin_animation>(ev->view, ANIMATION_TYPE_UNMAP,
-                animation.duration, animation.animation_name);
-        }
+        set_animation(ev->view, animation.animation_name,
+            wf::animate::ANIMATION_TYPE_UNMAP, animation.duration);
     };
 
     wf::signal::connection_t<wf::view_minimize_request_signal> on_minimize_request =
         [=] (wf::view_minimize_request_signal *ev)
     {
-        if (ev->state)
-        {
-            if (std::string(minimize_animation) == "squeezimize")
-            {
-                set_animation<wf::squeezimize::squeezimize_animation>(ev->view, ANIMATION_TYPE_MINIMIZE,
-                    default_duration,
-                    "minimize");
-            } else if (std::string(minimize_animation) == "zoom")
-            {
-                set_animation<zoom_animation>(ev->view, ANIMATION_TYPE_MINIMIZE, default_duration,
-                    "minimize");
-            }
-        } else
-        {
-            if (std::string(minimize_animation) == "squeezimize")
-            {
-                set_animation<wf::squeezimize::squeezimize_animation>(ev->view, ANIMATION_TYPE_RESTORE,
-                    default_duration,
-                    "minimize");
-            } else if (std::string(minimize_animation) == "zoom")
-            {
-                set_animation<zoom_animation>(ev->view, ANIMATION_TYPE_RESTORE, default_duration,
-                    "minimize");
-            }
-        }
-
+        set_animation(ev->view, minimize_animation,
+            ev->state ? wf::animate::ANIMATION_TYPE_MINIMIZE : wf::animate::ANIMATION_TYPE_RESTORE,
+            default_duration);
         // ev->carried_out should remain false, so that core also does the automatic minimize/restore and
         // refocus
     };

--- a/plugins/animate/animate.hpp
+++ b/plugins/animate/animate.hpp
@@ -5,33 +5,73 @@
 #include <wayfire/util/duration.hpp>
 #include <wayfire/option-wrapper.hpp>
 
-#define HIDING_ANIMATION (1 << 0)
-#define SHOWING_ANIMATION (1 << 1)
-#define MAP_STATE_ANIMATION (1 << 2)
-#define MINIMIZE_STATE_ANIMATION (1 << 3)
+#define WF_ANIMATE_HIDING_ANIMATION (1 << 0)
+#define WF_ANIMATE_SHOWING_ANIMATION (1 << 1)
+#define WF_ANIMATE_MAP_STATE_ANIMATION (1 << 2)
+#define WF_ANIMATE_MINIMIZE_STATE_ANIMATION (1 << 3)
 
-enum wf_animation_type
+namespace wf
 {
-    ANIMATION_TYPE_MAP      = SHOWING_ANIMATION | MAP_STATE_ANIMATION,
-    ANIMATION_TYPE_UNMAP    = HIDING_ANIMATION | MAP_STATE_ANIMATION,
-    ANIMATION_TYPE_MINIMIZE = HIDING_ANIMATION | MINIMIZE_STATE_ANIMATION,
-    ANIMATION_TYPE_RESTORE  = SHOWING_ANIMATION | MINIMIZE_STATE_ANIMATION,
+namespace animate
+{
+enum animation_type
+{
+    ANIMATION_TYPE_MAP      = WF_ANIMATE_SHOWING_ANIMATION | WF_ANIMATE_MAP_STATE_ANIMATION,
+    ANIMATION_TYPE_UNMAP    = WF_ANIMATE_HIDING_ANIMATION | WF_ANIMATE_MAP_STATE_ANIMATION,
+    ANIMATION_TYPE_MINIMIZE = WF_ANIMATE_HIDING_ANIMATION | WF_ANIMATE_MINIMIZE_STATE_ANIMATION,
+    ANIMATION_TYPE_RESTORE  = WF_ANIMATE_SHOWING_ANIMATION | WF_ANIMATE_MINIMIZE_STATE_ANIMATION,
 };
 
-class animation_base
+class animation_base_t
 {
   public:
-    virtual void init(wayfire_view view, wf::animation_description_t duration, wf_animation_type type);
-    virtual bool step(); /* return true if continue, false otherwise */
-    virtual void reverse(); /* reverse the animation */
-    virtual int get_direction();
+    virtual void init(wayfire_view view, wf::animation_description_t duration, animation_type type)
+    {}
 
-    animation_base() = default;
-    virtual ~animation_base();
-    animation_base(const animation_base &) = default;
-    animation_base(animation_base &&) = default;
-    animation_base& operator =(const animation_base&) = default;
-    animation_base& operator =(animation_base&&) = default;
+    /**
+     * @return True if the animation should continue for at least one more frame.
+     */
+    virtual bool step()
+    {
+        return false;
+    }
+
+    /**
+     * Reverse the animation direction (hiding -> showing, showing -> hiding)
+     */
+    virtual void reverse()
+    {}
+
+    virtual ~animation_base_t() = default;
 };
+
+struct effect_description_t
+{
+    std::function<std::unique_ptr<animation_base_t>()> generator;
+    std::function<std::optional<wf::animation_description_t>()> default_duration;
+};
+
+/**
+ * The effects registry holds a list of all available animation effects.
+ * Plugins can access the effects registry via ref_ptr_t helper in wayfire/plugins/common/shared-core-data.hpp
+ * They may add/remove their own effects.
+ */
+class animate_effects_registry_t
+{
+  public:
+    void register_effect(std::string name, effect_description_t effect)
+    {
+        effects[name] = effect;
+    }
+
+    void unregister_effect(std::string name)
+    {
+        effects.erase(name);
+    }
+
+    std::map<std::string, effect_description_t> effects;
+};
+}
+}
 
 #endif

--- a/plugins/animate/basic_animations.hpp
+++ b/plugins/animate/basic_animations.hpp
@@ -6,7 +6,7 @@
 #include <wayfire/view-transform.hpp>
 #include <wayfire/output.hpp>
 
-class fade_animation : public animation_base
+class fade_animation : public wf::animate::animation_base_t
 {
     wayfire_view view;
 
@@ -16,7 +16,7 @@ class fade_animation : public animation_base
 
   public:
 
-    void init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type) override
+    void init(wayfire_view view, wf::animation_description_t dur, wf::animate::animation_type type) override
     {
         this->view = view;
         this->progression =
@@ -24,7 +24,7 @@ class fade_animation : public animation_base
 
         this->progression.animate(start, end);
 
-        if (type & HIDING_ANIMATION)
+        if (type & WF_ANIMATE_HIDING_ANIMATION)
         {
             this->progression.flip();
         }
@@ -50,11 +50,6 @@ class fade_animation : public animation_base
         this->progression.reverse();
     }
 
-    int get_direction() override
-    {
-        return this->progression.get_direction();
-    }
-
     ~fade_animation()
     {
         view->get_transformed_node()->rem_transformer(name);
@@ -73,15 +68,14 @@ class zoom_animation_t : public duration_t
     timed_transition_t offset_y{*this};
 };
 
-class zoom_animation : public animation_base
+class zoom_animation : public fade_animation::animation_base_t
 {
     wayfire_view view;
     zoom_animation_t progression;
     std::string name;
 
   public:
-
-    void init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type) override
+    void init(wayfire_view view, wf::animation_description_t dur, wf::animate::animation_type type) override
     {
         this->view = view;
         this->progression = zoom_animation_t(wf::create_option<wf::animation_description_t>(dur));
@@ -95,7 +89,7 @@ class zoom_animation : public animation_base
             this->progression, 0, 0);
         this->progression.start();
 
-        if (type & MINIMIZE_STATE_ANIMATION)
+        if (type & WF_ANIMATE_MINIMIZE_STATE_ANIMATION)
         {
             auto toplevel = wf::toplevel_cast(view);
             wf::dassert(toplevel != nullptr, "We cannot minimize non-toplevel views!");
@@ -121,7 +115,7 @@ class zoom_animation : public animation_base
             }
         }
 
-        if (type & HIDING_ANIMATION)
+        if (type & WF_ANIMATE_HIDING_ANIMATION)
         {
             progression.alpha.flip();
             progression.zoom.flip();

--- a/plugins/animate/fire/fire.cpp
+++ b/plugins/animate/fire/fire.cpp
@@ -232,7 +232,7 @@ static float fire_duration_mod_for_height(int height)
     return std::min(height / 400.0, 3.0);
 }
 
-void FireAnimation::init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type)
+void FireAnimation::init(wayfire_view view, wf::animation_description_t dur, wf::animate::animation_type type)
 {
     this->view = view;
 
@@ -242,7 +242,7 @@ void FireAnimation::init(wayfire_view view, wf::animation_description_t dur, wf_
         wf::create_option<wf::animation_description_t>(dur));
     this->progression.animate(0, 1);
 
-    if (type & HIDING_ANIMATION)
+    if (type & WF_ANIMATE_HIDING_ANIMATION)
     {
         this->progression.flip();
     }

--- a/plugins/animate/fire/fire.hpp
+++ b/plugins/animate/fire/fire.hpp
@@ -8,7 +8,7 @@
 class FireTransformer;
 class ParticleSystem;
 
-class FireAnimation : public animation_base
+class FireAnimation : public wf::animate::animation_base_t
 {
     std::string name; // the name of the transformer in the view's table
     wayfire_view view;
@@ -17,7 +17,7 @@ class FireAnimation : public animation_base
   public:
 
     ~FireAnimation();
-    void init(wayfire_view view, wf::animation_description_t, wf_animation_type type) override;
+    void init(wayfire_view view, wf::animation_description_t, wf::animate::animation_type type) override;
     bool step() override; /* return true if continue, false otherwise */
     void reverse() override; /* reverse the animation */
 };

--- a/plugins/animate/meson.build
+++ b/plugins/animate/meson.build
@@ -12,3 +12,5 @@ animiate = shared_module('animate',
                          dependencies: dependencies,
                          install: true,
                          install_dir: join_paths(get_option('libdir'), 'wayfire'))
+
+install_headers(['animate.hpp'], subdir: 'wayfire/plugins/animate')

--- a/plugins/animate/spin.hpp
+++ b/plugins/animate/spin.hpp
@@ -23,7 +23,6 @@
  */
 
 #include "animate.hpp"
-#include "wayfire/toplevel-view.hpp"
 #include <memory>
 #include <wayfire/plugin.hpp>
 #include <wayfire/opengl.hpp>
@@ -31,7 +30,6 @@
 #include <wayfire/output.hpp>
 
 
-wf::option_wrapper_t<wf::animation_description_t> spin_duration{"animate/spin_duration"};
 wf::option_wrapper_t<int> spin_rotations{"animate/spin_rotations"};
 
 namespace wf
@@ -45,22 +43,21 @@ class spin_animation_t : public duration_t
   public:
     using duration_t::duration_t;
 };
-class spin_animation : public animation_base
+class spin_animation : public animate::animation_base_t
 {
     wayfire_view view;
-    wf_animation_type type;
+    animate::animation_type type;
     wf::spin::spin_animation_t progression;
 
   public:
 
-    void init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type) override
+    void init(wayfire_view view, wf::animation_description_t dur, animate::animation_type type) override
     {
         this->view = view;
         this->type = type;
-        this->progression =
-            wf::spin::spin_animation_t(wf::create_option<wf::animation_description_t>(spin_duration));
+        this->progression = wf::spin::spin_animation_t(wf::create_option<wf::animation_description_t>(dur));
 
-        if (type & HIDING_ANIMATION)
+        if (type & WF_ANIMATE_HIDING_ANIMATION)
         {
             this->progression.reverse();
         }
@@ -88,11 +85,6 @@ class spin_animation : public animation_base
     void reverse() override
     {
         this->progression.reverse();
-    }
-
-    int get_direction() override
-    {
-        return this->progression.get_direction();
     }
 
     ~spin_animation()

--- a/plugins/animate/squeezimize.hpp
+++ b/plugins/animate/squeezimize.hpp
@@ -39,8 +39,6 @@
 #include "animate.hpp"
 
 
-wf::option_wrapper_t<wf::animation_description_t> squeezimize_duration{"animate/squeezimize_duration"};
-
 static const char *squeeze_vert_source =
     R"(
 #version 100
@@ -132,7 +130,7 @@ class squeezimize_transformer : public wf::scene::view_2d_transformer_t
     OpenGL::program_t program;
     wf::geometry_t minimize_target;
     wf::geometry_t animation_geometry;
-    squeezimize_animation_t progression{squeezimize_duration};
+    squeezimize_animation_t progression;
 
     class simple_node_render_instance_t : public wf::scene::transformer_render_instance_t<squeezimize_transformer>
     {
@@ -251,9 +249,10 @@ class squeezimize_transformer : public wf::scene::view_2d_transformer_t
         }
     };
 
-    squeezimize_transformer(wayfire_view view,
+    squeezimize_transformer(wayfire_view view, wf::animation_description_t duration,
         wf::geometry_t minimize_target, wf::geometry_t bbox) : wf::scene::view_2d_transformer_t(view)
     {
+        this->progression     = squeezimize_animation_t{wf::create_option<>(duration)};
         this->minimize_target = minimize_target;
         /* If there is no minimize target set, minimize to the bottom center of the output */
         if ((this->minimize_target.width <= 0) || (this->minimize_target.height <= 0))
@@ -313,12 +312,12 @@ class squeezimize_transformer : public wf::scene::view_2d_transformer_t
     }
 };
 
-class squeezimize_animation : public animation_base
+class squeezimize_animation : public animate::animation_base_t
 {
     wayfire_view view;
 
   public:
-    void init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type) override
+    void init(wayfire_view view, wf::animation_description_t dur, animate::animation_type type) override
     {
         this->view = view;
         pop_transformer(view);
@@ -327,9 +326,9 @@ class squeezimize_animation : public animation_base
         wf::dassert(toplevel != nullptr, "We cannot minimize non-toplevel views!");
         auto hint = toplevel->get_minimize_hint();
         auto tmgr = view->get_transformed_node();
-        auto node = std::make_shared<wf::squeezimize::squeezimize_transformer>(view, hint, bbox);
+        auto node = std::make_shared<wf::squeezimize::squeezimize_transformer>(view, dur, hint, bbox);
         tmgr->add_transformer(node, wf::TRANSFORMER_HIGHLEVEL + 1, squeezimize_transformer_name);
-        node->init_animation(type & HIDING_ANIMATION);
+        node->init_animation(type & WF_ANIMATE_HIDING_ANIMATION);
     }
 
     void pop_transformer(wayfire_view view)

--- a/plugins/animate/unmapped-view-node.hpp
+++ b/plugins/animate/unmapped-view-node.hpp
@@ -39,6 +39,11 @@ class unmapped_view_snapshot_node : public wf::scene::node_t
         instances.push_back(std::make_unique<rinstance_t>(this, push_damage, shown_on));
     }
 
+    std::string stringify() const override
+    {
+        return "unmapped-view-snapshot-node " + this->stringify_flags();
+    }
+
   private:
     class rinstance_t : public wf::scene::simple_render_instance_t<unmapped_view_snapshot_node>
     {

--- a/plugins/animate/zap.hpp
+++ b/plugins/animate/zap.hpp
@@ -23,15 +23,11 @@
  */
 
 #include "animate.hpp"
-#include "wayfire/toplevel-view.hpp"
 #include <memory>
 #include <wayfire/plugin.hpp>
 #include <wayfire/opengl.hpp>
 #include <wayfire/view-transform.hpp>
 #include <wayfire/output.hpp>
-
-
-wf::option_wrapper_t<wf::animation_description_t> zap_duration{"animate/zap_duration"};
 
 namespace wf
 {
@@ -44,22 +40,21 @@ class zap_animation_t : public duration_t
   public:
     using duration_t::duration_t;
 };
-class zap_animation : public animation_base
+class zap_animation : public animate::animation_base_t
 {
     wayfire_view view;
-    wf_animation_type type;
+    animate::animation_type type;
     wf::zap::zap_animation_t progression;
 
   public:
 
-    void init(wayfire_view view, wf::animation_description_t dur, wf_animation_type type) override
+    void init(wayfire_view view, wf::animation_description_t dur, animate::animation_type type) override
     {
         this->view = view;
         this->type = type;
-        this->progression =
-            wf::zap::zap_animation_t(wf::create_option<wf::animation_description_t>(zap_duration));
+        this->progression = wf::zap::zap_animation_t(wf::create_option<wf::animation_description_t>(dur));
 
-        if (type & HIDING_ANIMATION)
+        if (type & WF_ANIMATE_HIDING_ANIMATION)
         {
             this->progression.reverse();
         }
@@ -89,11 +84,6 @@ class zap_animation : public animation_base
     void reverse() override
     {
         this->progression.reverse();
-    }
-
-    int get_direction() override
-    {
-        return this->progression.get_direction();
     }
 
     ~zap_animation()


### PR DESCRIPTION
The API for it is installed in the `wayfire/plugins/animate/animate.hpp` header.

How it works:

1. The external plugin providing extra animations needs to implement the actual animation by deriving from (and implementing the methods of) the `animation_base_t` class:

```cpp
class animation_base_t
{
    virtual void init(wayfire_view view, wf::animation_description_t duration, animation_type type)
    {}

    /**
     * @return True if the animation should continue for at least one more frame.
     */
    virtual bool step()
    {
        return false;
    }

    /**
     * Reverse the animation direction (hiding -> showing, showing -> hiding)
     */
    virtual void reverse()
    {}
};
```

2. The plugin can register its animation type with the animate plugin by using the animation effects registry class:

```cpp
// Automatically fetches the global instance of the effects registry
wf::shared_data::ref_ptr_t<wf::animate::animate_effects_registry_t> effects_registry;

effects_registry->register_effect("coolneweffect", wf::animate::effect_description_t{
    .generator = [] { return std::make_unique<cool_new_effect_t>(); },
    .default_duration = [cfg_option] { return cfg_option->get_value(); },
});

// On unloading the plugin:
effects_registry->unregister_effect("coolneweffect");
```
