### PR TITLE
input method: don't forward key-release without correspinding key-press

### DIFF
--- a/src/core/seat/input-method-relay.cpp
+++ b/src/core/seat/input-method-relay.cpp
@@ -284,6 +284,19 @@ bool wf::input_method_relay::handle_key(struct wlr_keyboard *kbd, uint32_t time,
         return false;
     }
 
+    if (state == WL_KEYBOARD_KEY_STATE_PRESSED) {
+        pressed_keys.insert(key);
+    } else
+    {
+        // Don't forward the release event if the press event for the same key
+        // has also been forwarded.
+        if (!pressed_keys.count(key))
+        {
+            return false;
+        }
+        pressed_keys.erase(pressed_keys.find(key));
+    }
+
     wlr_input_method_keyboard_grab_v2_set_keyboard(keyboard_grab, kbd);
     wlr_input_method_keyboard_grab_v2_send_key(keyboard_grab, time, key, state);
     return true;

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <memory>
+#include <set>
 
 namespace wf
 {
@@ -24,6 +25,8 @@ class input_method_relay : public text_input_v3_im_relay_interface_t
     std::optional<uint32_t> last_done_serial;
     uint32_t next_done_serial = 0;
     void send_im_done();
+
+    std::multiset<uint32_t> pressed_keys;
 
     text_input *find_focusable_text_input();
     void set_focus(wlr_surface*);


### PR DESCRIPTION
This PR follows the fix in https://github.com/labwc/labwc/pull/2437.

After commit [e2189903](https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/e21899037a97dcade40149f05ab54229c0018644) in wlroots, when ctrl-f is pressed in firefox with a IME client running, the following key-release event for "f" is not sent, thus "f" is repeated like "ffffffffff..." in the input box of firefox.

The video below is the demonstration of the regression in labwc, but it also happens in wayfire:

https://github.com/user-attachments/assets/b87e7e7f-c288-4f50-8902-361a6f0be678

This happens in the following flow:
- The compositor receives key-press events for ctrl+f and sends them to Firefox
- Firefox enables text_input for the input box
- The compositor activates the IME client
- The compositor receives a key-release event for "f", and forward it to the IME client
- The IME client sends the key-release event for "f" to the compositor via a virtual keyboard, but wlroots ignores it because the key "f" has not been pressed in the virtual keyboard.
- As firefox doesn't see the key-release event, its repeat timer timeouts and it starts printing "fffffffff...".

So this PR fixes this problem by not forwarding the key-release event to the IME client unless the corresponding key-press event has also been forwarded.