### PR TITLE
layer-shell: save the initial state when a view is mapped

### DIFF
--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -505,17 +505,18 @@ void wayfire_layer_shell_view::map()
     on_surface_commit.connect(&lsurface->surface->events.commit);
 
     /* Read initial data */
-    keyboard_focus_enabled = lsurface->current.keyboard_interactive;
+    auto& state = lsurface->current;
+    keyboard_focus_enabled = state.keyboard_interactive;
 
     wf::scene::add_front(get_output()->node_for_layer(get_layer()), get_root_node());
     wf_layer_shell_manager::get_instance().handle_map(this);
 
-    auto& state = lsurface->current;
     if ((state.keyboard_interactive >= 1) && (state.layer >= ZWLR_LAYER_SHELL_V1_LAYER_TOP))
     {
         wf::get_core().seat->focus_view(self());
     }
 
+    prev_state = state;
     emit_view_map();
 }
 


### PR DESCRIPTION
Fixes #2449 

After re-reviewing my suggested patch, I now believe this is the correct place for it: when a view is first mapped, save its state, so that it can be compared to on subsequent commits.

Note: the only functional change is setting `prev_state`, I've rearranged the use of the `state` variable for more consistency, but this could be avoided of course.