### PR TITLE
Add an option to enable 3fg/4fg drag gesture

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,6 +153,11 @@ if cpp.has_argument('-fno-gnu-unique')
 endif
 add_project_arguments(project_args, language: ['cpp', 'c'])
 
+# Compile new libinput features only if they are supported with the libinput installed version
+if cpp.has_function('libinput_device_config_3fg_drag_set_enabled', dependencies: libinput)
+  add_project_arguments('-DHAVE_LIBINPUT_3FG_DRAG=1', language : ['cpp', 'c'])
+endif
+
 # Needed on some older compilers
 if cpp.has_link_argument('-lc++fs')
   add_project_link_arguments(['-lc++fs'], language: 'cpp')

--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -218,6 +218,27 @@
 				<_long>Enables or disables drag lock.</_long>
 				<default>false</default>
 			</option>
+			<option name="3fg_drag" type="string">
+				<_short>Multi-finger drag</_short>
+				<_long>Enables or disables 3-finger or 4-finger drag. Requires libinput ≥ 1.28.</_long>
+				<default>default</default>
+				<desc>
+					<value>default</value>
+					<_name>Default</_name>
+				</desc>
+				<desc>
+					<value>none</value>
+					<_name>None</_name>
+				</desc>
+				<desc>
+					<value>3fg-drag</value>
+					<_name>Drag using 3 fingers</_name>
+				</desc>
+				<desc>
+					<value>4fg-drag</value>
+					<_name>Drag using 4 fingers</_name>
+				</desc>
+			</option>
 			<option name="touchpad_cursor_speed" type="double">
 				<_short>Touchpad cursor speed</_short>
 				<_long>Changes the touchpad acceleration.</_long>

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -30,6 +30,7 @@ void wf::pointing_device_t::load_options()
     touchpad_natural_scroll_enabled.load_option(section_name + "/natural_scroll");
     touchpad_tap_and_drag_enabled.load_option(section_name + "/tap_and_drag");
     touchpad_drag_lock_enabled.load_option(section_name + "/drag_lock");
+    touchpad_3fg_drag.load_option(section_name + "/3fg_drag");
 
     mouse_accel_profile.load_option(section_name + "/mouse_accel_profile");
     touchpad_accel_profile.load_option(section_name + "/touchpad_accel_profile");
@@ -146,6 +147,24 @@ void wf::pointing_device_t::update_options()
             touchpad_drag_lock_enabled ?
             LIBINPUT_CONFIG_DRAG_LOCK_ENABLED :
             LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
+
+        if ((std::string)touchpad_3fg_drag == "default")
+        {
+            libinput_device_config_3fg_drag_set_enabled(dev,
+                libinput_device_config_3fg_drag_get_default_enabled(dev));
+        } else if ((std::string)touchpad_3fg_drag == "none")
+        {
+            libinput_device_config_3fg_drag_set_enabled(dev,
+                LIBINPUT_CONFIG_3FG_DRAG_DISABLED);
+        } else if ((std::string)touchpad_3fg_drag == "3fg-drag")
+        {
+            libinput_device_config_3fg_drag_set_enabled(dev,
+                LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG);
+        } else if ((std::string)touchpad_3fg_drag == "4fg-drag")
+        {
+            libinput_device_config_3fg_drag_set_enabled(dev,
+                LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG);
+        }
 
         if (libinput_device_config_scroll_has_natural_scroll(dev) > 0)
         {

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -148,6 +148,8 @@ void wf::pointing_device_t::update_options()
             LIBINPUT_CONFIG_DRAG_LOCK_ENABLED :
             LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
 
+#if HAVE_LIBINPUT_3FG_DRAG
+
         if ((std::string)touchpad_3fg_drag == "default")
         {
             libinput_device_config_3fg_drag_set_enabled(dev,
@@ -165,6 +167,8 @@ void wf::pointing_device_t::update_options()
             libinput_device_config_3fg_drag_set_enabled(dev,
                 LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG);
         }
+
+#endif
 
         if (libinput_device_config_scroll_has_natural_scroll(dev) > 0)
         {

--- a/src/core/seat/pointing-device.cpp
+++ b/src/core/seat/pointing-device.cpp
@@ -57,6 +57,9 @@ static void set_libinput_accel_profile(libinput_device *dev, std::string name)
     {
         libinput_device_config_accel_set_profile(dev,
             LIBINPUT_CONFIG_ACCEL_PROFILE_FLAT);
+    } else
+    {
+        LOGE("Invalid libinput acceleration profile.");
     }
 }
 
@@ -105,6 +108,9 @@ void wf::pointing_device_t::update_options()
         {
             libinput_device_config_click_set_method(dev,
                 LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER);
+        } else
+        {
+            LOGE("Invalid libinput click method.");
         }
 
         if ((std::string)touchpad_scroll_method == "default")
@@ -127,6 +133,9 @@ void wf::pointing_device_t::update_options()
         {
             libinput_device_config_scroll_set_method(dev,
                 LIBINPUT_CONFIG_SCROLL_ON_BUTTON_DOWN);
+        } else
+        {
+            LOGE("Invalid libinput scroll method.");
         }
 
         libinput_device_config_dwt_set_enabled(dev,
@@ -148,27 +157,40 @@ void wf::pointing_device_t::update_options()
             LIBINPUT_CONFIG_DRAG_LOCK_ENABLED :
             LIBINPUT_CONFIG_DRAG_LOCK_DISABLED);
 
-#if HAVE_LIBINPUT_3FG_DRAG
-
         if ((std::string)touchpad_3fg_drag == "default")
         {
+#if HAVE_LIBINPUT_3FG_DRAG
             libinput_device_config_3fg_drag_set_enabled(dev,
                 libinput_device_config_3fg_drag_get_default_enabled(dev));
+#endif
         } else if ((std::string)touchpad_3fg_drag == "none")
         {
+#if HAVE_LIBINPUT_3FG_DRAG
             libinput_device_config_3fg_drag_set_enabled(dev,
                 LIBINPUT_CONFIG_3FG_DRAG_DISABLED);
+#else
+            LOGW("Multi-finger drag not implemented with current libinput version.");
+#endif
         } else if ((std::string)touchpad_3fg_drag == "3fg-drag")
         {
+#if HAVE_LIBINPUT_3FG_DRAG
             libinput_device_config_3fg_drag_set_enabled(dev,
                 LIBINPUT_CONFIG_3FG_DRAG_ENABLED_3FG);
+#else
+            LOGW("Multi-finger drag not implemented with current libinput version.");
+#endif
         } else if ((std::string)touchpad_3fg_drag == "4fg-drag")
         {
+#if HAVE_LIBINPUT_3FG_DRAG
             libinput_device_config_3fg_drag_set_enabled(dev,
                 LIBINPUT_CONFIG_3FG_DRAG_ENABLED_4FG);
-        }
-
+#else
+            LOGW("Multi-finger drag not implemented with current libinput version.");
 #endif
+        } else
+        {
+            LOGE("Invalid libinput multi-finger drag value.");
+        }
 
         if (libinput_device_config_scroll_has_natural_scroll(dev) > 0)
         {

--- a/src/core/seat/pointing-device.hpp
+++ b/src/core/seat/pointing-device.hpp
@@ -33,6 +33,7 @@ struct pointing_device_t : public input_device_impl_t
     wf::option_wrapper_t<bool> mouse_natural_scroll_enabled;
     wf::option_wrapper_t<bool> touchpad_tap_and_drag_enabled;
     wf::option_wrapper_t<bool> touchpad_drag_lock_enabled;
+    wf::option_wrapper_t<std::string> touchpad_3fg_drag;
 };
 }
 


### PR DESCRIPTION
This PR adds a setting to enable the new 3-finger/4-finger drag setting on libinput. See https://gitlab.freedesktop.org/libinput/libinput/-/merge_requests/1042 and https://who-t.blogspot.com/2025/02/libinput-and-3-finger-dragging.html for explanations and details about this feature (to summarize: this is an alternative to the tap-and-drag gesture).

This feature is currently on the main branch of libinput and will be available on the future 1.28 release. On Wayfire, the code to enable this feature is compiled only if the functions are implemented on the installed libinput version. To achieve that goal, I use a solution inspired from what is done on xf86-input-libinput project: in the meson file, I check if the function exists and then set (or not) a macro that is used to activate the code. Another solution would be to wait the release of libinput 1.28 and then require the minimum version of libinput is 1.28 (`libinput = dependency('libinput', version: '>=1.28.0'`).

If the feature is not present on the installed libinput version, this new setting is nevertheless added to the config. But its activation does nothing.

By default, the setting disables this feature to not change the current behavior.