### PR TITLE
xdg-activation: add options to make it more strict

### DIFF
--- a/metadata/xdg-activation.xml
+++ b/metadata/xdg-activation.xml
@@ -2,7 +2,23 @@
 <wayfire>
 	<plugin name="xdg-activation">
 		<_short>XDG Activation Protocol</_short>
-		<_long>An implementation of the xdg-activation-v1 protocol.</_long>
+		<_long>An implementation of the xdg-activation-v1 protocol. This allows the active app to pass the focus to a different view in the same or a different app.</_long>
 		<category>Utility</category>
+		<option name="check_surface" type="bool">
+			<_short>Restrict to valid view</_short>
+			<_long>Whether to reject creating activation requests if no source view exists. Without this option, any view can grab to focus at any time.</_long>
+			<default>false</default>
+		</option>
+		<option name="only_last_request" type="bool">
+			<_short>Restrict to the most recent activation request</_short>
+			<_long>Whether to reject activation requests if a newer request has arrived since their creation.</_long>
+			<default>false</default>
+		</option>
+		<option name="timeout" type="int">
+			<_short>Timeout for activation (in seconds)</_short>
+			<_long>Focus requests will be ignored if at least this amount of time has elapsed between creating and using it.</_long>
+			<default>30</default>
+			<min>0</min>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/protocols/xdg-activation.cpp
+++ b/plugins/protocols/xdg-activation.cpp
@@ -12,16 +12,29 @@
 class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
 {
   public:
+    wayfire_xdg_activation_protocol_impl()
+    {
+        set_callbacks();
+    }
+
     void init() override
     {
         xdg_activation = wlr_xdg_activation_v1_create(wf::get_core().display);
-        xdg_activation_request_activate.notify = xdg_activation_handle_request_activate;
+        if (timeout >= 0)
+        {
+            xdg_activation->token_timeout_msec = 1000 * timeout;
+        }
 
-        wl_signal_add(&xdg_activation->events.request_activate, &xdg_activation_request_activate);
+        xdg_activation_request_activate.connect(&xdg_activation->events.request_activate);
+        xdg_activation_new_token.connect(&xdg_activation->events.new_token);
     }
 
     void fini() override
-    {}
+    {
+        xdg_activation_request_activate.disconnect();
+        xdg_activation_new_token.disconnect();
+        last_token = nullptr;
+    }
 
     bool is_unloadable() override
     {
@@ -29,36 +42,105 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
     }
 
   private:
-    static void xdg_activation_handle_request_activate(struct wl_listener *listener, void *data)
+    void set_callbacks()
     {
-        auto event = static_cast<const struct wlr_xdg_activation_v1_request_activate_event*>(data);
-
-        wayfire_view view = wf::wl_surface_to_wayfire_view(event->surface->resource);
-        if (!view)
+        xdg_activation_request_activate.set_callback([this] (void *data)
         {
-            LOGE("Could not get view");
-            return;
-        }
+            auto event = static_cast<const struct wlr_xdg_activation_v1_request_activate_event*>(data);
 
-        auto toplevel = wf::toplevel_cast(view);
-        if (!toplevel)
+            if (!event->token->seat)
+            {
+                LOGI("Denying focus request, token was rejected at creation");
+                return;
+            }
+
+            if (only_last_token && (event->token != last_token))
+            {
+                LOGI("Denying focus request, token is expired");
+                return;
+            }
+
+            last_token = nullptr; // avoid reusing the same token
+
+            wayfire_view view = wf::wl_surface_to_wayfire_view(event->surface->resource);
+            if (!view)
+            {
+                LOGE("Could not get view");
+                return;
+            }
+
+            auto toplevel = wf::toplevel_cast(view);
+            if (!toplevel)
+            {
+                LOGE("Could not get toplevel view");
+                return;
+            }
+
+            LOGI("Activating view");
+            wf::get_core().default_wm->focus_request(toplevel);
+        });
+
+        xdg_activation_new_token.set_callback([this] (void *data)
         {
-            LOGE("Could not get toplevel view");
-            return;
-        }
+            auto token = static_cast<struct wlr_xdg_activation_token_v1*>(data);
+            bool reject_token = false;
+            if (!token->seat)
+            {
+                // note: for a valid seat, wlroots already checks that the serial is valid
+                LOGI("Not registering activation token, seat was not supplied");
+                reject_token = true;
+            }
 
-        if (!event->token->seat)
-        {
-            LOGI("Denying focus request, seat wasn't supplied");
-            return;
-        }
+            if (check_surface && !token->surface)
+            {
+                // note: for a valid surface, wlroots already checks that this is the active surface
+                LOGI("Not registering activation token, surface was not supplied");
+                token->seat  = nullptr; // this will ensure that this token will be rejected later
+                reject_token = true;
+            }
 
-        LOGI("Activating view");
-        wf::get_core().default_wm->focus_request(toplevel);
+            if (reject_token)
+            {
+                if (token == last_token)
+                {
+                    /* corner case: (1) we created a valid token, storing it in last_token (2) it was freed by
+                     * wlroots without using it (3) a new token is created that is allocated the same memory.
+                     * In this case, we explicitly mark it as invalid. In other cases, we do not touch
+                     * last_token, since it can be a valid one and we don't want to cancel it because of a
+                     * rejected request.
+                     */
+                    last_token = nullptr;
+                }
+
+                // we will reject this token also in the activate callback
+                return;
+            }
+
+            last_token = token; // update our token
+        });
+
+        timeout.set_callback(timeout_changed);
     }
 
+    wf::config::option_base_t::updated_callback_t timeout_changed =
+        [this] ()
+    {
+        if (xdg_activation && (timeout >= 0))
+        {
+            xdg_activation->token_timeout_msec = 1000 * timeout;
+        }
+    };
+
     struct wlr_xdg_activation_v1 *xdg_activation;
-    struct wl_listener xdg_activation_request_activate;
+    wf::wl_listener_wrapper xdg_activation_request_activate;
+    wf::wl_listener_wrapper xdg_activation_new_token;
+    /* last valid token generated -- might be stale if it was destroyed by wlroots, should not be
+     * dereferenced, only compared to other tokens */
+    struct wlr_xdg_activation_token_v1 *last_token = nullptr;
+
+    wf::option_wrapper_t<bool> check_surface{"xdg-activation/check_surface"};
+    wf::option_wrapper_t<bool> only_last_token{"xdg-activation/only_last_request"};
+    wf::option_wrapper_t<int> timeout{"xdg-activation/timeout"};
 };
 
 DECLARE_WAYFIRE_PLUGIN(wayfire_xdg_activation_protocol_impl);

--- a/plugins/protocols/xdg-activation.cpp
+++ b/plugins/protocols/xdg-activation.cpp
@@ -7,6 +7,7 @@
 #include <wayfire/toplevel-view.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/window-manager.hpp>
+#include <wayfire/util.hpp>
 #include "config.h"
 
 class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t

--- a/plugins/protocols/xdg-activation.cpp
+++ b/plugins/protocols/xdg-activation.cpp
@@ -77,7 +77,7 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
                 return;
             }
 
-            LOGI("Activating view");
+            LOGD("Activating view");
             wf::get_core().default_wm->focus_request(toplevel);
         });
 
@@ -107,11 +107,7 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
 
         xdg_activation_token_destroy.set_callback([this] (void *data)
         {
-            auto token = static_cast<struct wlr_xdg_activation_token_v1*>(data);
-            if (token == last_token)
-            {
-                last_token = nullptr;
-            }
+            last_token = nullptr;
 
             xdg_activation_token_destroy.disconnect();
         });


### PR DESCRIPTION
This adds three options to configure xdg-activation and allow more strict behavior. These include:
 - reject requests without a view supplied (disabled by default)
 - only allow activating with the last issued token (disabled by default)
 - set the timeout used by wlroots (default: 30s, which is also used by wlroots)

Currently, wlroots already rejects token creation if the client supplied a wl_surface which is not focused. However, if there is no surface, creating a token always succeeds, basically allowing any app to focus itself (e.g. using `gtk_window_present()` which falls back to self-generated tokens with no surface if none is available in the environment). This can be a good thing e.g. when interacting with already running apps from the terminal, but can lead to unexpected focus changes as well. With this PR, this behavior can be changed according to individual preferences.

A small test program is here: https://github.com/dkondor/xdg_activation_test -- it is a case of a parent passing tokens to a child process. Without this PR, all three cases in it always work. With the new, restrictive options enabled, only the first case works.

Note that this still does not do full focus stealing prevention, for that, we would need to keep track if the surface that requested the token loses focus. I would consider looking into that next if there is interest.

If this gets merged, I'm happy to add some notes to the Wiki on the options (and also on xdg-activation more generally).