### PR TITLE
Add an option to disable tap-and-drag gesture

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -208,6 +208,11 @@
 				<_long>Enables or disables natural (inverted) scrolling.</_long>
 				<default>false</default>
 			</option>
+			<option name="tap_and_drag" type="bool">
+				<_short>Tap and drag</_short>
+				<_long>Enables or disables tap-and-drag.</_long>
+				<default>true</default>
+			</option>
 			<option name="drag_lock" type="bool">
 				<_short>Drag lock</_short>
 				<_long>Enables or disables drag lock.</_long>

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -28,6 +28,7 @@ void wf::pointing_device_t::load_options()
     touchpad_dwt_enabled.load_option(section_name + "/disable_touchpad_while_typing");
     touchpad_dwmouse_enabled.load_option(section_name + "/disable_touchpad_while_mouse");
     touchpad_natural_scroll_enabled.load_option(section_name + "/natural_scroll");
+    touchpad_tap_and_drag_enabled.load_option(section_name + "/tap_and_drag");
     touchpad_drag_lock_enabled.load_option(section_name + "/drag_lock");
 
     mouse_accel_profile.load_option(section_name + "/mouse_accel_profile");
@@ -135,6 +136,11 @@ void wf::pointing_device_t::update_options()
             touchpad_dwmouse_enabled ?
             LIBINPUT_CONFIG_SEND_EVENTS_DISABLED_ON_EXTERNAL_MOUSE :
             LIBINPUT_CONFIG_SEND_EVENTS_ENABLED);
+
+        libinput_device_config_tap_set_drag_enabled(dev,
+            touchpad_tap_and_drag_enabled ?
+            LIBINPUT_CONFIG_DRAG_ENABLED :
+            LIBINPUT_CONFIG_DRAG_DISABLED);
 
         libinput_device_config_tap_set_drag_lock_enabled(dev,
             touchpad_drag_lock_enabled ?

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -31,6 +31,7 @@ struct pointing_device_t : public input_device_impl_t
     wf::option_wrapper_t<bool> touchpad_dwmouse_enabled;
     wf::option_wrapper_t<bool> touchpad_natural_scroll_enabled;
     wf::option_wrapper_t<bool> mouse_natural_scroll_enabled;
+    wf::option_wrapper_t<bool> touchpad_tap_and_drag_enabled;
     wf::option_wrapper_t<bool> touchpad_drag_lock_enabled;
 };
 }


### PR DESCRIPTION
I don't like the tap-and-drag feature with touchpads because I have a lot of false positives when I use it. So, I suggest to add a setting to disable it.
By default, the option is still enabled.