### PR TITLE
Compilation time improvements (part 2)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
     - run: find /usr/bin/ | grep clang
     - run: (cd subprojects/wlroots && env CC=clang-17 CXX=clang++-17 CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build --prefix=/usr && ninja -C build install)
-    - run: env CC=clang-17 CXX=clang++-17 CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true -Duse_system_wlroots=enabled --unity on
+    - run: env CC=clang-17 CXX=clang++-17 CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true -Dcustom_pch=true -Duse_system_wlroots=enabled --unity on
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_code_style:

--- a/meson.build
+++ b/meson.build
@@ -4,7 +4,7 @@ project(
 	'cpp',
 	version: '0.10.0',
 	license: 'MIT',
-	meson_version: '>=0.63.0',
+	meson_version: '>=0.64.0',
 	default_options: [
 		'cpp_std=c++17',
 		'c_std=c11',
@@ -203,6 +203,14 @@ configure_file(input: 'config.h.in',
                install: true,
                install_dir: join_paths('include', 'wayfire'),
                configuration: conf_data)
+
+# Detect address sanitizer
+cxx_flags_asan = run_command('/bin/sh', '-c', 'echo $CXXFLAGS $CPPFLAGS | grep fsanitize', check: false)
+if get_option('b_sanitize').contains('address') or cxx_flags_asan.returncode() == 0
+  has_asan = true
+else
+  has_asan = false
+endif
 
 subdir('proto')
 subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,8 @@ project(
 	],
 )
 
+cpp = meson.get_compiler('cpp')
+
 version = '"@0@"'.format(meson.project_version())
 add_project_arguments('-DWAYFIRE_VERSION=@0@'.format(version), language: 'cpp')
 
@@ -32,7 +34,7 @@ glm            = dependency('glm', required: false)
 libinput       = dependency('libinput', version: '>=1.7.0')
 pixman         = dependency('pixman-1')
 xkbcommon      = dependency('xkbcommon')
-libdl          = meson.get_compiler('cpp').find_library('dl')
+libdl          = cpp.find_library('dl')
 json           = dependency('nlohmann_json', version: '>= 3.11.2')
 udev           = dependency('libudev')
 
@@ -106,11 +108,11 @@ elif get_option('use_system_wfconfig').auto()
 	endif
 endif
 
-if not glm.found() and not meson.get_compiler('cpp').check_header('glm/glm.hpp')
+if not glm.found() and not cpp.check_header('glm/glm.hpp')
   error('GLM not found, and directly using the header \'glm/glm.hpp\' is not possible.')
 endif
 
-backtrace = meson.get_compiler('cpp').find_library('execinfo', required: false)
+backtrace = cpp.find_library('execinfo', required: false)
 
 wfutils = subproject('wf-utils').get_variable('wfutils')
 wftouch = subproject('wf-touch').get_variable('wftouch')
@@ -122,7 +124,7 @@ jpeg = dependency('libjpeg', required: false)
 png  = dependency('libpng',  required: false)
 
 # backtrace() is in a separate library on FreeBSD and Linux with musl
-backtrace = meson.get_compiler('cpp').find_library('execinfo', required: false)
+backtrace = cpp.find_library('execinfo', required: false)
 
 conf_data = configuration_data()
 
@@ -139,8 +141,6 @@ if get_option('default_config_backend') == 'default'
 else
   conf_data.set('DEFAULT_CONFIG_BACKEND', get_option('default_config_backend'))
 endif
-
-cpp = meson.get_compiler('cpp')
 
 # needed to dlopen() plugins
 # -E is for RTTI/dynamic_cast across plugins

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,4 @@ option('xwayland', type: 'feature', value: 'auto', description: 'Build with xway
 option('default_config_backend', type: 'string', value: 'default', description: 'Default configuration backend to use')
 option('print_trace', type: 'boolean', value: true, description: 'Print stack trace in debug logs (disables coredump)')
 option('tests', type: 'feature', value: 'auto', description: 'Enable unit tests')
+option('custom_pch', type: 'boolean', value: false, description: 'Use custom PCH for plugins. May not work with all compilers and setups.')

--- a/plugins/animate/meson.build
+++ b/plugins/animate/meson.build
@@ -1,7 +1,10 @@
 dependencies = [wlroots, pixman, wfconfig]
+animate_pch_deps = [plugin_pch_dep]
 
 if get_option('enable_openmp')
    dependencies += [dependency('openmp')]
+   # PCH does not have openmp enabled
+   animate_pch_deps = []
 endif
 
 animiate = shared_module('animate',
@@ -9,7 +12,7 @@ animiate = shared_module('animate',
                           'fire/particle.cpp',
                           'fire/fire.cpp'],
                          include_directories: [wayfire_api_inc, wayfire_conf_inc],
-                         dependencies: dependencies,
+                         dependencies: dependencies + animate_pch_deps,
                          install: true,
                          install_dir: join_paths(get_option('libdir'), 'wayfire'))
 

--- a/plugins/blur/meson.build
+++ b/plugins/blur/meson.build
@@ -1,7 +1,7 @@
 blur_base = shared_library('wayfire-blur-base',
      ['blur-base.cpp', 'box.cpp', 'gaussian.cpp', 'kawase.cpp', 'bokeh.cpp'],
      include_directories: [wayfire_api_inc, wayfire_conf_inc],
-     dependencies: [wlroots, pixman, wfconfig],
+     dependencies: [wlroots, pixman, wfconfig, plugin_pch_dep],
      override_options: ['b_lundef=false'],
      install: true)
 install_headers(['blur.hpp'], subdir: 'wayfire/plugins/blur')
@@ -9,5 +9,5 @@ install_headers(['blur.hpp'], subdir: 'wayfire/plugins/blur')
 blur = shared_module('blur', ['blur.cpp'],
      link_with: blur_base,
      include_directories: [wayfire_api_inc, wayfire_conf_inc],
-     dependencies: [wlroots, pixman, wfconfig],
+     dependencies: [wlroots, pixman, wfconfig, plugin_pch_dep],
      install: true, install_dir: join_paths(get_option('libdir'), 'wayfire'))

--- a/plugins/cube/meson.build
+++ b/plugins/cube/meson.build
@@ -1,6 +1,6 @@
 animiate = shared_module('cube',
                          ['cube.cpp', 'cubemap.cpp', 'skydome.cpp', 'simple-background.cpp'],
                          include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, ipc_include_dirs],
-                         dependencies: [wlroots, pixman, wfconfig, json],
+                         dependencies: [wlroots, pixman, wfconfig, json, plugin_pch_dep],
                          install: true,
                          install_dir: join_paths(get_option('libdir'), 'wayfire'))

--- a/plugins/decor/meson.build
+++ b/plugins/decor/meson.build
@@ -2,6 +2,6 @@ decoration = shared_module('decoration',
     ['decoration.cpp', 'deco-subsurface.cpp', 'deco-button.cpp',
       'deco-layout.cpp', 'deco-theme.cpp'],
     include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc],
-    dependencies: [wlroots, pixman, wf_protos, wfconfig, cairo, pango, pangocairo],
+    dependencies: [wlroots, pixman, wf_protos, wfconfig, cairo, pango, pangocairo, plugin_pch_dep],
     install: true,
     install_dir: join_paths(get_option('libdir'), 'wayfire'))

--- a/plugins/grid/meson.build
+++ b/plugins/grid/meson.build
@@ -1,6 +1,6 @@
 grid_inc = include_directories('.')
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, wobbly_inc, grid_inc]
-all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, json]
+all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, json, plugin_pch_dep]
 
 shared_module('grid', ['grid.cpp'],
         include_directories: all_include_dirs,

--- a/plugins/ipc-rules/ipc-events.hpp
+++ b/plugins/ipc-rules/ipc-events.hpp
@@ -4,7 +4,6 @@
 #include <set>
 #include "plugins/ipc/ipc-method-repository.hpp"
 #include <wayfire/per-output-plugin.hpp>
-#include <nlohmann/json.hpp>
 
 namespace wf
 {

--- a/plugins/ipc-rules/ipc-rules-common.hpp
+++ b/plugins/ipc-rules/ipc-rules-common.hpp
@@ -2,7 +2,6 @@
 #include "plugins/ipc/ipc-helpers.hpp"
 #include <wayfire/output.hpp>
 #include <wayfire/workarea.hpp>
-#include <nlohmann/json.hpp>
 #include <wayfire/workspace-set.hpp>
 #include "config.h"
 #include "wayfire/plugins/common/util.hpp"

--- a/plugins/ipc-rules/meson.build
+++ b/plugins/ipc-rules/meson.build
@@ -1,5 +1,5 @@
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc]
-all_deps = [wlroots, pixman, wfconfig, wftouch, json]
+all_deps = [wlroots, pixman, wfconfig, wftouch, json, plugin_pch_dep]
 
 shared_module('ipc-rules', ['ipc-rules.cpp'],
         include_directories: all_include_dirs,

--- a/plugins/ipc/ipc-helpers.hpp
+++ b/plugins/ipc/ipc-helpers.hpp
@@ -7,7 +7,7 @@
 #include <wayfire/core.hpp>
 #include <wayfire/output-layout.hpp>
 #include <wayfire/core.hpp>
-#include <nlohmann/json.hpp>
+#include <nlohmann/json.hpp> // IWYU pragma: keep
 
 namespace wf
 {

--- a/plugins/ipc/ipc-method-repository.hpp
+++ b/plugins/ipc/ipc-method-repository.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json.hpp> // IWYU pragma: keep
 #include <functional>
 #include <map>
 #include "wayfire/signal-provider.hpp"

--- a/plugins/ipc/ipc.hpp
+++ b/plugins/ipc/ipc.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <nlohmann/json.hpp>
+#include <nlohmann/json.hpp> // IWYU pragma: keep
 #include <sys/un.h>
 #include <wayfire/object.hpp>
 #include <wayland-server.h>

--- a/plugins/ipc/meson.build
+++ b/plugins/ipc/meson.build
@@ -5,21 +5,21 @@ ipc_include_dirs = include_directories('.')
 ipc = shared_module('ipc',
     ['ipc.cpp'],
     include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc],
-    dependencies: [wlroots, pixman, wfconfig, wftouch, json, evdev],
+    dependencies: [wlroots, pixman, wfconfig, wftouch, json, evdev, plugin_pch_dep],
     install: true,
     install_dir: conf_data.get('PLUGIN_PATH'))
 
 stipc = shared_module('stipc',
     ['stipc.cpp'],
     include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc],
-    dependencies: [wlroots, pixman, wfconfig, wftouch, json, evdev],
+    dependencies: [wlroots, pixman, wfconfig, wftouch, json, evdev, plugin_pch_dep],
     install: true,
     install_dir: conf_data.get('PLUGIN_PATH'))
 
 demoipc = shared_module('demo-ipc',
     ['demo-ipc.cpp'],
     include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc],
-    dependencies: [wlroots, pixman, wfconfig, wftouch, json, evdev],
+    dependencies: [wlroots, pixman, wfconfig, wftouch, json, evdev, plugin_pch_dep],
     install: true,
     install_dir: conf_data.get('PLUGIN_PATH'))
 

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -1,4 +1,57 @@
 subdir('common')
+
+if get_option('custom_pch')
+  # Add a workaround for https://github.com/mesonbuild/meson/issues/4350
+  # We create a PCH ourselves and manage it for all plugins.
+  cc = meson.get_compiler('cpp')
+  pch_file = meson.current_source_dir() / 'pch/plugin_pch.hpp'
+  custom_pch_flags = ['@INPUT@', '-c', '-o', '@OUTPUT@', '-MD', '-MF', '@DEPFILE@',
+      '-std=' + get_option('cpp_std'), '-pthread', '-fPIC'] + get_option('cpp_args')
+
+  # Meson enables this unconditionally on everything not-macos and non-msvc
+  custom_pch_flags += ['-D_FILE_OFFSET_BITS=64']
+
+  # Gather flags from the compiler ...
+  if get_option('b_ndebug') == 'false' or (get_option('b_ndebug') == 'if-release' and
+      get_option('buildtype') != 'release')
+    custom_pch_flags += ['-D_GLIBCXX_ASSERTIONS=1']
+  else
+    custom_pch_flags += ['-DNDEBUG']
+  endif
+
+  custom_pch_flags += ['-O' + get_option('optimization')]
+  if get_option('debug')
+    custom_pch_flags += ['-g']
+  endif
+
+  if has_asan
+    custom_pch_flags += ['-fsanitize=address']
+  endif
+
+  pch = custom_target('plugin_pch',
+      input: pch_file,
+      output: 'plugin_pch.hpp.gch',
+      depfile: 'plugin_pch.hpp.d',
+      command: cc.cmd_array() + custom_pch_flags)
+
+  fs = import('fs')
+  if cc.get_id() == 'clang'
+    # In clang, everything is simple, we just tell the compiler which PCH file to use
+    plugin_pch_arg = ['-include-pch', pch.full_path(), '-pthread']
+  elif cc.get_id() == 'gcc'
+    # GCC requires that the .gch and the .hpp file are in the same dir.
+    fs.copyfile(pch_file) # copy to build dir where .gch is found
+    plugin_pch_arg = ['-I' + fs.parent(pch.full_path()), '-include', fs.name(pch_file), '-pthread', '-fpch-preprocess']
+  else
+    error('Unsupported compiler for custom pch: ' + cc.get_id())
+  endif
+
+  plugin_pch_dep = declare_dependency(sources: pch, compile_args: plugin_pch_arg)
+else
+  plugin_pch_args = []
+  plugin_pch_dep = declare_dependency()
+endif
+
 subdir('ipc')
 subdir('protocols')
 subdir('vswitch')

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -3,7 +3,6 @@ subdir('common')
 if get_option('custom_pch')
   # Add a workaround for https://github.com/mesonbuild/meson/issues/4350
   # We create a PCH ourselves and manage it for all plugins.
-  cc = meson.get_compiler('cpp')
   pch_file = meson.current_source_dir() / 'pch/plugin_pch.hpp'
   custom_pch_flags = ['@INPUT@', '-c', '-o', '@OUTPUT@', '-MD', '-MF', '@DEPFILE@',
       '-std=' + get_option('cpp_std'), '-pthread', '-fPIC'] + get_option('cpp_args')
@@ -32,18 +31,18 @@ if get_option('custom_pch')
       input: pch_file,
       output: 'plugin_pch.hpp.gch',
       depfile: 'plugin_pch.hpp.d',
-      command: cc.cmd_array() + custom_pch_flags)
+      command: cpp.cmd_array() + custom_pch_flags)
 
   fs = import('fs')
-  if cc.get_id() == 'clang'
+  if cpp.get_id() == 'clang'
     # In clang, everything is simple, we just tell the compiler which PCH file to use
     plugin_pch_arg = ['-include-pch', pch.full_path(), '-pthread']
-  elif cc.get_id() == 'gcc'
+  elif cpp.get_id() == 'gcc'
     # GCC requires that the .gch and the .hpp file are in the same dir.
     fs.copyfile(pch_file) # copy to build dir where .gch is found
     plugin_pch_arg = ['-I' + fs.parent(pch.full_path()), '-include', fs.name(pch_file), '-pthread', '-fpch-preprocess']
   else
-    error('Unsupported compiler for custom pch: ' + cc.get_id())
+    error('Unsupported compiler for custom pch: ' + cpp.get_id())
   endif
 
   plugin_pch_dep = declare_dependency(sources: pch, compile_args: plugin_pch_arg)

--- a/plugins/pch/plugin_pch.hpp
+++ b/plugins/pch/plugin_pch.hpp
@@ -1,0 +1,13 @@
+#include <wayland-server.h>
+#include <glm/glm.hpp>
+
+#include <string>
+#include <vector>
+#include <utility>
+#include <memory>
+#include <functional>
+#include <algorithm>
+#include <sstream>
+#include <map>
+#include <cmath>
+#include <cstddef>

--- a/plugins/protocols/meson.build
+++ b/plugins/protocols/meson.build
@@ -4,7 +4,7 @@ protocol_plugins = [
 ]
 
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc]
-all_deps = [wlroots, pixman, wfconfig, wf_protos, json, cairo, pango, pangocairo]
+all_deps = [wlroots, pixman, wfconfig, wf_protos, json, cairo, pango, pangocairo, plugin_pch_dep]
 
 foreach plugin : protocol_plugins
   shared_module(plugin, plugin + '.cpp',

--- a/plugins/scale/meson.build
+++ b/plugins/scale/meson.build
@@ -1,5 +1,5 @@
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, vswitch_inc, wobbly_inc, include_directories('.')]
-all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, pango, pangocairo, json]
+all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, pango, pangocairo, json, plugin_pch_dep]
 
 shared_module('scale', ['scale.cpp', 'scale-title-overlay.cpp'],
         include_directories: all_include_dirs,

--- a/plugins/single_plugins/meson.build
+++ b/plugins/single_plugins/meson.build
@@ -6,7 +6,7 @@ plugins = [
 ]
 
 all_include_dirs = [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, vswitch_inc, wobbly_inc, grid_inc]
-all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, pango, pangocairo, json]
+all_deps = [wlroots, pixman, wfconfig, wftouch, cairo, pango, pangocairo, json, plugin_pch_dep]
 
 foreach plugin : plugins
   shared_module(plugin, plugin + '.cpp',

--- a/plugins/tile/meson.build
+++ b/plugins/tile/meson.build
@@ -1,7 +1,7 @@
 tile = shared_module('simple-tile',
         ['tile-plugin.cpp', 'tree.cpp', 'tree-controller.cpp'],
         include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, grid_inc, wobbly_inc, ipc_include_dirs],
-        dependencies: [wlroots, pixman, wfconfig, json],
+        dependencies: [wlroots, pixman, wfconfig, json, plugin_pch_dep],
         install: true,
         install_dir: join_paths(get_option('libdir'), 'wayfire'))
 

--- a/plugins/tile/tile-ipc.hpp
+++ b/plugins/tile/tile-ipc.hpp
@@ -4,7 +4,6 @@
 #include <wayfire/workspace-set.hpp>
 #include <wayfire/toplevel-view.hpp>
 #include "tree.hpp"
-#include <nlohmann/json.hpp>
 #include "plugins/ipc/ipc-helpers.hpp"
 #include "plugins/ipc/ipc-method-repository.hpp"
 #include "tile-wset.hpp"

--- a/plugins/vswitch/meson.build
+++ b/plugins/vswitch/meson.build
@@ -3,7 +3,7 @@ vswitch_inc = include_directories('.')
 vswitch = shared_module('vswitch',
     ['vswitch.cpp'],
     include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc, vswitch_inc, ipc_include_dirs],
-    dependencies: [wlroots, pixman, wfconfig, json],
+    dependencies: [wlroots, pixman, wfconfig, json, plugin_pch_dep],
     install: true,
     install_dir: join_paths(get_option('libdir'), 'wayfire'))
 

--- a/plugins/window-rules/meson.build
+++ b/plugins/window-rules/meson.build
@@ -1,7 +1,6 @@
 window_rules  = shared_module('window-rules',
                               ['window-rules.cpp', 'view-action-interface.cpp'],
                               include_directories: [wayfire_api_inc, wayfire_conf_inc, grid_inc, plugins_common_inc],
-                              dependencies: [wlroots, pixman, wfconfig, wfutils],
+                              dependencies: [wlroots, pixman, wfconfig, wfutils, plugin_pch_dep],
                               install: true,
-                              install_dir: join_paths(get_option('libdir'), 'wayfire')
-                              )
+                              install_dir: join_paths(get_option('libdir'), 'wayfire'))

--- a/plugins/wm-actions/meson.build
+++ b/plugins/wm-actions/meson.build
@@ -1,7 +1,7 @@
 wm_actions = shared_module('wm-actions',
                            ['wm-actions.cpp'],
                            include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc],
-                           dependencies: [wlroots, pixman, wfconfig, json],
+                           dependencies: [wlroots, pixman, wfconfig, json, plugin_pch_dep],
                            install: true,
                            install_dir: join_paths(get_option('libdir'), 'wayfire'))
 

--- a/plugins/wobbly/meson.build
+++ b/plugins/wobbly/meson.build
@@ -1,7 +1,10 @@
+wobbly_c_model = static_library('wobbly-c-model', ['wobbly.c'], install: false)
+
 wobbly = shared_module('wobbly',
-                       ['wobbly.cpp', 'wobbly.c'],
+                       ['wobbly.cpp'],
                        include_directories: [wayfire_api_inc, wayfire_conf_inc, plugins_common_inc],
-                       dependencies: [wlroots, pixman, wfconfig],
+                       dependencies: [wlroots, pixman, wfconfig, plugin_pch_dep],
+                       link_with: wobbly_c_model,
                        install: true,
                        install_dir: join_paths(get_option('libdir'), 'wayfire'))
 

--- a/plugins/wobbly/wayfire/plugins/wobbly/wobbly-signal.hpp
+++ b/plugins/wobbly/wayfire/plugins/wobbly/wobbly-signal.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/core.hpp>
 #include <wayfire/toplevel-view.hpp>

--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #ifndef WLR_USE_UNSTABLE
-    #define WLR_USE_UNSTABLE
+    #define WLR_USE_UNSTABLE 1
 #endif
 
 /**

--- a/src/api/wayfire/per-output-plugin.hpp
+++ b/src/api/wayfire/per-output-plugin.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "wayfire/signal-provider.hpp"
 #include <wayfire/plugin.hpp>
 #include <wayfire/core.hpp>

--- a/src/meson.build
+++ b/src/meson.build
@@ -81,8 +81,7 @@ else
 endif
 
 
-cxx_flags_asan = run_command('/bin/sh', '-c', 'echo $CXXFLAGS $CPPFLAGS | grep fsanitize', check: false)
-if get_option('b_sanitize').contains('address') or cxx_flags_asan.returncode() == 0
+if has_asan
   print_trace = false
   debug_arguments += ['-DHAS_ASAN=1']
   message('Address sanitizer enabled, disabling internal backtrace')


### PR DESCRIPTION
This PR adds support for PCH in plugins.
Mostly it is a workaround for https://github.com/mesonbuild/meson/issues/4350.

This does not work with all C++ compilers and is "use at own risk", therefore disabled by default. Can be enabled by passing `-Dcustom_pch=true` to meson. When disabled, it should not affect anything.

Speeds up compilation by at least 20% in local tests (48s vs 38s in plain build, 1m54s vs 1m40s in debugoptimized+asan).
