### PR TITLE
Small fixes

### DIFF
--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -62,6 +62,7 @@ extern "C"
 #include <wlr/util/box.h>
 #include <wlr/util/edges.h>
 #include <wayland-server.h>
+#include <wlr/config.h>
 
     static constexpr uint32_t WLR_KEY_PRESSED  = WL_KEYBOARD_KEY_STATE_PRESSED;
     static constexpr uint32_t WLR_KEY_RELEASED = WL_KEYBOARD_KEY_STATE_RELEASED;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -14,6 +14,7 @@
 #include "wayfire/config-backend.hpp"
 #include "core/plugin-loader.hpp"
 #include "core/core-impl.hpp"
+#include <wayfire/nonstd/wlroots.hpp>
 
 static void print_version()
 {
@@ -382,27 +383,40 @@ int main(int argc, char *argv[])
     core.ev_loop = wl_display_get_event_loop(core.display);
     core.backend = wlr_backend_autocreate(core.ev_loop, &core.session);
 
-    int drm_fd = wlr_backend_get_drm_fd(core.backend);
+    int drm_fd = -1;
+    char *drm_device = getenv("WLR_RENDER_DRM_DEVICE");
+    if (drm_device)
+    {
+        drm_fd = open(drm_device, O_RDWR | O_CLOEXEC);
+    } else
+    {
+        drm_fd = wlr_backend_get_drm_fd(core.backend);
+    }
+
     if (drm_fd < 0)
     {
-        char *drm_device = getenv("WLR_RENDER_DRM_DEVICE");
-        if (drm_device)
-        {
-            drm_fd = open(drm_device, O_RDWR | O_CLOEXEC);
-        }
-
-        if (drm_fd < 0)
-        {
-            LOGE("Failed to get DRM file descriptor,",
-                " try specifying a valid WLR_RENDER_DRM_DEVICE!");
-            wl_display_destroy_clients(core.display);
-            wl_display_destroy(core.display);
-            return EXIT_FAILURE;
-        }
+#if WLR_HAS_UDMABUF_ALLOCATOR == 1
+        LOGW("Failed to open DRM render device, consider specifying WLR_RENDER_DRM_DEVICE."
+             "Trying SW rendering instead.");
+#else
+        LOGE("Failed to open DRM render device, consider specifying WLR_RENDER_DRM_DEVICE."
+             "If you want to use software rendering, ensure that wlroots has been compiled with udmabuf "
+             "allocator support (available in wlroots >= 0.19.0) and recompile Wayfire.");
+        wl_display_destroy_clients(core.display);
+        wl_display_destroy(core.display);
+        return EXIT_FAILURE;
+#endif
     }
 
     core.renderer = wlr_gles2_renderer_create_with_drm_fd(drm_fd);
-    assert(core.renderer);
+    if (!core.renderer)
+    {
+        LOGE("Failed to create renderer");
+        wl_display_destroy_clients(core.display);
+        wl_display_destroy(core.display);
+        return EXIT_FAILURE;
+    }
+
     core.allocator = wlr_allocator_autocreate(core.backend, core.renderer);
     assert(core.allocator);
     core.egl = wlr_gles2_renderer_get_egl(core.renderer);

--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -243,6 +243,11 @@ wf::xdg_toplevel_view_t::xdg_toplevel_view_t(wlr_xdg_toplevel *tlvl) : xdg_tople
     on_request_minimize.connect(&xdg_toplevel->events.request_minimize);
     on_show_window_menu.connect(&xdg_toplevel->events.request_show_window_menu);
     on_request_fullscreen.connect(&xdg_toplevel->events.request_fullscreen);
+
+    if (xdg_toplevel && uses_csd.count(xdg_toplevel->base->surface))
+    {
+        this->has_client_decoration = uses_csd[xdg_toplevel->base->surface];
+    }
 }
 
 std::shared_ptr<wf::xdg_toplevel_view_t> wf::xdg_toplevel_view_t::create(wlr_xdg_toplevel *toplevel)
@@ -302,11 +307,6 @@ bool wf::xdg_toplevel_view_t::is_mapped() const
 
 void wf::xdg_toplevel_view_t::map()
 {
-    if (xdg_toplevel && uses_csd.count(xdg_toplevel->base->surface))
-    {
-        this->has_client_decoration = uses_csd[xdg_toplevel->base->surface];
-    }
-
     adjust_view_output_on_map(this);
 
     xdg_toplevel_view_base_t::map();


### PR DESCRIPTION
- xdg-toplevel-view: read csd state as soon as possible
- main.cpp: prepare wayfire for software rendering coming in wlroots 0.19

@soreau Please review, esp. the second commit.
