### PR TITLE
workarounds: Add force frame sync option

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -68,5 +68,10 @@
 			<_long>Enable certain damage optimizations which are based on a surfaces' opaque regions. In some cases, this optimization might give unexpected results (i.e background app stops updating) even though this is fine according to Wayland's protocol.</_long>
 			<default>false</default>
 		</option>
+		<option name="force_frame_sync" type="bool">
+			<_short>Force frame synchronization.</_short>
+			<_long>This option can be used to workaround driver bugs that cause rendering artifacts, though can cause more resource usage. Leave disabled if unsure.</_long>
+			<default>false</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -28,6 +28,7 @@ namespace wf
  */
 struct swapchain_damage_manager_t
 {
+    wf::option_wrapper_t<bool> force_frame_sync{"workarounds/force_frame_sync"};
     signal::connection_t<scene::root_node_update_signal> root_update;
     std::vector<scene::render_instance_uptr> render_instances;
 
@@ -341,6 +342,14 @@ struct swapchain_damage_manager_t
 
     void swap_buffers(std::unique_ptr<frame_object_t> next_frame, const wf::region_t& swap_damage)
     {
+        /* If force frame sync option is set, call glFinish to block until
+         * the GPU finishes rendering. This can work around some driver
+         * bugs, but may cause more resource usage. */
+        if (force_frame_sync)
+        {
+            GL_CALL(glFinish());
+        }
+
         frame_damage.clear();
 
         if (!wlr_render_pass_submit(next_frame->render_pass))


### PR DESCRIPTION
The force frame sync option causes glFinish() to be called after rendering but before commiting the new buffer. This can be used to workaround driver bugs, especially where dma-fences are not available for frame synchronization. This is the case with multi- threaded llvmpipe rendering, using drm or wayland backends.