### PR TITLE
Fix compile warning.

### DIFF
--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -92,8 +92,13 @@ std::string read_output(std::string command)
         return "";
     }
 
-    fgets(buffer, MAX_FUNCTION_NAME, file);
+    char *line_as_c_str = fgets(buffer, MAX_FUNCTION_NAME, file);
     pclose(file);
+
+    if (!line_as_c_str)
+    {
+        return {};
+    }
 
     std::string line = buffer;
     if (line.size() && (line.back() == '\n'))


### PR DESCRIPTION
Fix fixes the compile warning,

../../../../github/wayfire/wayfire.git/src/debug.cpp: In function ‘std::string read_output(std::string)’: ../../../../github/wayfire/wayfire.git/src/debug.cpp:95:10: warning: ignoring return value of ‘char* fgets(char*, int, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   95 |     fgets(buffer, MAX_FUNCTION_NAME, file);
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

In this case there is a potential problem: if gets returns NULL, then nothing was read and the buffer is uninitialized. Not only would this function be returning uninitialized data, an arbitrary amount of memory could be allocated into `line` (and be returned) when `std::string line = buffer;` is searching for a terminating zero in the uninitialized buffer.

I kinda rewrote this function (while I was at it) to not write first to the stack and then copy that into `line`. Instead the `std::string` is created with the same space as the buffer was, and then we write directly into the allocated memory. Afterwards a `resize()` sets `line` to the correct size - removing any trailing newline at the same time.

In other words, this code is much faster too (as if that was needed, but alas)!