### PR TITLE
session-lock: lock the screen even if the client provides no lock surface

### DIFF
--- a/plugins/protocols/session-lock.cpp
+++ b/plugins/protocols/session-lock.cpp
@@ -144,10 +144,9 @@ class lock_crashed_node : public lock_base_node<simple_text_node_t>
         // TODO: make the text smaller and display a useful message instead of a big explosion.
         set_text(text);
         auto layer_node = output->node_for_layer(wf::scene::layer::LOCK);
-        if (!is_displayed)
+        if (parent() == nullptr)
         {
             wf::scene::add_back(layer_node, shared_from_this());
-            is_displayed = true;
         }
 
         wf::get_core().seat->set_active_node(shared_from_this());
@@ -166,9 +165,6 @@ class lock_crashed_node : public lock_base_node<simple_text_node_t>
         result.local_coords = at;
         return result;
     }
-
-  private:
-    bool is_displayed = false;
 };
 
 class wf_session_lock_plugin : public wf::plugin_interface_t

--- a/plugins/protocols/session-lock.cpp
+++ b/plugins/protocols/session-lock.cpp
@@ -144,7 +144,12 @@ class lock_crashed_node : public lock_base_node<simple_text_node_t>
         // TODO: make the text smaller and display a useful message instead of a big explosion.
         set_text(text);
         auto layer_node = output->node_for_layer(wf::scene::layer::LOCK);
-        wf::scene::add_back(layer_node, shared_from_this());
+        if (!is_displayed)
+        {
+            wf::scene::add_back(layer_node, shared_from_this());
+            is_displayed = true;
+        }
+
         wf::get_core().seat->set_active_node(shared_from_this());
     }
 
@@ -161,6 +166,9 @@ class lock_crashed_node : public lock_base_node<simple_text_node_t>
         result.local_coords = at;
         return result;
     }
+
+  private:
+    bool is_displayed = false;
 };
 
 class wf_session_lock_plugin : public wf::plugin_interface_t
@@ -290,6 +298,12 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
             {
                 disconnect_signals();
                 set_state(state == UNLOCKED ? DESTROYED : ZOMBIE);
+                if (state == ZOMBIE)
+                {
+                    // ensure that the crashed node is displayed in this case as well
+                    lock_all();
+                }
+
                 LOGC(LSHELL, "session lock destroyed");
             });
             destroy.connect(&lock->events.destroy);
@@ -315,15 +329,9 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
         void handle_output_added(wf::output_t *output)
         {
             output_states[output] = std::make_shared<output_state>(output);
-            if (state == LOCKED)
+            if ((state == LOCKED) || (state == ZOMBIE))
             {
                 lock_output(output, output_states[output]);
-            }
-
-            if (state == ZOMBIE)
-            {
-                output->set_inhibited(true);
-                output_states[output]->crashed_node->display_crashed();
             }
 
             output->connect(&output_changed);
@@ -351,7 +359,10 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
         void lock_output(wf::output_t *output, std::shared_ptr<output_state> output_state)
         {
             output->set_inhibited(true);
-            if (output_state->surface_node)
+            if (state == ZOMBIE)
+            {
+                output_state->crashed_node->display_crashed();
+            } else if (output_state->surface_node)
             {
                 output_state->surface_node->display();
             } else
@@ -368,8 +379,12 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
                 lock_output(output, output_state);
             }
 
-            wlr_session_lock_v1_send_locked(lock);
-            set_state(LOCKED);
+            if (state != ZOMBIE)
+            {
+                wlr_session_lock_v1_send_locked(lock);
+                set_state(LOCKED);
+            }
+
             LOGC(LSHELL, "lock");
         }
 

--- a/plugins/protocols/session-lock.cpp
+++ b/plugins/protocols/session-lock.cpp
@@ -134,7 +134,7 @@ class lock_crashed_node : public lock_base_node<simple_text_node_t>
         set_size(output->get_screen_size());
     }
 
-    void display()
+    void display(std::string text)
     {
         wf::cairo_text_t::params params(
             1280 /* font_size */,
@@ -142,7 +142,7 @@ class lock_crashed_node : public lock_base_node<simple_text_node_t>
             wf::color_t{0.9, 0.9, 0.9, 1} /* fg_color */);
         set_text_params(params);
         // TODO: make the text smaller and display a useful message instead of a big explosion.
-        set_text("💥");
+        set_text(text);
         auto layer_node = output->node_for_layer(wf::scene::layer::LOCK);
         wf::scene::add_back(layer_node, shared_from_this());
         wf::get_core().seat->set_active_node(shared_from_this());
@@ -253,7 +253,7 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
                         output_states[output]->surface_node.reset();
                         if (output_states[output]->crashed_node)
                         {
-                            output_states[output]->crashed_node->display();
+                            output_states[output]->crashed_node->display("💥");
                         }
                     }
 
@@ -318,7 +318,7 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
             if (state == ZOMBIE)
             {
                 output->set_inhibited(true);
-                output_states[output]->crashed_node->display();
+                output_states[output]->crashed_node->display("💥");
             }
 
             output->connect(&output_changed);
@@ -349,9 +349,11 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
             if (output_state->surface_node)
             {
                 output_state->surface_node->display();
+            } else
+            {
+                // if the surface node has not yet been displayed we show an empty surface
+                output_state->crashed_node->display("");
             }
-
-            // TODO: if the surface node has not yet been displayed, display... something?
         }
 
         void lock_all()

--- a/plugins/protocols/session-lock.cpp
+++ b/plugins/protocols/session-lock.cpp
@@ -148,6 +148,11 @@ class lock_crashed_node : public lock_base_node<simple_text_node_t>
         wf::get_core().seat->set_active_node(shared_from_this());
     }
 
+    void display_crashed()
+    {
+        display("💥");
+    }
+
     // Ensure pointer interaction is not passed to views behind this node.
     std::optional<wf::scene::input_node_t> find_node_at(const wf::pointf_t& at) override
     {
@@ -253,7 +258,7 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
                         output_states[output]->surface_node.reset();
                         if (output_states[output]->crashed_node)
                         {
-                            output_states[output]->crashed_node->display("💥");
+                            output_states[output]->crashed_node->display_crashed();
                         }
                     }
 
@@ -318,7 +323,7 @@ class wf_session_lock_plugin : public wf::plugin_interface_t
             if (state == ZOMBIE)
             {
                 output->set_inhibited(true);
-                output_states[output]->crashed_node->display("💥");
+                output_states[output]->crashed_node->display_crashed();
             }
 
             output->connect(&output_changed);


### PR DESCRIPTION
Minimal changes to hide the screen contents in this case as well.

Simple test client: https://github.com/dkondor/simple_lock

