### PR TITLE
foreign-toplevel: Fix potential crash when app-id mode is 'full'

### DIFF
--- a/plugins/protocols/foreign-toplevel.cpp
+++ b/plugins/protocols/foreign-toplevel.cpp
@@ -85,10 +85,14 @@ class wayfire_foreign_toplevel
         } else if (app_id_mode == "full")
         {
 #if WF_HAS_XWAYLAND
-            if (wlr_xwayland_surface *xw_surface =
-                    wlr_xwayland_surface_try_from_wlr_surface(view->get_wlr_surface()))
+            auto wlr_surface = view->get_wlr_surface();
+            if (wlr_surface)
             {
-                ev.app_id = nonull(xw_surface->instance);
+                if (wlr_xwayland_surface *xw_surface =
+                        wlr_xwayland_surface_try_from_wlr_surface(wlr_surface))
+                {
+                    ev.app_id = nonull(xw_surface->instance);
+                }
             }
 
 #endif


### PR DESCRIPTION
This fixes a potential crash with compositor views when workarounds option app-id-mode is set to 'full'. The crash can be caused when attempting to use magnifier, with this option set.