### PR TITLE
Add to log message which plugin failed to load.

### DIFF
--- a/src/core/plugin-loader.cpp
+++ b/src/core/plugin-loader.cpp
@@ -84,7 +84,7 @@ std::pair<void*, void*> wf::get_new_instance_handle(const std::string& path)
     void *handle = dlopen(path.c_str(), RTLD_NOW | RTLD_GLOBAL);
     if (handle == NULL)
     {
-        LOGE("error loading plugin: ", dlerror());
+        LOGE("error loading plugin [", path, "]: ", dlerror());
         return {nullptr, nullptr};
     }
 


### PR DESCRIPTION
This changes a message like:

[wayfire.git/src/core/plugin-loader.cpp:87] error loading plugin: /usr/lib/libcwd_r.so.9: undefined symbol: elf_nextscn

into:

[wayfire.git/src/core/plugin-loader.cpp:87] error loading plugin [/usr/lib/wayfire/libpixdecor.so]: /usr/lib/libcwd_r.so.9: undefined symbol: elf_nextscn

In other words, not just print the dlerror, but print which plugin failed to load.