### PR TITLE
nonstd: fix source file encoding

### DIFF
--- a/src/api/wayfire/nonstd/observer_ptr.h
+++ b/src/api/wayfire/nonstd/observer_ptr.h
@@ -292,7 +292,7 @@ template< class W1, class W2 >
 bool operator<( observer_ptr<W1> p1, observer_ptr<W2> p2 )
 {
     // return std::less<W3>()( p1.get(), p2.get() );
-    // where W3 is the composite pointer type (C++14 §5) of W1* and W2*.
+    // where W3 is the composite pointer type (C++14 Section 5) of W1* and W2*.
     return std::less< typename detail::common_type<W1*,W2*>::type >()( p1.get(), p2.get() );
 }
 


### PR DESCRIPTION
Found this while looking into the packaging status in Debian:
https://udd.debian.org/lintian/?packages=wayfire

There was one non-UTF-8 character in comments ('§'); instead of using the UTF-8 variant, I suggest to rephrase to use only ASCII characters for simplicity.