### PR TITLE
Pr 06 unidirectional maximization support

### DIFF
--- a/plugins/decor/deco-layout.hpp
+++ b/plugins/decor/deco-layout.hpp
@@ -78,7 +78,9 @@ enum decoration_layout_action_t
     /* Button actions */
     DECORATION_ACTION_CLOSE           = 3,
     DECORATION_ACTION_TOGGLE_MAXIMIZE = 4,
-    DECORATION_ACTION_MINIMIZE        = 5,
+    DECORATION_ACTION_TOGGLE_MAXIMIZE_VERTICALLY = 5,
+    DECORATION_ACTION_TOGGLE_MAXIMIZE_HORIZONTALLY = 6,
+    DECORATION_ACTION_MINIMIZE        = 7,
 };
 
 class decoration_theme_t;

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -27,6 +27,8 @@
 
 #include <cairo.h>
 
+namespace wf::decor
+{
 class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_interaction_t,
     public wf::touch_interaction_t
 {
@@ -64,8 +66,8 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
     } title_texture;
 
   public:
-    wf::decor::decoration_theme_t theme;
-    wf::decor::decoration_layout_t layout;
+    decoration_theme_t theme;
+    decoration_layout_t layout;
     wf::region_t cached_region;
 
     wf::dimensions_t size;
@@ -82,12 +84,10 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         view->connect(&title_set);
         if (view->parent)
         {
-            theme.set_buttons(wf::decor::button_type_t(wf::decor::BUTTON_TOGGLE_MAXIMIZE |
-                wf::decor::BUTTON_CLOSE));
+            theme.set_buttons(button_type_t(BUTTON_TOGGLE_MAXIMIZE | BUTTON_CLOSE));
         } else
         {
-            theme.set_buttons(wf::decor::button_type_t(wf::decor::BUTTON_MINIMIZE |
-                wf::decor::BUTTON_TOGGLE_MAXIMIZE | wf::decor::BUTTON_CLOSE));
+            theme.set_buttons(button_type_t(BUTTON_MINIMIZE | BUTTON_TOGGLE_MAXIMIZE | BUTTON_CLOSE));
         }
 
         // make sure to hide frame if the view is fullscreen
@@ -125,7 +125,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         auto renderables = layout.get_renderable_areas();
         for (auto item : renderables)
         {
-            if (item->get_type() == wf::decor::DECORATION_AREA_TITLE)
+            if (item->get_type() == DECORATION_AREA_TITLE)
             {
                 OpenGL::render_begin(fb);
                 fb.logic_scissor(scissor);
@@ -193,10 +193,10 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
             if (!our_damage.empty())
             {
                 instructions.push_back(wf::scene::render_instruction_t{
-                    .instance = this,
-                    .target   = target,
-                    .damage   = std::move(our_damage),
-                });
+                        .instance = this,
+                        .target   = target,
+                        .damage   = std::move(our_damage),
+                    });
             }
         }
 
@@ -249,22 +249,22 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         handle_action(layout.handle_press_event(ev.state == WL_POINTER_BUTTON_STATE_PRESSED));
     }
 
-    void handle_action(wf::decor::decoration_layout_t::action_response_t action)
+    void handle_action(decoration_layout_t::action_response_t action)
     {
         if (auto view = _view.lock())
         {
             switch (action.action)
             {
-              case wf::decor::DECORATION_ACTION_MOVE:
+              case DECORATION_ACTION_MOVE:
                 return wf::get_core().default_wm->move_request(view);
 
-              case wf::decor::DECORATION_ACTION_RESIZE:
+              case DECORATION_ACTION_RESIZE:
                 return wf::get_core().default_wm->resize_request(view, action.edges);
 
-              case wf::decor::DECORATION_ACTION_CLOSE:
+              case DECORATION_ACTION_CLOSE:
                 return view->close();
 
-              case wf::decor::DECORATION_ACTION_TOGGLE_MAXIMIZE:
+              case DECORATION_ACTION_TOGGLE_MAXIMIZE:
                 if (view->pending_tiled_edges())
                 {
                     return wf::get_core().default_wm->tile_request(view, 0);
@@ -275,7 +275,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
 
                 break;
 
-              case wf::decor::DECORATION_ACTION_MINIMIZE:
+              case DECORATION_ACTION_MINIMIZE:
                 return wf::get_core().default_wm->minimize_request(view, true);
                 break;
 
@@ -337,7 +337,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
     }
 };
 
-wf::simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
+simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
 {
     this->view = view;
     deco = std::make_shared<simple_decoration_node_t>(view);
@@ -368,12 +368,12 @@ wf::simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
     };
 }
 
-wf::simple_decorator_t::~simple_decorator_t()
+simple_decorator_t::~simple_decorator_t()
 {
     wf::scene::remove_child(deco);
 }
 
-wf::decoration_margins_t wf::simple_decorator_t::get_margins(const wf::toplevel_state_t& state)
+wf::decoration_margins_t simple_decorator_t::get_margins(const wf::toplevel_state_t& state)
 {
     if (state.fullscreen)
     {
@@ -389,3 +389,4 @@ wf::decoration_margins_t wf::simple_decorator_t::get_margins(const wf::toplevel_
         .top    = titlebar,
     };
 }
+} // namespace wf::decor

--- a/plugins/decor/deco-subsurface.hpp
+++ b/plugins/decor/deco-subsurface.hpp
@@ -6,9 +6,10 @@
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/toplevel-view.hpp>
 
-class simple_decoration_node_t;
-namespace wf
+namespace wf::decor
 {
+class simple_decoration_node_t;
+
 /**
  * A decorator object attached as custom data to a toplevel object.
  */

--- a/plugins/decor/decoration.cpp
+++ b/plugins/decor/decoration.cpp
@@ -14,6 +14,8 @@
 #include "wayfire/toplevel-view.hpp"
 #include "wayfire/toplevel.hpp"
 
+namespace wf::decor
+{
 class wayfire_decoration : public wf::plugin_interface_t
 {
     wf::view_matcher_t ignore_views{"decoration/ignore_views"};
@@ -28,7 +30,7 @@ class wayfire_decoration : public wf::plugin_interface_t
             {
                 // First check whether the toplevel already has decoration
                 // In that case, we should just set the correct margins
-                if (auto deco = toplevel->get_data<wf::simple_decorator_t>())
+                if (auto deco = toplevel->get_data<simple_decorator_t>())
                 {
                     toplevel->pending().margins = deco->get_margins(toplevel->pending());
                     continue;
@@ -111,8 +113,8 @@ class wayfire_decoration : public wf::plugin_interface_t
     {
         auto toplevel = view->toplevel();
 
-        toplevel->store_data(std::make_unique<wf::simple_decorator_t>(view));
-        auto deco     = toplevel->get_data<wf::simple_decorator_t>();
+        toplevel->store_data(std::make_unique<simple_decorator_t>(view));
+        auto deco     = toplevel->get_data<simple_decorator_t>();
         auto& pending = toplevel->pending();
         pending.margins = deco->get_margins(pending);
 
@@ -128,7 +130,7 @@ class wayfire_decoration : public wf::plugin_interface_t
 
     void remove_decoration(wayfire_toplevel_view view)
     {
-        view->toplevel()->erase_data<wf::simple_decorator_t>();
+        view->toplevel()->erase_data<simple_decorator_t>();
         auto& pending = view->toplevel()->pending();
         if (!pending.fullscreen && !pending.tiled_edges)
         {
@@ -140,7 +142,7 @@ class wayfire_decoration : public wf::plugin_interface_t
 
     bool is_toplevel_decorated(const std::shared_ptr<wf::toplevel_t>& toplevel)
     {
-        return toplevel->has_data<wf::simple_decorator_t>();
+        return toplevel->has_data<simple_decorator_t>();
     }
 
     void update_view_decoration(wayfire_view view)
@@ -163,5 +165,6 @@ class wayfire_decoration : public wf::plugin_interface_t
         }
     }
 };
+} // namespace wf::decor
 
-DECLARE_WAYFIRE_PLUGIN(wayfire_decoration);
+DECLARE_WAYFIRE_PLUGIN(wf::decor::wayfire_decoration);

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -6,6 +6,7 @@
 
 extern "C" {
 #include <wlr/util/box.h>
+#include <wlr/util/edges.h>
 }
 
 namespace wf
@@ -111,7 +112,197 @@ geometry_t clamp(geometry_t window, geometry_t output);
 // The returned subbox will occupy the same relative part of @B as
 // @box occupies in @A.
 wf::geometry_t scale_box(wf::geometry_t A, wf::geometry_t B, wf::geometry_t box);
+
+/**
+ *
+ * Let the members of geometry_difference_t be an outwards displacement.
+ *
+ *                   from.x
+ *                       |
+ *              to.x     v
+ *                |      +<-----from.width----->+
+ *                v      |                      |
+ *      to.y ->---┌─────────────────────────────────────┐--------------+
+ *                │      |         ^ d.top      |       │              ^
+ *    from.y ->---│------┌─────────┴────────────┐-------│----+         |
+ *                │      │                      │       │    ^         |
+ *                │d.left│                      │d.right│    |         |
+ *                │<-----│                      │------>│  from.height |
+ *                │      │                      │       │    |         |
+ *                │      │                      │       │    v     to.height
+ *                │      └─────────┬────────────┘-------│----+         |
+ *                │                v d.bottom           │              v
+ *                └─────────────────────────────────────┘--------------+
+ *                |                                     |
+ *                +<-------------to.width-------------->+
+ *
+ * geometry_t from;
+ * geometry_difference_t d;
+ * geometry_t to = from + d;
+ *
+ * In the above `from` is expanded, grown, in each of the four directions.
+ * However, negative values of left, right, bottom and top are also legal;
+ * in that case the corresponding border simply shifts the opposite way.
+ *
+ * It is not possible to add geometry_t's or to negate them, of course.
+ * But it is possible to subtract them: d = to - from.
+ *
+ * This must be an aggregate type for historical reasons.
+ */
+struct geometry_difference_t
+{
+    int left;
+    int right;
+    int bottom;
+    int top;
+
+    geometry_difference_t& subtract_if(uint32_t tiled_edges, geometry_difference_t delta);
+};
+
+// Allow printing a geometry_difference_t.
+std::ostream& operator <<(std::ostream& stream, geometry_difference_t const& geometry_difference);
+
+/**
+ * Add a geometry_difference_t to a geometry_t.
+ */
+inline geometry_t operator +(geometry_t const& g, geometry_difference_t const& m)
+{
+    return {g.x - m.left, g.y - m.top, g.width + m.left + m.right, g.height + m.top + m.bottom};
 }
+
+/**
+ * Subtract a geometry_difference_t from a geometry_t.
+ */
+inline geometry_t operator -(geometry_t const& g, geometry_difference_t const& m)
+{
+    return {g.x + m.left, g.y + m.top, g.width - m.left - m.right, g.height - m.top - m.bottom};
+}
+
+/**
+ * Subtract a geometry_t from a geometry_t.
+ */
+inline geometry_difference_t operator -(geometry_t const& to, geometry_t const& from)
+{
+    return {.left = from.x - to.x, .right = to.x + to.width - (from.x + from.width),
+        .bottom   = to.y + to.height - (from.y + from.height), .top = from.y - to.y};
+}
+
+class rectangle_t
+{
+  private:
+    int x1_, y1_; // Top-left coorinate, inclusive.
+    int x2_, y2_; // One pixel beyond the bottom-right (aka, not inclusive).
+
+  public:
+    // Default constructor.
+    rectangle_t() = default;
+
+    // Construct a rectangle_t from top-left and bottom-right coordinates.
+    rectangle_t(int x1, int y1, int x2, int y2) : x1_(x1), y1_(y1), x2_(x2), y2_(y2)
+    {}
+
+    // Construct a rectangle_t from a geometry_t.
+    rectangle_t(geometry_t g) : x1_(g.x), y1_(g.y), x2_(g.x + g.width), y2_(g.y + g.height)
+    {}
+
+    // We can't add a constructor to geometry_t because that must be an aggregate type.
+    // Therefore add conversion from rectangle_t to geometry_t here.
+    operator geometry_t() const {
+        return {x1_, y1_, x2_ - x1_, y2_ - y1_};
+    }
+
+    // Accessors.
+    int x1() const
+    {
+        return x1_;
+    }
+
+    int y1() const
+    {
+        return y1_;
+    }
+
+    int x2() const
+    {
+        return x2_;
+    }
+
+    int y2() const
+    {
+        return y2_;
+    }
+
+    friend geometry_t expand_geometry_if(geometry_t geometry_in, uint32_t tiled_edges,
+        geometry_difference_t const& tiled_edge_delta,
+        geometry_difference_t const& delta);
+
+    void print_on(std::ostream& stream) const;
+};
+
+inline std::ostream& operator <<(std::ostream& stream, rectangle_t& rectangle)
+{
+    rectangle.print_on(stream);
+    return stream;
+}
+
+/**
+ * Conditionally expand (or shrink in case of negative values) each edge with
+ * the displacement given by delta OR tiled_edge_delta, as a function of `tiled_edges`.
+ *
+ * If the corresponding WLR_EDGE_* bit is set in `tiled_edges` then `tiled_edge_delta`
+ * is used, otherwise `delta` is used. The order of the arguments has been chosen
+ * to match `tiled_edges ? tiled_edge_delta : delta`.
+ */
+inline geometry_t expand_geometry_if(geometry_t geometry_in,
+    uint32_t tiled_edges,
+    geometry_difference_t const& tiled_edge_delta,
+    geometry_difference_t const& delta)
+{
+    rectangle_t rectangle{geometry_in};
+
+    rectangle.x1_ -= (tiled_edges & WLR_EDGE_LEFT) ? tiled_edge_delta.left : delta.left;
+    rectangle.y1_ -= (tiled_edges & WLR_EDGE_TOP) ? tiled_edge_delta.top : delta.top;
+    rectangle.x2_ += (tiled_edges & WLR_EDGE_RIGHT) ? tiled_edge_delta.right : delta.right;
+    rectangle.y2_ += (tiled_edges & WLR_EDGE_BOTTOM) ? tiled_edge_delta.bottom : delta.bottom;
+
+    return rectangle;
+}
+
+/**
+ * Return a geometry with edges from tiled_edge_rect or rect respectively, as function of tiled_edges.
+ */
+inline rectangle_t geometry_switch_if(uint32_t tiled_edges, rectangle_t const& tiled_edge_rect,
+    rectangle_t const& rect)
+{
+    return {
+        (tiled_edges & WLR_EDGE_LEFT) ? tiled_edge_rect.x1() : rect.x1(),
+        (tiled_edges & WLR_EDGE_TOP) ? tiled_edge_rect.y1() : rect.y1(),
+        (tiled_edges & WLR_EDGE_RIGHT) ? tiled_edge_rect.x2() : rect.x2(),
+        (tiled_edges & WLR_EDGE_BOTTOM) ? tiled_edge_rect.y2() : rect.y2()
+    };
+}
+
+/**
+ * Conditionally subtract another geometry_difference_t, as function of tiled_edges.
+ */
+inline geometry_difference_t& geometry_difference_t::subtract_if(uint32_t tiled_edges,
+    geometry_difference_t delta)
+{
+    left   -= (tiled_edges & WLR_EDGE_LEFT) ? delta.left : 0;
+    right  -= (tiled_edges & WLR_EDGE_RIGHT) ? delta.right : 0;
+    bottom -= (tiled_edges & WLR_EDGE_BOTTOM) ? delta.bottom : 0;
+    top    -= (tiled_edges & WLR_EDGE_TOP) ? delta.top : 0;
+    return *this;
+}
+
+/**
+ * Invert all displacements of a geometry_difference_t.
+ */
+inline geometry_difference_t operator -(geometry_difference_t const& delta)
+{
+    return {.left = -delta.left, .right = -delta.right, .bottom = -delta.bottom, .top = -delta.top};
+}
+} // namespace wf
 
 bool operator ==(const wf::geometry_t& a, const wf::geometry_t& b);
 bool operator !=(const wf::geometry_t& a, const wf::geometry_t& b);
@@ -133,7 +324,7 @@ bool operator &(const wf::geometry_t& rect, const wf::pointf_t& point);
 /* Returns true if the two geometries have a common point */
 bool operator &(const wf::geometry_t& r1, const wf::geometry_t& r2);
 
-/* Make geometry and point printable */
+/* Make geometry_t printable */
 std::ostream& operator <<(std::ostream& stream, const wf::geometry_t& geometry);
 
 #endif /* end of include guard: WF_GEOMETRY_HPP */

--- a/src/api/wayfire/maximization.hpp
+++ b/src/api/wayfire/maximization.hpp
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <wlr/util/edges.h>
+#include <cstdint>
+
+class wayfire_resize;
+class wayfire_decoration;
+namespace wf
+{
+namespace grid
+{
+class grid_animation_t;
+}
+
+namespace tile
+{
+class view_node_t;
+}
+
+/**
+ * A bitmask consisting of the top and bottom edges.
+ * This corresponds to a vertically maximized state.
+ */
+constexpr uint32_t TILED_EDGES_VERTICAL =
+    WLR_EDGE_TOP | WLR_EDGE_BOTTOM;
+
+/**
+ * A bitmask consisting of the left and right edges.
+ * This corresponds to a horizontally maximized state.
+ */
+constexpr uint32_t TILED_EDGES_HORIZONTAL =
+    WLR_EDGE_LEFT | WLR_EDGE_RIGHT;
+
+/**
+ * A bitmask consisting of all tiled edges.
+ * This corresponds to a maximized state.
+ */
+constexpr uint32_t TILED_EDGES_ALL =
+    TILED_EDGES_VERTICAL | TILED_EDGES_HORIZONTAL;
+
+/**
+ * Represents the maximization state (like in pending), not toggle.
+ *
+ * We can no longer use a boolean for "maximized" or not.
+ * This class wraps two bits to represent being maximized vertically, horizontally or both.
+ *
+ * To test for vertical maximization (including full maximization), use:
+ *
+ *   maximization >= maximization_t::vertical
+ *
+ * To test if the maximization state is purely vertical and not horizontal, use:
+ *
+ *   maximization == maximization_t::vertical
+ *
+ * Likewise for horizontal.
+ */
+class maximization_t
+{
+  public:
+    struct state_t
+    {
+        using mask_t = unsigned char;
+        mask_t mask_;
+
+        constexpr state_t operator |(state_t state) const
+        {
+            return {static_cast<mask_t>(mask_ | state.mask_)};
+        }
+
+        constexpr state_t operator &(state_t state) const
+        {
+            return {static_cast<mask_t>(mask_ & state.mask_)};
+        }
+
+        bool operator ==(state_t state) const
+        {
+            return mask_ == state.mask_;
+        }
+
+        bool operator !=(state_t state) const
+        {
+            return mask_ != state.mask_;
+        }
+    };
+
+    static constexpr state_t none{0};
+    static constexpr state_t vertical{1};
+    static constexpr state_t horizontal{2};
+    static constexpr state_t full{vertical.mask_ | horizontal.mask_};
+
+  private:
+    state_t state_;
+
+    /**
+     * Convert a tiled_edges bit mask to a maximization_t.
+     */
+    friend struct toplevel_state_t;
+    maximization_t(uint32_t tiled_edges) : state_{
+            ((tiled_edges & TILED_EDGES_VERTICAL) == TILED_EDGES_VERTICAL ? vertical : none) |
+            ((tiled_edges & TILED_EDGES_HORIZONTAL) == TILED_EDGES_HORIZONTAL ? horizontal : none)}
+    {}
+
+  public:
+    /**
+     * Default constructor is a non-maximized state.
+     */
+    maximization_t() : state_{none}
+    {}
+
+    /**
+     * Allow users to use maximization_t::full etc. where a maximization_t is required.
+     */
+    maximization_t(state_t state) : state_(state)
+    {}
+
+    /**
+     * Add two states together.
+     *
+     * This is akin to a bit-wise OR.
+     */
+    maximization_t& operator +=(maximization_t maximization)
+    {
+        state_.mask_ |= maximization.state_.mask_;
+        return *this;
+    }
+
+    /**
+     * Remove maximization state.
+     *
+     * Clear the bits that are set in `maximization`.
+     */
+    maximization_t& operator -=(maximization_t maximization)
+    {
+        state_.mask_ &= ~maximization.state_.mask_;
+        return *this;
+    }
+
+    /**
+     * Toggle maximization state.
+     */
+    maximization_t& operator ^=(maximization_t maximization)
+    {
+        state_.mask_ ^= maximization.state_.mask_;
+        return *this;
+    }
+
+    /**
+     * Invert maximization state.
+     */
+    maximization_t operator ~() const
+    {
+        maximization_t inverted{*this};
+        inverted ^= full;
+        return inverted;
+    }
+
+    /**
+     * Test contains maximization state.
+     *
+     * Returns true if the bits set in `maximization` are also set in this object.
+     */
+    bool operator >=(maximization_t maximization) const
+    {
+        return (state_ & maximization.state_) == maximization.state_;
+    }
+
+    /**
+     * Test does not contain maximization state.
+     *
+     * Returns true if the bits set in `maximization` are not set in this object.
+     */
+    bool operator <(maximization_t maximization) const
+    {
+        return (state_ & maximization.state_) == none;
+    }
+
+    /**
+     * Test equal.
+     *
+     * Returns true if the maximization states are the same.
+     */
+    bool operator ==(maximization_t maximization) const
+    {
+        return state_ == maximization.state_;
+    }
+
+    /**
+     * Test unequal.
+     *
+     * Returns true if the maximization states are not the same.
+     */
+    bool operator !=(maximization_t maximization) const
+    {
+        return state_ != maximization.state_;
+    }
+
+    /**
+     * Convert maximization_t to tiled_edges.
+     */
+    uint32_t as_tiled_edges() const
+    {
+        return ((state_ & vertical) !=
+            none ? TILED_EDGES_VERTICAL : 0) | ((state_ & horizontal) != none ? TILED_EDGES_HORIZONTAL : 0);
+    }
+};
+} // namespace wf

--- a/src/api/wayfire/toplevel-view.hpp
+++ b/src/api/wayfire/toplevel-view.hpp
@@ -33,13 +33,6 @@ enum view_allowed_actions_t
 };
 
 /**
- * A bitmask consisting of all tiled edges.
- * This corresponds to a maximized state.
- */
-constexpr uint32_t TILED_EDGES_ALL =
-    WLR_EDGE_TOP | WLR_EDGE_BOTTOM | WLR_EDGE_LEFT | WLR_EDGE_RIGHT;
-
-/**
  * Toplevel views are a subtype of views which have an associated toplevel object. As such, they may be moved,
  * resized, etc. freely by plugins and have many additional operations when compared to other view types.
  */
@@ -122,6 +115,11 @@ class toplevel_view_interface_t : public virtual wf::view_interface_t
     inline uint32_t pending_tiled_edges() const
     {
         return toplevel()->pending().tiled_edges;
+    }
+
+    inline maximization_t pending_maximization() const
+    {
+        return toplevel()->pending();
     }
 
     inline bool pending_fullscreen() const

--- a/src/api/wayfire/toplevel.hpp
+++ b/src/api/wayfire/toplevel.hpp
@@ -12,13 +12,7 @@ namespace wf
 /**
  * Describes the size of the decoration frame around a toplevel.
  */
-struct decoration_margins_t
-{
-    int left;
-    int right;
-    int bottom;
-    int top;
-};
+using decoration_margins_t = geometry_difference_t;
 
 struct toplevel_state_t
 {

--- a/src/api/wayfire/toplevel.hpp
+++ b/src/api/wayfire/toplevel.hpp
@@ -127,8 +127,6 @@ class toplevel_t : public wf::txn::transaction_object_t, public wf::object_base_
     toplevel_state_t _current;
     toplevel_state_t _pending;
     toplevel_state_t _committed;
-
-    std::optional<wf::geometry_t> last_windowed_geometry;
 };
 
 // Helper functions when working with toplevel state

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -11,6 +11,19 @@ std::ostream& operator <<(std::ostream& stream, const wf::geometry_t& geometry)
     return stream;
 }
 
+std::ostream& wf::operator <<(std::ostream& stream, const wf::geometry_difference_t& geometry_difference)
+{
+    stream << '{' << geometry_difference.left << ',' << geometry_difference.right << ',' <<
+        geometry_difference.top << ',' << geometry_difference.bottom << '}';
+
+    return stream;
+}
+
+void wf::rectangle_t::print_on(std::ostream& stream) const
+{
+    stream << '{' << x1_ << ',' << y1_ << ' ' << x2_ << ',' << y2_ << '}';
+}
+
 std::ostream& wf::operator <<(std::ostream& stream, const wf::point_t& point)
 {
     stream << '(' << point.x << ',' << point.y << ')';

--- a/src/output/workspace-impl.cpp
+++ b/src/output/workspace-impl.cpp
@@ -234,16 +234,24 @@ struct workspace_set_t::impl
             if (view->get_output() && view->toplevel()->current().fullscreen)
             {
                 view->set_geometry(new_geometry);
-            } else if (view->toplevel()->current().tiled_edges)
+            } else if (view->toplevel()->current() == maximization_t::full)
             {
                 // Do nothing. This is taken care of, by the grid plugin.
                 // If the user does not have grid enabled, we ignore it anyways.
             } else
             {
-                view->set_geometry({
-                        int(px * new_geometry.width), int(py * new_geometry.height),
-                        wm.width, wm.height
-                    });
+                wf::geometry_t& new_geometry = wm;
+                if (view->toplevel()->current() < maximization_t::vertical)
+                {
+                    new_geometry.y = int(py * new_geometry.height);
+                }
+
+                if (view->toplevel()->current() < maximization_t::horizontal)
+                {
+                    new_geometry.x = int(px * new_geometry.width);
+                }
+
+                view->set_geometry(new_geometry);
             }
         }
 

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -449,15 +449,18 @@ void wf::adjust_view_pending_geometry_on_start_map(wf::toplevel_view_interface_t
         wf::get_core().default_wm->fullscreen_request(self, self->get_output(), true);
     } else if (map_maximized)
     {
-        self->toplevel()->pending().tiled_edges = wf::TILED_EDGES_ALL;
+        // TODO: what about partial maximization?
+        self->toplevel()->pending() = maximization_t::full;
         if (self->get_output())
         {
             self->toplevel()->pending().geometry = self->get_output()->workarea->get_workarea();
         }
     } else
     {
+        // TODO: at the moment we are assuming that we're not unidirectional maximized at this point.
+        // Therefore, not vertically and also not horizontally.
         auto map_geometry = wf::expand_geometry_by_margins(map_geometry_client,
-            self->toplevel()->pending().margins);
+            self->toplevel()->pending().margins, maximization_t::none);
 
         if (self->get_output())
         {

--- a/src/view/xdg-shell/xdg-toplevel.cpp
+++ b/src/view/xdg-shell/xdg-toplevel.cpp
@@ -82,8 +82,9 @@ void wf::xdg_toplevel_t::commit()
         auto version = wl_resource_get_version(toplevel->resource);
         if (version >= XDG_TOPLEVEL_STATE_TILED_LEFT_SINCE_VERSION)
         {
+            // TODO: support unidirectional maximization.
             this->target_configure =
-                wlr_xdg_toplevel_set_maximized(this->toplevel, (_pending.tiled_edges == TILED_EDGES_ALL));
+                wlr_xdg_toplevel_set_maximized(this->toplevel, _pending == maximization_t::full);
         } else
         {
             this->target_configure = wlr_xdg_toplevel_set_maximized(this->toplevel, !!_pending.tiled_edges);

--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -151,7 +151,8 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
             configure_geometry = wf::clamp(configure_geometry, view_workarea);
         }
 
-        configure_geometry = wf::expand_geometry_by_margins(configure_geometry, toplevel->pending().margins);
+        configure_geometry = wf::expand_geometry_by_margins(configure_geometry,
+            toplevel->pending().margins, wf::maximization_t::none);
         set_geometry(configure_geometry);
     }
 


### PR DESCRIPTION
This works, together with changes already made to pixdecor. Aka, it is tested. But on its own it should do precisely nothing: have no effect at all (aka, still compile everything as before and still behave in the same way), short from UB as a result of plugins not following the correct meaning of TILED_EDGES_* - because now each bit is actually treated as how to treat that edge.