### PR TITLE
layer-shell: do not grab focus if keyboard interactivity is set to ON_DEMAND

### DIFF
--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -566,10 +566,10 @@ void wayfire_layer_shell_view::commit()
 
         if (prev_state.keyboard_interactive != state->keyboard_interactive)
         {
-            if ((state->keyboard_interactive >= 1) && (state->layer >= ZWLR_LAYER_SHELL_V1_LAYER_TOP))
+            if ((state->keyboard_interactive == 1) && (state->layer >= ZWLR_LAYER_SHELL_V1_LAYER_TOP))
             {
                 wf::get_core().seat->focus_view(self());
-            } else
+            } else if (state->keyboard_interactive == 0)
             {
                 wf::get_core().seat->refocus();
             }


### PR DESCRIPTION
Fixes #2450 

This change avoids automatically focusing layer-shell surfaces when their keyboard interactivity is changed to ON_DEMAND. As discussed in https://github.com/WayfireWM/wayfire/issues/2422#issuecomment-2308661898, this is not intended. However, this change can lead to unexpected changes if an app expects that this will grab focus. So it might not be the best solution after all.

Main change: Layer-shell views can now intentionally lose focus by setting keyboard interactivity to NONE and then back to ON_DEMAND (thus allowing them to be later refocused by normal user interactions; this was not possible before).

Possible drawback: if an app sets keyboard interactivity to ON_DEMAND as a response to user action (e.g. mouse click), it will not get keyboard focus until further user action. This is demonstrated e.g. by the test code in issue #2450 where after applying this patch, clicking on the "On demand" button will not grab focus. However, grabbing focus is still possible by first setting it to EXCLUSIVE and then back to ON_DEMAND (this is e.g. used by [wf-shell](https://github.com/WayfireWM/wf-shell/blob/f49f719effed6de47a85a64689672581cc18ec58/src/util/wf-autohide-window.cpp#L412) which continues to work fine with this patch applied).

