### PR TITLE
Allow Vendored Configuration File

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ xbps-install -S wayfire
 
 ## Configuration
 
-Copy [`wayfire.ini`] to `~/.config/wayfire.ini`.
+Copy [`wayfire.ini`] to `~/.config/wayfire.ini` or `~/.config/wayfire/wayfire.ini`.
 Before running Wayfire, you may want to change the command to start a terminal.
 See the [Configuration] document for information on the options.
 

--- a/man/wayfire.1.in
+++ b/man/wayfire.1.in
@@ -32,6 +32,8 @@ with an alternative configuration file.
 The default configuration file is searched first in the
 .Ev ${WAYFIRE_CONFIG_FILE}
 environment variable, or paths
+.Pa ${XDG_CONFIG_HOME}/wayfire/wayfire.ini ,
+.Pa ${HOME}/.config/wayfire/wayfire.ini ,
 .Pa ${XDG_CONFIG_HOME}/wayfire.ini ,
 .Pa ${HOME}/.config/wayfire.ini .
 .Pp

--- a/src/default-config-backend.cpp
+++ b/src/default-config-backend.cpp
@@ -145,7 +145,8 @@ class dynamic_ini_config_t : public wf::config_backend_t
             (std::string(nonull(getenv("HOME"))) + "/.config");
 
         std::string vendored_cfg_file = env_cfg_home + "/wayfire/wayfire.ini";
-        if (std::filesystem::exists(vendored_cfg_file)) {
+        if (std::filesystem::exists(vendored_cfg_file))
+        {
             return vendored_cfg_file;
         }
 

--- a/src/default-config-backend.cpp
+++ b/src/default-config-backend.cpp
@@ -141,9 +141,15 @@ class dynamic_ini_config_t : public wf::config_backend_t
             return env_cfg_file;
         }
 
-        return (getenv("XDG_CONFIG_HOME") ?:
-            (std::string(nonull(getenv("HOME"))) + "/.config")) +
-               "/wayfire.ini";
+        std::string env_cfg_home = getenv("XDG_CONFIG_HOME") ?:
+            (std::string(nonull(getenv("HOME"))) + "/.config");
+
+        std::string vendored_cfg_file = env_cfg_home + "/wayfire/wayfire.ini";
+        if (std::filesystem::exists(vendored_cfg_file)) {
+            return vendored_cfg_file;
+        }
+
+        return env_cfg_home + "/wayfire.ini";
     }
 };
 }


### PR DESCRIPTION
This PR adds support for vendoring the Wayfire configuration file.  In particular this means `${XDG_CONFIG_HOME}/wayfire/wayfire.ini` will take precedence over `${XDG_CONFIG_HOME}/wayfire.ini` while looking for a configuration file.

I opted to implement this change, since Wayfire already uses vendor-directories for plugin data in `${XDG_DATA_HOME}/wayfire/plugin`. Furthermore, I spent way too long trying to find out why my default configuration is not working.  I assume this change can reduce the maintenance burden, since people doing the same mistake will not open an issue or ask in IRC.
I copied it from `/usr/share/examples/wayfire/wayfire.ini` as packaged by my distro and therefore assumed wayfire uses the common vendor prefix pattern.  While researching my problem, I found several threads where people likely did the same mistake.