### PR TITLE
plugin-loader: check API/ABI version with RTLD_LAZY|RTLD_LOCAL

### DIFF
--- a/src/core/plugin-loader.hpp
+++ b/src/core/plugin-loader.hpp
@@ -3,7 +3,6 @@
 #include <vector>
 #include <unordered_map>
 #include "wayfire/plugin.hpp"
-#include "config.h"
 #include "wayfire/util.hpp"
 #include <wayfire/option-wrapper.hpp>
 
@@ -62,7 +61,7 @@ B union_cast(A object)
  *
  * @return (dlopen() handle, newInstance pointer)
  */
-std::pair<void*, void*> get_new_instance_handle(const std::string& path);
+std::pair<void*, void*> get_new_instance_handle(const std::string& path, bool can_unload_so);
 
 /**
  * List the locations where wayfire's plugins are installed.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -171,7 +171,7 @@ static wf::config_backend_t *load_backend(const std::string& backend)
             wf::get_plugin_path_for_name(plugin_prefixes, backend).value_or("");
     }
 
-    auto [_, init_ptr] = wf::get_new_instance_handle(config_plugin);
+    auto [_, init_ptr] = wf::get_new_instance_handle(config_plugin, false);
 
     if (!init_ptr)
     {


### PR DESCRIPTION
This allows Wayfire to better detect when plugins have the wrong API/ABI.

For example with the old check, we load the full code of the plugin before checking its ABI.
But if the plugin includes symbols for example from header-only libraries (for example the way signals are),
then even fully loading the .so file is enough to corrupt the running process and cause a crash.
