### PR TITLE
Compilation time improvements (part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,6 @@
 
 build/**
 
+.cache/**
+
 # End of https://www.toptal.com/developers/gitignore/api/c++,meson,ninja,linux

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -21,6 +21,7 @@
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
 #include "wayfire/signal-provider.hpp"
+#include <list>
 
 using blur_algorithm_provider =
     std::function<nonstd::observer_ptr<wf_blur_base>()>;

--- a/plugins/common/wayfire/plugins/common/simple-text-node.hpp
+++ b/plugins/common/wayfire/plugins/common/simple-text-node.hpp
@@ -2,6 +2,7 @@
 #include "wayfire/output.hpp"
 #include "wayfire/scene.hpp"
 #include <wayfire/plugins/common/cairo-util.hpp>
+#include <wayfire/scene-render.hpp>
 
 class simple_text_node_t : public wf::scene::node_t
 {

--- a/plugins/common/wayfire/plugins/common/util.hpp
+++ b/plugins/common/wayfire/plugins/common/util.hpp
@@ -9,7 +9,7 @@
 #include "wayfire/output.hpp"
 #include "wayfire/view-helpers.hpp"
 #include "wayfire/toplevel-view.hpp"
-#include "wayfire/workspace-set.hpp"
+#include "wayfire/view-transform.hpp"
 #include <memory>
 namespace wf
 {

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -8,6 +8,7 @@
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/output-layout.hpp>
 #include <wayfire/config/compound-option.hpp>
+#include <wayfire/config/config-manager.hpp>
 
 extern "C" {
 #include <wlr/backend/headless.h>
@@ -115,7 +116,7 @@ class ipc_rules_utility_methods_t
     {
         WFJSON_EXPECT_FIELD(data, "option", string);
 
-        auto option = wf::get_core().config.get_option(data["option"]);
+        auto option = wf::get_core().config->get_option(data["option"]);
         if (!option)
         {
             return wf::ipc::json_error("Option not found!");
@@ -245,7 +246,7 @@ class ipc_rules_utility_methods_t
 
         for (auto& [option, value] : data.items())
         {
-            auto opt = wf::get_core().config.get_option(option);
+            auto opt = wf::get_core().config->get_option(option);
             if (!opt)
             {
                 return wf::ipc::json_error(option + ": Option not found!");

--- a/plugins/protocols/foreign-toplevel.cpp
+++ b/plugins/protocols/foreign-toplevel.cpp
@@ -1,4 +1,5 @@
 #include "wayfire/core.hpp"
+#include "wayfire/debug.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include <wayfire/output-layout.hpp>
 #include "wayfire/view.hpp"

--- a/plugins/protocols/shortcuts-inhibit.cpp
+++ b/plugins/protocols/shortcuts-inhibit.cpp
@@ -1,6 +1,5 @@
 #include "wayfire/core.hpp"
 #include "wayfire/option-wrapper.hpp"
-#include "wayfire/plugins/common/shared-core-data.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include "wayfire/signal-provider.hpp"
 #include "wayfire/util.hpp"
@@ -11,6 +10,7 @@
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/plugin.hpp>
 #include <wayland-server-protocol.h>
+#include <map>
 
 class wayfire_shortcuts_inhibit : public wf::plugin_interface_t
 {

--- a/plugins/single_plugins/autostart.cpp
+++ b/plugins/single_plugins/autostart.cpp
@@ -2,6 +2,7 @@
 #include <wayfire/core.hpp>
 #include <wayfire/util/log.hpp>
 #include <wayfire/option-wrapper.hpp>
+#include <wayfire/config/config-manager.hpp>
 #include <config.h>
 
 class wayfire_autostart : public wf::plugin_interface_t
@@ -14,7 +15,7 @@ class wayfire_autostart : public wf::plugin_interface_t
     void init() override
     {
         /* Run only once, at startup */
-        auto section = wf::get_core().config.get_section("autostart");
+        auto section = wf::get_core().config->get_section("autostart");
 
         bool panel_manually_started = false;
         bool background_manually_started = false;

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -16,6 +16,7 @@
 #include <wayfire/seat.hpp>
 #include <wayfire/util/log.hpp>
 #include <plugins/ipc/ipc-method-repository.hpp>
+#include <list>
 
 /* Initial repeat delay passed */
 static int repeat_delay_timeout_handler(void *callback)

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -49,7 +49,6 @@ class wayfire_oswitch : public wf::plugin_interface_t
         auto current_output = wf::get_core().seat->get_active_output();
         auto view =
             wf::find_topmost_parent(wf::toplevel_cast(wf::get_active_view_for_output(current_output)));
-
         if (view)
         {
             move_view_to_output(view, target_output, true);

--- a/plugins/single_plugins/preserve-output.cpp
+++ b/plugins/single_plugins/preserve-output.cpp
@@ -1,4 +1,5 @@
 #include "wayfire/core.hpp"
+#include "wayfire/debug.hpp"
 #include "wayfire/plugin.hpp"
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/signal-definitions.hpp>

--- a/plugins/single_plugins/wsets.cpp
+++ b/plugins/single_plugins/wsets.cpp
@@ -23,6 +23,7 @@
 #include <wayfire/config/types.hpp>
 #include <wayfire/output-layout.hpp>
 #include <wayfire/bindings-repository.hpp>
+#include <list>
 
 
 class wayfire_wsets_plugin_t : public wf::plugin_interface_t

--- a/plugins/single_plugins/xkb-bindings.cpp
+++ b/plugins/single_plugins/xkb-bindings.cpp
@@ -4,6 +4,7 @@
 #include <wayfire/bindings-repository.hpp>
 #include "wayfire/core.hpp"
 #include "wayfire/seat.hpp"
+#include <map>
 
 namespace wf
 {

--- a/plugins/window-rules/view-action-interface.cpp
+++ b/plugins/window-rules/view-action-interface.cpp
@@ -11,6 +11,7 @@
 #include "../wm-actions/wm-actions-signals.hpp"
 #include <wayfire/plugins/common/util.hpp>
 #include <wayfire/window-manager.hpp>
+#include <wayfire/workspace-set.hpp>
 
 #include <algorithm>
 #include <cfloat>

--- a/plugins/window-rules/view-action-interface.hpp
+++ b/plugins/window-rules/view-action-interface.hpp
@@ -2,7 +2,7 @@
 #define VIEW_ACTION_INTERFACE_HPP
 
 #include "wayfire/action/action_interface.hpp"
-#include "wayfire/view.hpp"
+#include "wayfire/toplevel-view.hpp"
 #include <string>
 #include <tuple>
 #include <vector>

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -18,6 +18,7 @@
 #include "wayfire/seat.hpp"
 #include "wayfire/nonstd/reverse.hpp"
 #include "wm-actions-signals.hpp"
+#include "wayfire/nonstd/reverse.hpp"
 
 class always_on_top_root_node_t : public wf::scene::output_node_t
 {

--- a/plugins/wobbly/wayfire/plugins/wobbly/wobbly-signal.hpp
+++ b/plugins/wobbly/wayfire/plugins/wobbly/wobbly-signal.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/core.hpp>
+#include <wayfire/toplevel-view.hpp>
 
 enum wobbly_event
 {
@@ -97,13 +98,10 @@ inline void move_wobbly(wayfire_toplevel_view view, int grab_x, int grab_y)
  */
 inline void activate_wobbly(wayfire_toplevel_view view)
 {
-    if (!view->get_transformed_node()->get_transformer("wobbly"))
-    {
-        wobbly_signal sig;
-        sig.view   = view;
-        sig.events = WOBBLY_EVENT_ACTIVATE;
-        wf::get_core().emit(&sig);
-    }
+    wobbly_signal sig;
+    sig.view   = view;
+    sig.events = WOBBLY_EVENT_ACTIVATE;
+    wf::get_core().emit(&sig);
 }
 
 /**

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -932,6 +932,12 @@ class wayfire_wobbly : public wf::plugin_interface_t
     void adjust_wobbly(wobbly_signal *data)
     {
         auto tr_manager = data->view->get_transformed_node();
+
+        if ((data->events == WOBBLY_EVENT_ACTIVATE) && tr_manager->get_transformer("wobbly"))
+        {
+            return;
+        }
+
         if ((data->events & (WOBBLY_EVENT_GRAB | WOBBLY_EVENT_ACTIVATE)) &&
             !tr_manager->get_transformer<wobbly_transformer_node_t>("wobbly"))
         {

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -10,7 +10,6 @@
 #include <limits>
 #include <vector>
 #include <wayfire/nonstd/observer_ptr.h>
-#include <wayfire/config/config-manager.hpp>
 
 #include <wayland-server.h>
 #include <wayfire/nonstd/wlroots.hpp>
@@ -37,6 +36,11 @@ namespace touch
 {
 class gesture_t;
 struct gesture_state_t;
+}
+
+namespace config
+{
+class config_manager_t;
 }
 }
 
@@ -80,7 +84,7 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
     /**
      * The current configuration used by Wayfire
      */
-    wf::config::config_manager_t config;
+    std::unique_ptr<wf::config::config_manager_t> config;
 
     /**
      * Command line arguments.

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -2,10 +2,7 @@
 #define CORE_HPP
 
 #include "wayfire/object.hpp"
-#include "wayfire/scene-input.hpp"
-#include <wayfire/geometry.hpp>
 #include <wayfire/idle.hpp>
-#include <wayfire/config-backend.hpp>
 #include <wayfire/scene.hpp>
 #include <wayfire/signal-provider.hpp>
 
@@ -24,6 +21,7 @@ class view_interface_t;
 class toplevel_view_interface_t;
 class window_manager_t;
 class workspace_set_t;
+class config_backend_t;
 
 namespace scene
 {

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -1,8 +1,12 @@
 #ifndef WF_GEOMETRY_HPP
 #define WF_GEOMETRY_HPP
 
-#include <ostream>
-#include <wayfire/nonstd/wlroots.hpp>
+#include <iosfwd>
+#include <algorithm>
+
+extern "C" {
+#include <wlr/util/box.h>
+}
 
 namespace wf
 {

--- a/src/api/wayfire/nonstd/tracking-allocator.hpp
+++ b/src/api/wayfire/nonstd/tracking-allocator.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <functional>
+#include <algorithm>
 #include <wayfire/dassert.hpp>
 #include <wayfire/nonstd/observer_ptr.h>
 #include <wayfire/signal-provider.hpp>

--- a/src/api/wayfire/option-wrapper.hpp
+++ b/src/api/wayfire/option-wrapper.hpp
@@ -3,6 +3,7 @@
 #include <wayfire/config/option.hpp>
 #include <wayfire/config/option-wrapper.hpp>
 #include <wayfire/core.hpp>
+#include <wayfire/util/duration.hpp>
 
 namespace wf
 {

--- a/src/api/wayfire/option-wrapper.hpp
+++ b/src/api/wayfire/option-wrapper.hpp
@@ -14,6 +14,7 @@ namespace detail
 void option_wrapper_debug_message(const std::string& option_name, const std::runtime_error& err);
 [[noreturn]]
 void option_wrapper_debug_message(const std::string& option_name, const std::logic_error& err);
+std::shared_ptr<config::option_base_t> load_raw_option(const std::string& name);
 }
 
 /**
@@ -49,9 +50,9 @@ class option_wrapper_t : public base_option_wrapper_t<Type>
     {}
 
   protected:
-    std::shared_ptr<config::option_base_t> load_raw_option(const std::string& name)
+    std::shared_ptr<wf::config::option_base_t> load_raw_option(const std::string& name) override
     {
-        return wf::get_core().config.get_option(name);
+        return detail::load_raw_option(name);
     }
 };
 }

--- a/src/api/wayfire/output-layout.hpp
+++ b/src/api/wayfire/output-layout.hpp
@@ -18,6 +18,85 @@
 namespace wf
 {
 class output_t;
+
+/* ----------------------------------------------------------------------------/
+ * Output signals
+ * -------------------------------------------------------------------------- */
+
+/** Base class for all output signals. */
+
+/**
+ * on: output-layout
+ * when: Each time a new output is added.
+ */
+struct output_added_signal
+{
+    wf::output_t *output;
+};
+
+/**
+ * on: output, output-layout(output-)
+ * when: Emitted just before starting the destruction procedure for an output.
+ */
+struct output_pre_remove_signal
+{
+    wf::output_t *output;
+};
+
+/**
+ * on: output-layout
+ * when: Each time a new output is added.
+ */
+struct output_removed_signal
+{
+    wf::output_t *output;
+};
+
+enum output_config_field_t
+{
+    /** Output source changed */
+    OUTPUT_SOURCE_CHANGE    = (1 << 0),
+    /** Output mode changed */
+    OUTPUT_MODE_CHANGE      = (1 << 1),
+    /** Output scale changed */
+    OUTPUT_SCALE_CHANGE     = (1 << 2),
+    /** Output transform changed */
+    OUTPUT_TRANSFORM_CHANGE = (1 << 3),
+    /** Output position changed */
+    OUTPUT_POSITION_CHANGE  = (1 << 4),
+};
+
+struct output_state_t;
+
+/**
+ * on: output-layout
+ * when: Each time the configuration of the output layout changes.
+ */
+struct output_layout_configuration_changed_signal
+{};
+
+/**
+ * on: output
+ * when: Each time the output's source, mode, scale, transform and/or position changes.
+ */
+struct output_configuration_changed_signal
+{
+    wf::output_t *output;
+    output_configuration_changed_signal(const wf::output_state_t& st) : state(st)
+    {}
+
+    /**
+     * Which output attributes actually changed.
+     * A bitwise OR of output_config_field_t.
+     */
+    uint32_t changed_fields;
+
+    /**
+     * The new state of the output.
+     */
+    const wf::output_state_t& state;
+};
+
 /** Represents the source of pixels for this output */
 enum output_image_source_t
 {

--- a/src/api/wayfire/per-output-plugin.hpp
+++ b/src/api/wayfire/per-output-plugin.hpp
@@ -1,5 +1,3 @@
-#include "wayfire/object.hpp"
-#include "wayfire/signal-definitions.hpp"
 #include "wayfire/signal-provider.hpp"
 #include <wayfire/plugin.hpp>
 #include <wayfire/core.hpp>

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -3,7 +3,7 @@
 
 #include <functional>
 #include <string>
-#include <wayfire/nonstd/wlroots.hpp>
+#include <cstdint>
 
 class wayfire_config;
 namespace wf

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -105,7 +105,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2025'02'18;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2025'02'26;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/render-manager.hpp
+++ b/src/api/wayfire/render-manager.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "wayfire/opengl.hpp"
 #include <wayfire/output.hpp>
 #include <wayfire/object.hpp>
 #include <wayfire/region.hpp>

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
-#include "wayfire/opengl.hpp"
 #include <optional>
 #include <memory>
 #include <vector>
-#include <map>
 #include <wayfire/geometry.hpp>
 #include <wayfire/region.hpp>
 #include <wayfire/nonstd/observer_ptr.h>
 #include <wayfire/scene-input.hpp>
-#include <wayfire/scene-render.hpp>
 #include <wayfire/signal-provider.hpp>
 
 namespace wf
@@ -70,6 +67,10 @@ namespace scene
 class node_t;
 using node_ptr = std::shared_ptr<node_t>;
 using node_weak_ptr = std::weak_ptr<node_t>;
+
+class render_instance_t;
+using render_instance_uptr = std::unique_ptr<render_instance_t>;
+using damage_callback = std::function<void (const wf::region_t&)>;
 
 /**
  * Describes the current state of a node.

--- a/src/api/wayfire/seat.hpp
+++ b/src/api/wayfire/seat.hpp
@@ -17,6 +17,23 @@ enum class keyboard_focus_reason
 };
 
 /**
+ * on: core
+ * when: Keyboard focus is changed (may change to nullptr).
+ */
+struct keyboard_focus_changed_signal
+{
+    wf::scene::node_ptr new_focus;
+    keyboard_focus_reason reason = keyboard_focus_reason::UNKNOWN;
+};
+
+/**
+ * on: core
+ * when: Seat activity has happened after being idle.
+ */
+struct seat_activity_signal
+{};
+
+/**
  * A seat represents a group of input devices (mouse, keyboard, etc.) which logically belong together.
  * Each seat has its own keyboard, touch, pointer and tablet focus.
  * Currently, Wayfire supports only a single seat.

--- a/src/api/wayfire/seat.hpp
+++ b/src/api/wayfire/seat.hpp
@@ -3,7 +3,6 @@
 #include <memory>
 #include <wayfire/scene.hpp>
 #include <wayfire/nonstd/wlroots.hpp>
-#include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/view.hpp>
 
 namespace wf

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -3,7 +3,6 @@
 
 #include "wayfire/view.hpp"
 #include "wayfire/output.hpp"
-#include "wayfire/seat.hpp"
 
 /**
  * Documentation of signals emitted from core components.
@@ -197,106 +196,11 @@ struct reload_config_signal
 
 /**
  * on: core
- * when: Keyboard focus is changed (may change to nullptr).
- */
-struct keyboard_focus_changed_signal
-{
-    wf::scene::node_ptr new_focus;
-    keyboard_focus_reason reason = keyboard_focus_reason::UNKNOWN;
-};
-
-/**
- * on: core
- * when: Seat activity has happened after being idle.
- */
-struct seat_activity_signal
-{};
-
-/**
- * on: core
  * when: idle inhibit changed.
  */
 struct idle_inhibit_changed_signal
 {
     bool inhibit;
-};
-
-/* ----------------------------------------------------------------------------/
- * Output signals
- * -------------------------------------------------------------------------- */
-
-/** Base class for all output signals. */
-
-/**
- * on: output-layout
- * when: Each time a new output is added.
- */
-struct output_added_signal
-{
-    wf::output_t *output;
-};
-
-/**
- * on: output, output-layout(output-)
- * when: Emitted just before starting the destruction procedure for an output.
- */
-struct output_pre_remove_signal
-{
-    wf::output_t *output;
-};
-
-/**
- * on: output-layout
- * when: Each time a new output is added.
- */
-struct output_removed_signal
-{
-    wf::output_t *output;
-};
-
-enum output_config_field_t
-{
-    /** Output source changed */
-    OUTPUT_SOURCE_CHANGE    = (1 << 0),
-    /** Output mode changed */
-    OUTPUT_MODE_CHANGE      = (1 << 1),
-    /** Output scale changed */
-    OUTPUT_SCALE_CHANGE     = (1 << 2),
-    /** Output transform changed */
-    OUTPUT_TRANSFORM_CHANGE = (1 << 3),
-    /** Output position changed */
-    OUTPUT_POSITION_CHANGE  = (1 << 4),
-};
-
-struct output_state_t;
-
-/**
- * on: output-layout
- * when: Each time the configuration of the output layout changes.
- */
-struct output_layout_configuration_changed_signal
-{};
-
-/**
- * on: output
- * when: Each time the output's source, mode, scale, transform and/or position changes.
- */
-struct output_configuration_changed_signal
-{
-    wf::output_t *output;
-    output_configuration_changed_signal(const wf::output_state_t& st) : state(st)
-    {}
-
-    /**
-     * Which output attributes actually changed.
-     * A bitwise OR of output_config_field_t.
-     */
-    uint32_t changed_fields;
-
-    /**
-     * The new state of the output.
-     */
-    const wf::output_state_t& state;
 };
 
 /**

--- a/src/api/wayfire/signal-provider.hpp
+++ b/src/api/wayfire/signal-provider.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <memory>
 #include <unordered_set>
 #include <unordered_map>
 #include <wayfire/nonstd/safe-list.hpp>

--- a/src/api/wayfire/toplevel.hpp
+++ b/src/api/wayfire/toplevel.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <optional>
+#include <wayfire/nonstd/wlroots.hpp>
 #include "wayfire/geometry.hpp"
 #include "wayfire/object.hpp"
 #include <wayfire/txn/transaction-object.hpp>

--- a/src/api/wayfire/txn/transaction-object.hpp
+++ b/src/api/wayfire/txn/transaction-object.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <wayfire/signal-provider.hpp>
+#include <string>
+#include <memory>
 
 namespace wf
 {

--- a/src/api/wayfire/txn/transaction-object.hpp
+++ b/src/api/wayfire/txn/transaction-object.hpp
@@ -61,12 +61,6 @@ struct object_ready_signal
 /**
  * Emit the object-ready signal on the given object.
  */
-inline void emit_object_ready(wf::txn::transaction_object_t *obj)
-{
-    wf::txn::object_ready_signal data_ready;
-    data_ready.self = obj;
-    obj->emit(&data_ready);
-    return;
-}
+void emit_object_ready(wf::txn::transaction_object_t *obj);
 }
 }

--- a/src/api/wayfire/unstable/wlr-surface-node.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-node.hpp
@@ -6,6 +6,7 @@
 #include "wayfire/view-transform.hpp"
 #include <wayfire/scene.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
+#include <wayfire/output-layout.hpp>
 
 namespace wf
 {

--- a/src/api/wayfire/view.hpp
+++ b/src/api/wayfire/view.hpp
@@ -3,13 +3,10 @@
 
 #include <memory>
 #include <type_traits>
-#include <vector>
 #include <wayfire/nonstd/observer_ptr.h>
 
 #include "wayfire/nonstd/tracking-allocator.hpp"
 #include "wayfire/object.hpp"
-#include "wayfire/geometry.hpp"
-#include "wayfire/view-transform.hpp"
 #include <wayfire/nonstd/wlroots.hpp>
 #include <wayfire/signal-provider.hpp>
 #include <wayfire/scene.hpp>
@@ -29,6 +26,7 @@ class output_t;
 namespace scene
 {
 class view_node_t;
+class transform_manager_node_t;
 }
 
 /* abstraction for desktop-apis, no real need for plugins

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -12,6 +12,7 @@
 #include "wayfire/bindings-repository.hpp"
 #include "wayfire/util.hpp"
 #include <memory>
+#include "wayfire/config-backend.hpp" // IWYU pragma: keep
 
 #include "plugin-loader.hpp"
 #include "seat/tablet.hpp"

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -605,7 +605,10 @@ const std::shared_ptr<wf::scene::root_node_t>& wf::compositor_core_impl_t::scene
 }
 
 wf::compositor_core_t::compositor_core_t()
-{}
+{
+    this->config = std::make_unique<wf::config::config_manager_t>();
+}
+
 wf::compositor_core_t::~compositor_core_t()
 {}
 
@@ -654,3 +657,8 @@ std::unique_ptr<wf::compositor_core_impl_t> wf::compositor_core_impl_t::static_c
 
 // TODO: move this to a better location
 wf_runtime_config runtime_config;
+
+std::shared_ptr<wf::config::option_base_t> wf::detail::load_raw_option(const std::string& name)
+{
+    return wf::get_core().config->get_option(name);
+}

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -6,6 +6,7 @@
 #include "wayfire/render-manager.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include "wayfire/util.hpp"
+#include "wayfire/config-backend.hpp"
 
 #include "../output/output-impl.hpp"
 #include <xf86drmMode.h>

--- a/src/core/plugin.cpp
+++ b/src/core/plugin.cpp
@@ -4,6 +4,8 @@
 #include <wayfire/config-backend.hpp>
 #include <wayfire/plugin.hpp>
 #include <libudev.h>
+#include <wayfire/plugin.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
 
 void wf::plugin_interface_t::fini()
 {}
@@ -17,13 +19,13 @@ std::shared_ptr<config::section_t> wf::config_backend_t::get_output_section(
     std::string name = output->name;
     name = "output:" + name;
     auto& config = wf::get_core().config;
-    if (!config.get_section(name))
+    if (!config->get_section(name))
     {
-        config.merge_section(
-            config.get_section("output")->clone_with_name(name));
+        config->merge_section(
+            config->get_section("output")->clone_with_name(name));
     }
 
-    return config.get_section(name);
+    return config->get_section(name);
 }
 
 static struct udev_property_and_desc
@@ -66,7 +68,7 @@ std::shared_ptr<config::section_t> wf::config_backend_t::get_input_device_sectio
                     std::string name = prefix + ":" + nonull(value);
                     LOGC(INPUT_DEVICES, "Checking for config section [", name, "] ",
                         pd.property_name, " (", pd.description, ")");
-                    section = config.get_section(name);
+                    section = config->get_section(name);
                     if (section)
                     {
                         LOGC(INPUT_DEVICES, "Using config section [", name, "] for ", nonull(device->name));
@@ -81,24 +83,24 @@ std::shared_ptr<config::section_t> wf::config_backend_t::get_input_device_sectio
     name = prefix + ":" + name;
     LOGC(INPUT_DEVICES, "Checking for config section [", name, "]");
 
-    if (!config.get_section(name))
+    if (!config->get_section(name))
     {
         // For input-device:(*) section, we always use per-device sections.
         // For input:(*) sections, we fall back to the common [input] section.
         if (prefix == "input")
         {
             LOGC(INPUT_DEVICES, "Using default config section [", prefix, "]");
-            section = config.get_section(prefix);
+            section = config->get_section(prefix);
         } else
         {
             LOGC(INPUT_DEVICES, "Creating config section [", name, "]");
-            section = config.get_section(prefix)->clone_with_name(name);
-            config.merge_section(section);
+            section = config->get_section(prefix)->clone_with_name(name);
+            config->merge_section(section);
         }
     } else
     {
         LOGC(INPUT_DEVICES, "Using config section [", name, "]");
-        section = config.get_section(name);
+        section = config->get_section(name);
     }
 
     return section;

--- a/src/core/seat/hotspot-manager.hpp
+++ b/src/core/seat/hotspot-manager.hpp
@@ -6,6 +6,7 @@
 #include <wayfire/util/log.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
+#include <any>
 
 namespace  wf
 {

--- a/src/core/seat/input-manager.cpp
+++ b/src/core/seat/input-manager.cpp
@@ -1,5 +1,4 @@
 #include <cassert>
-#include <algorithm>
 #include "pointer.hpp"
 #include "wayfire/core.hpp"
 #include "wayfire/signal-definitions.hpp"
@@ -9,6 +8,7 @@
 #include "input-manager.hpp"
 #include "wayfire/output-layout.hpp"
 #include "wayfire/view.hpp"
+#include "wayfire/config-backend.hpp"
 #include <wayfire/util/log.hpp>
 #include <wayfire/debug.hpp>
 

--- a/src/core/seat/input-manager.hpp
+++ b/src/core/seat/input-manager.hpp
@@ -1,14 +1,11 @@
 #ifndef INPUT_MANAGER_HPP
 #define INPUT_MANAGER_HPP
 
-#include <map>
+#include <wayfire/output-layout.hpp>
 #include <vector>
-#include <chrono>
 
 #include "seat-impl.hpp"
-#include "wayfire/plugin.hpp"
 #include "wayfire/signal-provider.hpp"
-#include "wayfire/view.hpp"
 #include "wayfire/core.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include <wayfire/option-wrapper.hpp>

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -1,9 +1,9 @@
 #pragma once
 #include "wayfire/util.hpp"
-#include "wayfire/signal-definitions.hpp"
 #include "wayfire/view.hpp"
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/unstable/wlr-text-input-v3-popup.hpp>
+#include <wayfire/seat.hpp>
 
 #include <vector>
 #include <memory>

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -12,6 +12,7 @@
 #include "input-manager.hpp"
 #include "input-method-relay.hpp"
 #include "wayfire/signal-definitions.hpp"
+#include <wayfire/config-backend.hpp>
 
 void wf::keyboard_t::setup_listeners()
 {

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -1,4 +1,5 @@
 #include "pointing-device.hpp"
+#include <wayfire/config-backend.hpp>
 
 wf::pointing_device_t::pointing_device_t(wlr_input_device *dev) :
     input_device_impl_t(dev)

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -9,6 +9,7 @@
 #include "wayfire/output.hpp"
 #include "wayfire/util.hpp"
 #include "wayfire/output-layout.hpp"
+#include <glm/glm.hpp>
 
 class touch_timer_adapter_t : public wf::touch::timer_interface_t
 {

--- a/src/core/txn/transaction.cpp
+++ b/src/core/txn/transaction.cpp
@@ -118,3 +118,11 @@ std::unique_ptr<wf::txn::transaction_t> wf::txn::transaction_t::create(int64_t t
 
     return std::make_unique<wayfire_default_transaction_t>(timeout);
 }
+
+void wf::txn::emit_object_ready(wf::txn::transaction_object_t *obj)
+{
+    wf::txn::object_ready_signal data_ready;
+    data_ready.self = obj;
+    obj->emit(&data_ready);
+    return;
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -451,7 +451,7 @@ int main(int argc, char *argv[])
 
     LOGD("Using configuration backend: ", config_backend);
     core.config_backend = std::unique_ptr<wf::config_backend_t>(backend);
-    core.config_backend->init(display, core.config, config_file);
+    core.config_backend->init(display, *core.config, config_file);
     core.init();
 
     auto socket = choose_socket(core.display);

--- a/src/output/output-impl.hpp
+++ b/src/output/output-impl.hpp
@@ -5,13 +5,13 @@
 #include "wayfire/plugin.hpp"
 #include "wayfire/scene-render.hpp"
 #include "wayfire/scene.hpp"
-#include "wayfire/signal-definitions.hpp"
-#include "wayfire/signal-provider.hpp"
 
 #include <memory>
 #include <unordered_set>
 #include <wayfire/nonstd/safe-list.hpp>
 #include <wayfire/workspace-set.hpp>
+#include <wayfire/output-layout.hpp>
+#include <map>
 
 namespace wf
 {

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -19,6 +19,7 @@
 #include <wayfire/util/log.hpp>
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wlr/types/wlr_gamma_control_v1.h>
+#include <wayfire/output-layout.hpp>
 
 namespace wf
 {

--- a/src/output/workarea.cpp
+++ b/src/output/workarea.cpp
@@ -3,6 +3,7 @@
 #include "wayfire/signal-provider.hpp"
 #include <wayfire/output.hpp>
 #include <wayfire/signal-definitions.hpp>
+#include <wayfire/output-layout.hpp>
 
 struct wf::output_workarea_manager_t::impl
 {

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -3,7 +3,7 @@
 
 #include "view-impl.hpp"
 #include "wayfire/geometry.hpp"
-#include "wayfire/signal-definitions.hpp"
+#include "wayfire/seat.hpp"
 #include "wayfire/signal-provider.hpp"
 #include "wayfire/view.hpp"
 

--- a/test/misc/tracking-allocator.cpp
+++ b/test/misc/tracking-allocator.cpp
@@ -6,6 +6,7 @@
 class base_t : public wf::signal::provider_t
 {
   public:
+    using wf::signal::provider_t::provider_t;
     static int destroyed;
     virtual ~base_t()
     {


### PR DESCRIPTION
Part 1 of my changes aimed at improving compilation times in Wayfire.
The changes here are pretty straightforward, just shuffling header files and definitions around so that we don't include stuff we don't need.

~~There are no breaking changes for plugins, but some plugins may be broken if they rely on transitive includes.~~

Breaking changes for plugins:

- `wf::get_core().config` is now a pointer.
- Output signals are defined in output-layout.hpp instead of signal-definitions.hpp
- `keyboard-focus-changed` and `seat-activity` signals are defined in seat.hpp

If plugins use these signals, they ought to now include the correct headers.

Benchmark on my 6C12T laptop shows 52s build time before, 46s build time after, so about 12% faster.
