### PR TITLE
Compilation times improvements (part 4)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ pixman         = dependency('pixman-1')
 xkbcommon      = dependency('xkbcommon')
 libdl          = cpp.find_library('dl')
 udev           = dependency('libudev')
-json           = dependency('RapidJSON')
+json           = dependency('yyjson')
 
 # We're not to use system wlroots: So we'll use the subproject
 if get_option('use_system_wlroots').disabled()

--- a/meson.build
+++ b/meson.build
@@ -35,8 +35,8 @@ libinput       = dependency('libinput', version: '>=1.7.0')
 pixman         = dependency('pixman-1')
 xkbcommon      = dependency('xkbcommon')
 libdl          = cpp.find_library('dl')
-json           = dependency('nlohmann_json', version: '>= 3.11.2')
 udev           = dependency('libudev')
+json           = dependency('RapidJSON')
 
 # We're not to use system wlroots: So we'll use the subproject
 if get_option('use_system_wlroots').disabled()

--- a/plugins/ipc-rules/ipc-events.hpp
+++ b/plugins/ipc-rules/ipc-events.hpp
@@ -34,7 +34,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
             }
         }
 
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]  = "output-added";
         data["output"] = output_to_json(output);
         send_event_to_subscribes(data, data["event"]);
@@ -42,7 +42,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
 
     void handle_output_removed(wf::output_t *output) override
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]  = "output-removed";
         data["output"] = output_to_json(output);
         send_event_to_subscribes(data, data["event"]);
@@ -129,7 +129,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     std::map<wf::ipc::client_interface_t*, std::set<std::string>> clients;
 
     wf::ipc::method_callback_full on_client_watch =
-        [=] (wf::ipc::json_wrapper_t data, wf::ipc::client_interface_t *client)
+        [=] (wf::json_t data, wf::ipc::client_interface_t *client)
     {
         static constexpr const char *EVENTS = "events";
         if (data.has_member(EVENTS) && !data[EVENTS].is_array())
@@ -183,13 +183,13 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
 
     void send_view_to_subscribes(wayfire_view view, std::string event_name)
     {
-        wf::ipc::json_wrapper_t event;
+        wf::json_t event;
         event["event"] = event_name;
         event["view"]  = view_to_json(view);
         send_event_to_subscribes(event, event_name);
     }
 
-    void send_event_to_subscribes(const wf::ipc::json_wrapper_t& data, const std::string& event_name)
+    void send_event_to_subscribes(const wf::json_t& data, const std::string& event_name)
     {
         for (auto& [client, events] : clients)
         {
@@ -213,7 +213,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::view_set_output_signal> on_view_set_output =
         [=] (wf::view_set_output_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]  = "view-set-output";
         data["output"] = output_to_json(ev->output);
         data["view"]   = view_to_json(ev->view);
@@ -223,7 +223,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::view_geometry_changed_signal> on_view_geometry_changed =
         [=] (wf::view_geometry_changed_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"] = "view-geometry-changed";
         data["old-geometry"] = wf::ipc::geometry_to_json(ev->old_geometry);
         data["view"] = view_to_json(ev->view);
@@ -233,7 +233,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::view_moved_to_wset_signal> on_view_moved_to_wset =
         [=] (wf::view_moved_to_wset_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]    = "view-wset-changed";
         data["old-wset"] = wset_to_json(ev->old_wset.get());
         data["new-wset"] = wset_to_json(ev->new_wset.get());
@@ -250,7 +250,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     // Tiled rule handler.
     wf::signal::connection_t<wf::view_tiled_signal> _tiled = [=] (wf::view_tiled_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]     = "view-tiled";
         data["old-edges"] = ev->old_edges;
         data["new-edges"] = ev->new_edges;
@@ -279,7 +279,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::view_change_workspace_signal> _view_workspace =
         [=] (wf::view_change_workspace_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"] = "view-workspace-changed";
         data["from"]  = wf::ipc::point_to_json(ev->from);
         data["to"]    = wf::ipc::point_to_json(ev->to);
@@ -302,7 +302,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::output_plugin_activated_changed_signal> on_plugin_activation_changed =
         [=] (wf::output_plugin_activated_changed_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]  = "plugin-activation-state-changed";
         data["plugin"] = ev->plugin_name;
         data["state"]  = ev->activated;
@@ -314,7 +314,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::output_gain_focus_signal> on_output_gain_focus =
         [=] (wf::output_gain_focus_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]  = "output-gain-focus";
         data["output"] = output_to_json(ev->output);
         send_event_to_subscribes(data, data["event"]);
@@ -323,7 +323,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::workspace_set_changed_signal> on_wset_changed =
         [=] (wf::workspace_set_changed_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"]    = "output-wset-changed";
         data["new-wset"] = ev->new_wset ? (int)ev->new_wset->get_id() : -1;
         data["output"]   = ev->output ? (int)ev->output->get_id() : -1;
@@ -335,7 +335,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
     wf::signal::connection_t<wf::workspace_changed_signal> on_wset_workspace_changed =
         [=] (wf::workspace_changed_signal *ev)
     {
-        wf::ipc::json_wrapper_t data;
+        wf::json_t data;
         data["event"] = "wset-workspace-changed";
         data["previous-workspace"] = wf::ipc::point_to_json(ev->old_viewport);
         data["new-workspace"] = wf::ipc::point_to_json(ev->new_viewport);
@@ -343,7 +343,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
         data["wset"]   = (ev->output && ev->output->wset()) ? (int)ev->output->wset()->get_id() : -1;
         data["output-data"] = output_to_json(ev->output);
         data["wset-data"]   =
-            ev->output ? wset_to_json(ev->output->wset().get()) : ipc::json_wrapper_t::null();
+            ev->output ? wset_to_json(ev->output->wset().get()) : json_t::null();
         send_event_to_subscribes(data, data["event"]);
     };
 };

--- a/plugins/ipc-rules/ipc-input-methods.hpp
+++ b/plugins/ipc-rules/ipc-input-methods.hpp
@@ -50,12 +50,12 @@ class ipc_rules_input_methods_t
         }
     }
 
-    wf::ipc::method_callback list_input_devices = [&] (const wf::ipc::json_wrapper_t&)
+    wf::ipc::method_callback list_input_devices = [&] (const wf::json_t&)
     {
-        wf::ipc::json_wrapper_t response = ipc::json_wrapper_t::array();
+        wf::json_t response = json_t::array();
         for (auto& device : wf::get_core().get_input_devices())
         {
-            wf::ipc::json_wrapper_t d;
+            wf::json_t d;
             d["id"]     = (intptr_t)device->get_wlr_handle();
             d["name"]   = nonull(device->get_wlr_handle()->name);
             d["vendor"] = "unknown";
@@ -77,7 +77,7 @@ class ipc_rules_input_methods_t
         return response;
     };
 
-    wf::ipc::method_callback configure_input_device = [&] (const wf::ipc::json_wrapper_t& data)
+    wf::ipc::method_callback configure_input_device = [&] (const wf::json_t& data)
     {
         auto id = wf::ipc::json_get_int64(data, "id");
         auto enabled = wf::ipc::json_get_bool(data, "enabled");

--- a/plugins/ipc-rules/ipc-rules-common.hpp
+++ b/plugins/ipc-rules/ipc-rules-common.hpp
@@ -9,14 +9,14 @@
 #include <wayfire/unstable/wlr-surface-node.hpp>
 #include <wayfire/view-helpers.hpp>
 
-static inline nlohmann::json output_to_json(wf::output_t *o)
+static inline wf::ipc::json_wrapper_t output_to_json(wf::output_t *o)
 {
     if (!o)
     {
-        return nullptr;
+        return wf::ipc::json_wrapper_t::null();
     }
 
-    nlohmann::json response;
+    wf::ipc::json_wrapper_t response;
     response["id"]   = o->get_id();
     response["name"] = o->to_string();
     response["geometry"]   = wf::ipc::geometry_to_json(o->get_layout_geometry());
@@ -165,15 +165,15 @@ static inline std::string get_view_type(wayfire_view view)
     return "unknown";
 }
 
-static inline nlohmann::json view_to_json(wayfire_view view)
+static inline wf::ipc::json_wrapper_t view_to_json(wayfire_view view)
 {
     if (!view)
     {
-        return nullptr;
+        return wf::ipc::json_wrapper_t::null();
     }
 
     auto output = view->get_output();
-    nlohmann::json description;
+    wf::ipc::json_wrapper_t description;
     description["id"]     = view->get_id();
     description["pid"]    = get_view_pid(view);
     description["title"]  = view->get_title();
@@ -206,14 +206,14 @@ static inline nlohmann::json view_to_json(wayfire_view view)
     return description;
 }
 
-static inline nlohmann::json wset_to_json(wf::workspace_set_t *wset)
+static inline wf::ipc::json_wrapper_t wset_to_json(wf::workspace_set_t *wset)
 {
     if (!wset)
     {
-        return nullptr;
+        return wf::ipc::json_wrapper_t::null();
     }
 
-    nlohmann::json response;
+    wf::ipc::json_wrapper_t response;
     response["index"] = wset->get_index();
     response["name"]  = wset->to_string();
 

--- a/plugins/ipc-rules/ipc-rules-common.hpp
+++ b/plugins/ipc-rules/ipc-rules-common.hpp
@@ -9,14 +9,14 @@
 #include <wayfire/unstable/wlr-surface-node.hpp>
 #include <wayfire/view-helpers.hpp>
 
-static inline wf::ipc::json_wrapper_t output_to_json(wf::output_t *o)
+static inline wf::json_t output_to_json(wf::output_t *o)
 {
     if (!o)
     {
-        return wf::ipc::json_wrapper_t::null();
+        return wf::json_t::null();
     }
 
-    wf::ipc::json_wrapper_t response;
+    wf::json_t response;
     response["id"]   = o->get_id();
     response["name"] = o->to_string();
     response["geometry"]   = wf::ipc::geometry_to_json(o->get_layout_geometry());
@@ -165,15 +165,15 @@ static inline std::string get_view_type(wayfire_view view)
     return "unknown";
 }
 
-static inline wf::ipc::json_wrapper_t view_to_json(wayfire_view view)
+static inline wf::json_t view_to_json(wayfire_view view)
 {
     if (!view)
     {
-        return wf::ipc::json_wrapper_t::null();
+        return wf::json_t::null();
     }
 
     auto output = view->get_output();
-    wf::ipc::json_wrapper_t description;
+    wf::json_t description;
     description["id"]     = view->get_id();
     description["pid"]    = get_view_pid(view);
     description["title"]  = view->get_title();
@@ -206,14 +206,14 @@ static inline wf::ipc::json_wrapper_t view_to_json(wayfire_view view)
     return description;
 }
 
-static inline wf::ipc::json_wrapper_t wset_to_json(wf::workspace_set_t *wset)
+static inline wf::json_t wset_to_json(wf::workspace_set_t *wset)
 {
     if (!wset)
     {
-        return wf::ipc::json_wrapper_t::null();
+        return wf::json_t::null();
     }
 
-    wf::ipc::json_wrapper_t response;
+    wf::json_t response;
     response["index"] = wset->get_index();
     response["name"]  = wset->to_string();
 

--- a/plugins/ipc-rules/ipc-rules.cpp
+++ b/plugins/ipc-rules/ipc-rules.cpp
@@ -60,19 +60,19 @@ class ipc_rules_t : public wf::plugin_interface_t,
         fini_events(method_repository.get());
     }
 
-    wf::ipc::method_callback list_views = [=] (wf::ipc::json_wrapper_t)
+    wf::ipc::method_callback list_views = [=] (wf::json_t)
     {
-        wf::ipc::json_wrapper_t response = wf::ipc::json_wrapper_t::array();
+        wf::json_t response = wf::json_t::array();
         for (auto& view : wf::get_core().get_all_views())
         {
-            wf::ipc::json_wrapper_t v = view_to_json(view);
+            wf::json_t v = view_to_json(view);
             response.append(v);
         }
 
         return response;
     };
 
-    wf::ipc::method_callback get_view_info = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback get_view_info = [=] (wf::json_t data)
     {
         auto id = wf::ipc::json_get_uint64(data, "id");
         if (auto view = wf::ipc::find_view_by_id(id))
@@ -85,7 +85,7 @@ class ipc_rules_t : public wf::plugin_interface_t,
         return wf::ipc::json_error("no such view");
     };
 
-    wf::ipc::method_callback get_focused_view = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback get_focused_view = [=] (wf::json_t data)
     {
         if (auto view = wf::get_core().seat->get_active_view())
         {
@@ -95,12 +95,12 @@ class ipc_rules_t : public wf::plugin_interface_t,
         } else
         {
             auto response = wf::ipc::json_ok();
-            response["info"] = wf::ipc::json_wrapper_t::null();
+            response["info"] = wf::json_t::null();
             return response;
         }
     };
 
-    wf::ipc::method_callback get_focused_output = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback get_focused_output = [=] (wf::json_t data)
     {
         auto active_output = wf::get_core().seat->get_active_output();
         auto response = wf::ipc::json_ok();
@@ -110,13 +110,13 @@ class ipc_rules_t : public wf::plugin_interface_t,
             response["info"] = output_to_json(active_output);
         } else
         {
-            response["info"] = wf::ipc::json_wrapper_t::null();
+            response["info"] = wf::json_t::null();
         }
 
         return response;
     };
 
-    wf::ipc::method_callback focus_view = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback focus_view = [=] (wf::json_t data)
     {
         auto id = wf::ipc::json_get_uint64(data, "id");
         if (auto view = wf::ipc::find_view_by_id(id))
@@ -135,7 +135,7 @@ class ipc_rules_t : public wf::plugin_interface_t,
         return wf::ipc::json_error("no such view");
     };
 
-    wf::ipc::method_callback close_view = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback close_view = [=] (wf::json_t data)
     {
         auto id = wf::ipc::json_get_uint64(data, "id");
         if (auto view = wf::ipc::find_view_by_id(id))
@@ -148,9 +148,9 @@ class ipc_rules_t : public wf::plugin_interface_t,
         return wf::ipc::json_error("no such view");
     };
 
-    wf::ipc::method_callback list_outputs = [=] (wf::ipc::json_wrapper_t)
+    wf::ipc::method_callback list_outputs = [=] (wf::json_t)
     {
-        wf::ipc::json_wrapper_t response = wf::ipc::json_wrapper_t::array();
+        wf::json_t response = wf::json_t::array();
         for (auto& output : wf::get_core().output_layout->get_outputs())
         {
             response.append(output_to_json(output));
@@ -159,7 +159,7 @@ class ipc_rules_t : public wf::plugin_interface_t,
         return response;
     };
 
-    wf::ipc::method_callback get_output_info = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback get_output_info = [=] (wf::json_t data)
     {
         auto id = wf::ipc::json_get_uint64(data, "id");
         auto wo = wf::ipc::find_output_by_id(id);
@@ -172,7 +172,7 @@ class ipc_rules_t : public wf::plugin_interface_t,
         return response;
     };
 
-    wf::ipc::method_callback configure_view = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback configure_view = [=] (wf::json_t data)
     {
         auto id = wf::ipc::json_get_uint64(data, "id");
         auto output_id = wf::ipc::json_get_optional_uint64(data, "output_id");
@@ -225,9 +225,9 @@ class ipc_rules_t : public wf::plugin_interface_t,
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback list_wsets = [=] (wf::ipc::json_wrapper_t)
+    wf::ipc::method_callback list_wsets = [=] (wf::json_t)
     {
-        wf::ipc::json_wrapper_t response = wf::ipc::json_wrapper_t::array();
+        wf::json_t response = wf::json_t::array();
         for (auto& workspace_set : wf::workspace_set_t::get_all())
         {
             response.append(wset_to_json(workspace_set.get()));
@@ -236,7 +236,7 @@ class ipc_rules_t : public wf::plugin_interface_t,
         return response;
     };
 
-    wf::ipc::method_callback get_wset_info = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback get_wset_info = [=] (wf::json_t data)
     {
         auto id = wf::ipc::json_get_uint64(data, "id");
         auto ws = wf::ipc::find_workspace_set_by_index(id);

--- a/plugins/ipc/demo-ipc.cpp
+++ b/plugins/ipc/demo-ipc.cpp
@@ -34,64 +34,64 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
     }
 
     wf::ipc::method_callback_full on_client_watch =
-        [=] (nlohmann::json data, wf::ipc::client_interface_t *client)
+        [=] (wf::ipc::json_wrapper_t data, wf::ipc::client_interface_t *client)
     {
         clients.insert(client);
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback get_view_info = [=] (nlohmann::json data)
+    wf::ipc::method_callback get_view_info = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "id", number_integer);
-
-        for (auto view : wf::get_core().get_all_views())
-        {
-            if (view->get_id() == data["id"])
-            {
-                auto response = wf::ipc::json_ok();
-                response["info"] = view_to_json(view);
-                return response;
-            }
-        }
+// WFJSON_EXPECT_FIELD(data, "id", number_integer);
+//
+// for (auto view : wf::get_core().get_all_views())
+// {
+// if (view->get_id() == data["id"])
+// {
+// auto response = wf::ipc::json_ok();
+// response["info"] = view_to_json(view);
+// return response;
+// }
+// }
 
         return wf::ipc::json_error("no such view");
     };
 
-    wf::ipc::method_callback get_output_info = [=] (nlohmann::json data)
+    wf::ipc::method_callback get_output_info = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "id", number_integer);
-        auto wo = wf::ipc::find_output_by_id(data["id"]);
-        if (!wo)
-        {
-            return wf::ipc::json_error("output not found");
-        }
-
-        auto response = wf::ipc::json_ok();
-        response["info"]["name"]     = wo->to_string();
-        response["info"]["geometry"] = wf::ipc::geometry_to_json(wo->get_layout_geometry());
-        return response;
+// WFJSON_EXPECT_FIELD(data, "id", number_integer);
+// auto wo = wf::ipc::find_output_by_id(data["id"]);
+// if (!wo)
+// {
+// return wf::ipc::json_error("output not found");
+// }
+//
+// auto response = wf::ipc::json_ok();
+// response["info"]["name"]     = wo->to_string();
+// response["info"]["geometry"] = wf::ipc::geometry_to_json(wo->get_layout_geometry());
+        return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback set_view_geometry = [=] (nlohmann::json data)
+    wf::ipc::method_callback set_view_geometry = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "id", number_integer);
-        WFJSON_EXPECT_FIELD(data, "geometry", object);
+        // WFJSON_EXPECT_FIELD(data, "id", number_integer);
+        // WFJSON_EXPECT_FIELD(data, "geometry", object);
 
-        if (auto view = wf::ipc::find_view_by_id(data["id"]))
-        {
-            if (auto geometry = wf::ipc::geometry_from_json(data["geometry"]))
-            {
-                if (auto toplevel = toplevel_cast(view))
-                {
-                    toplevel->set_geometry(geometry.value());
-                    return wf::ipc::json_ok();
-                }
+        // if (auto view = wf::ipc::find_view_by_id(data["id"]))
+        // {
+        // if (auto geometry = wf::ipc::geometry_from_json(data["geometry"]))
+        // {
+        // if (auto toplevel = toplevel_cast(view))
+        // {
+        // toplevel->set_geometry(geometry.value());
+        // return wf::ipc::json_ok();
+        // }
 
-                return wf::ipc::json_error("view is not toplevel");
-            }
+        // return wf::ipc::json_error("view is not toplevel");
+        // }
 
-            return wf::ipc::json_error("geometry incorrect");
-        }
+        // return wf::ipc::json_error("geometry incorrect");
+        // }
 
         return wf::ipc::json_error("view not found");
     };
@@ -108,7 +108,7 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
 
     wf::signal::connection_t<wf::view_mapped_signal> on_view_mapped = [=] (wf::view_mapped_signal *ev)
     {
-        nlohmann::json event;
+        wf::ipc::json_wrapper_t event;
         event["event"] = "view-mapped";
         event["view"]  = view_to_json(ev->view);
         for (auto& client : clients)
@@ -117,9 +117,9 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
         }
     };
 
-    nlohmann::json view_to_json(wayfire_view view)
+    wf::ipc::json_wrapper_t view_to_json(wayfire_view view)
     {
-        nlohmann::json description;
+        wf::ipc::json_wrapper_t description;
         description["id"]     = view->get_id();
         description["app-id"] = view->get_app_id();
         description["title"]  = view->get_title();

--- a/plugins/ipc/demo-ipc.cpp
+++ b/plugins/ipc/demo-ipc.cpp
@@ -34,13 +34,13 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
     }
 
     wf::ipc::method_callback_full on_client_watch =
-        [=] (wf::ipc::json_wrapper_t data, wf::ipc::client_interface_t *client)
+        [=] (wf::json_t data, wf::ipc::client_interface_t *client)
     {
         clients.insert(client);
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback get_view_info = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback get_view_info = [=] (wf::json_t data)
     {
 // WFJSON_EXPECT_FIELD(data, "id", number_integer);
 //
@@ -57,7 +57,7 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
         return wf::ipc::json_error("no such view");
     };
 
-    wf::ipc::method_callback get_output_info = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback get_output_info = [=] (wf::json_t data)
     {
 // WFJSON_EXPECT_FIELD(data, "id", number_integer);
 // auto wo = wf::ipc::find_output_by_id(data["id"]);
@@ -72,7 +72,7 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback set_view_geometry = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback set_view_geometry = [=] (wf::json_t data)
     {
         // WFJSON_EXPECT_FIELD(data, "id", number_integer);
         // WFJSON_EXPECT_FIELD(data, "geometry", object);
@@ -108,7 +108,7 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
 
     wf::signal::connection_t<wf::view_mapped_signal> on_view_mapped = [=] (wf::view_mapped_signal *ev)
     {
-        wf::ipc::json_wrapper_t event;
+        wf::json_t event;
         event["event"] = "view-mapped";
         event["view"]  = view_to_json(ev->view);
         for (auto& client : clients)
@@ -117,9 +117,9 @@ class wayfire_demo_ipc : public wf::plugin_interface_t
         }
     };
 
-    wf::ipc::json_wrapper_t view_to_json(wayfire_view view)
+    wf::json_t view_to_json(wayfire_view view)
     {
-        wf::ipc::json_wrapper_t description;
+        wf::json_t description;
         description["id"]     = view->get_id();
         description["app-id"] = view->get_app_id();
         description["title"]  = view->get_title();

--- a/plugins/ipc/ipc-activator.hpp
+++ b/plugins/ipc/ipc-activator.hpp
@@ -70,7 +70,7 @@ class ipc_activator_t
         return false;
     };
 
-    ipc::method_callback ipc_cb = [=] (const wf::ipc::json_wrapper_t& data)
+    ipc::method_callback ipc_cb = [=] (const wf::json_t& data)
     {
         auto output_id = ipc::json_get_optional_int64(data, "output_id");
         if (!output_id.has_value())

--- a/plugins/ipc/ipc-activator.hpp
+++ b/plugins/ipc/ipc-activator.hpp
@@ -70,24 +70,24 @@ class ipc_activator_t
         return false;
     };
 
-    ipc::method_callback ipc_cb = [=] (const nlohmann::json& data)
+    ipc::method_callback ipc_cb = [=] (const wf::ipc::json_wrapper_t& data)
     {
-        WFJSON_OPTIONAL_FIELD(data, "output_id", number_integer);
-        WFJSON_OPTIONAL_FIELD(data, "view_id", number_integer);
-        WFJSON_OPTIONAL_FIELD(data, "output-id", number_integer);
-        WFJSON_OPTIONAL_FIELD(data, "view-id", number_integer);
+        auto output_id = ipc::json_get_optional_int64(data, "output_id");
+        if (!output_id.has_value())
+        {
+            output_id = ipc::json_get_optional_int64(data, "output-id");
+        }
+
+        auto view_id = ipc::json_get_optional_int64(data, "view_id");
+        if (!view_id.has_value())
+        {
+            view_id = ipc::json_get_optional_int64(data, "view-id");
+        }
 
         wf::output_t *wo = wf::get_core().seat->get_active_output();
-        if (data.contains("output_id"))
+        if (output_id.has_value())
         {
-            wo = ipc::find_output_by_id(data["output_id"]);
-            if (!wo)
-            {
-                return ipc::json_error("output id not found!");
-            }
-        } else if (data.contains("output-id"))
-        {
-            wo = ipc::find_output_by_id(data["output-id"]);
+            wo = ipc::find_output_by_id(output_id.value());
             if (!wo)
             {
                 return ipc::json_error("output id not found!");
@@ -95,16 +95,9 @@ class ipc_activator_t
         }
 
         wayfire_view view;
-        if (data.contains("view_id"))
+        if (view_id.has_value())
         {
-            view = ipc::find_view_by_id(data["view_id"]);
-            if (!view)
-            {
-                return ipc::json_error("view id not found!");
-            }
-        } else if (data.contains("view-id"))
-        {
-            view = ipc::find_view_by_id(data["view-id"]);
+            view = ipc::find_view_by_id(view_id.has_value());
             if (!view)
             {
                 return ipc::json_error("view id not found!");

--- a/plugins/ipc/ipc-helpers.hpp
+++ b/plugins/ipc/ipc-helpers.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "json-wrapper.hpp"
+#include <wayfire/nonstd/json.hpp>
 #include "wayfire/geometry.hpp"
 #include <wayfire/output.hpp>
 #include <wayfire/view.hpp>
@@ -15,7 +15,7 @@ namespace wf
 namespace ipc
 {
 #define WFJSON_GETTER_FUNCTION(type, ctype) \
-    inline ctype json_get_ ## type(const wf::ipc::json_wrapper_t& data, std::string field) \
+    inline ctype json_get_ ## type(const wf::json_t& data, std::string field) \
     { \
         if (!data.has_member(field)) \
         { \
@@ -30,7 +30,7 @@ namespace ipc
         return (ctype)data[field]; \
     } \
  \
-    inline std::optional<ctype> json_get_optional_ ## type(const wf::ipc::json_wrapper_t& data, \
+    inline std::optional<ctype> json_get_optional_ ## type(const wf::json_t& data, \
     std::string field) \
     { \
         if (!data.has_member(field)) \
@@ -94,9 +94,9 @@ inline wf::workspace_set_t *find_workspace_set_by_index(int32_t index)
     return nullptr;
 }
 
-inline wf::ipc::json_wrapper_t geometry_to_json(wf::geometry_t g)
+inline wf::json_t geometry_to_json(wf::geometry_t g)
 {
-    wf::ipc::json_wrapper_t j;
+    wf::json_t j;
     j["x"]     = g.x;
     j["y"]     = g.y;
     j["width"] = g.width;
@@ -106,7 +106,7 @@ inline wf::ipc::json_wrapper_t geometry_to_json(wf::geometry_t g)
 
 #define CHECK(field, type) (j.has_member(field) && j[field].is_ ## type())
 
-inline std::optional<wf::geometry_t> geometry_from_json(const wf::ipc::json_wrapper_t& j)
+inline std::optional<wf::geometry_t> geometry_from_json(const wf::json_t& j)
 {
     if (!CHECK("x", int) || !CHECK("y", int) ||
         !CHECK("width", int) || !CHECK("height", int))
@@ -122,15 +122,15 @@ inline std::optional<wf::geometry_t> geometry_from_json(const wf::ipc::json_wrap
     };
 }
 
-inline wf::ipc::json_wrapper_t point_to_json(wf::point_t p)
+inline wf::json_t point_to_json(wf::point_t p)
 {
-    wf::ipc::json_wrapper_t j;
+    wf::json_t j;
     j["x"] = p.x;
     j["y"] = p.y;
     return j;
 }
 
-inline std::optional<wf::point_t> point_from_json(const wf::ipc::json_wrapper_t& j)
+inline std::optional<wf::point_t> point_from_json(const wf::json_t& j)
 {
     if (!CHECK("x", int) || !CHECK("y", int))
     {
@@ -143,15 +143,15 @@ inline std::optional<wf::point_t> point_from_json(const wf::ipc::json_wrapper_t&
     };
 }
 
-inline wf::ipc::json_wrapper_t dimensions_to_json(wf::dimensions_t d)
+inline wf::json_t dimensions_to_json(wf::dimensions_t d)
 {
-    wf::ipc::json_wrapper_t j;
+    wf::json_t j;
     j["width"]  = d.width;
     j["height"] = d.height;
     return j;
 }
 
-inline std::optional<wf::dimensions_t> dimensions_from_json(const wf::ipc::json_wrapper_t& j)
+inline std::optional<wf::dimensions_t> dimensions_from_json(const wf::json_t& j)
 {
     if (!CHECK("width", int) || !CHECK("height", int))
     {

--- a/plugins/ipc/ipc-helpers.hpp
+++ b/plugins/ipc/ipc-helpers.hpp
@@ -8,6 +8,7 @@
 #include <wayfire/core.hpp>
 #include <wayfire/output-layout.hpp>
 #include <wayfire/core.hpp>
+#include "ipc-method-repository.hpp"
 
 namespace wf
 {
@@ -18,11 +19,12 @@ namespace ipc
     { \
         if (!data.has_member(field)) \
         { \
-            throw ("Missing \"" + field + "\""); \
+            throw ipc_method_exception_t("Missing \"" + field + "\""); \
         } \
         else if (!data[field].is_ ## type()) \
         { \
-            throw ("Field \"" + field + "\" does not have the correct type, expected " #type); \
+            throw ipc_method_exception_t( \
+    "Field \"" + field + "\" does not have the correct type, expected " #type); \
         } \
 \
         return (ctype)data[field]; \
@@ -37,7 +39,8 @@ namespace ipc
         } \
         else if (!data[field].is_ ## type()) \
         { \
-            throw ("Field \"" + field + "\" does not have the correct type, expected " #type); \
+            throw ipc_method_exception_t( \
+    "Field \"" + field + "\" does not have the correct type, expected " #type); \
         } \
 \
         return (ctype)data[field]; \

--- a/plugins/ipc/ipc.cpp
+++ b/plugins/ipc/ipc.cpp
@@ -131,7 +131,7 @@ void wf::ipc::server_t::client_disappeared(client_t *client)
 }
 
 void wf::ipc::server_t::handle_incoming_message(
-    client_t *client, nlohmann::json message)
+    client_t *client, wf::ipc::json_wrapper_t message)
 {
     client->send_json(method_repository->call_method(message["method"], message["data"], client));
 }
@@ -249,18 +249,30 @@ void wf::ipc::client_t::handle_fd_incoming(uint32_t event_mask)
 
         // Finally, received the message, make sure we have a terminating NULL byte
         buffer[current_buffer_valid] = '\0';
-        char *str    = buffer.data() + HEADER_LEN;
-        auto message = nlohmann::json::parse(str, nullptr, false);
-        if (message.is_discarded())
+        char *str = buffer.data() + HEADER_LEN;
+
+        json_wrapper_t message;
+        auto err = json_wrapper_t::parse_string(std::string_view{str, len}, message);
+        if (err.has_value())
         {
-            LOGE("Client's message could not be parsed: ", str);
+            json_wrapper_t error;
+            error["error"] = std::string("Client's message could not be parsed, error: ") + *err;
+            LOGE((std::string)error["error"], ": ", str);
+            this->send_json(error);
             ipc->client_disappeared(this);
             return;
         }
 
-        if (!message.contains("method"))
+        if (!message.has_member("method") || !message["method"].is_string())
         {
-            LOGE("Client's message does not contain a method to be called!");
+            LOGI("Start");
+            json_wrapper_t error;
+            error["error"] = "Client's message does not contain a method to be called!";
+            LOGI("MID");
+            LOGE(error["error"].as_string());
+            LOGI("END");
+
+            this->send_json(error);
             ipc->client_disappeared(this);
             return;
         }
@@ -278,7 +290,7 @@ wf::ipc::client_t::~client_t()
     close(this->fd);
 }
 
-static bool write_exact(int fd, char *buf, ssize_t n)
+static bool write_exact(int fd, const char *buf, ssize_t n)
 {
     while (n > 0)
     {
@@ -295,18 +307,18 @@ static bool write_exact(int fd, char *buf, ssize_t n)
     return true;
 }
 
-bool wf::ipc::client_t::send_json(nlohmann::json json)
+bool wf::ipc::client_t::send_json(wf::ipc::json_wrapper_t json)
 {
-    std::string serialized = json.dump(-1, ' ', false, nlohmann::detail::error_handler_t::ignore);
-    if (serialized.length() > MAX_MESSAGE_LEN)
+    std::string buffer = json.serialize();
+    if (buffer.size() > MAX_MESSAGE_LEN)
     {
         LOGE("Error sending json to client: message too long!");
         shutdown(fd, SHUT_RDWR);
         return false;
     }
 
-    uint32_t len = serialized.length();
-    if (!write_exact(fd, (char*)&len, 4) || !write_exact(fd, serialized.data(), len))
+    uint32_t len = buffer.size();
+    if (!write_exact(fd, (char*)&len, 4) || !write_exact(fd, buffer.data(), len))
     {
         LOGE("Error sending json to client!");
         shutdown(fd, SHUT_RDWR);

--- a/plugins/ipc/ipc.cpp
+++ b/plugins/ipc/ipc.cpp
@@ -131,7 +131,7 @@ void wf::ipc::server_t::client_disappeared(client_t *client)
 }
 
 void wf::ipc::server_t::handle_incoming_message(
-    client_t *client, wf::ipc::json_wrapper_t message)
+    client_t *client, wf::json_t message)
 {
     client->send_json(method_repository->call_method(message["method"], message["data"], client));
 }
@@ -251,11 +251,11 @@ void wf::ipc::client_t::handle_fd_incoming(uint32_t event_mask)
         buffer[current_buffer_valid] = '\0';
         char *str = buffer.data() + HEADER_LEN;
 
-        json_wrapper_t message;
-        auto err = json_wrapper_t::parse_string(std::string_view{str, len}, message);
+        json_t message;
+        auto err = json_t::parse_string(std::string_view{str, len}, message);
         if (err.has_value())
         {
-            json_wrapper_t error;
+            json_t error;
             error["error"] = std::string("Client's message could not be parsed, error: ") + *err;
             LOGE((std::string)error["error"], ": ", str);
             this->send_json(error);
@@ -266,7 +266,7 @@ void wf::ipc::client_t::handle_fd_incoming(uint32_t event_mask)
         if (!message.has_member("method") || !message["method"].is_string())
         {
             LOGI("Start");
-            json_wrapper_t error;
+            json_t error;
             error["error"] = "Client's message does not contain a method to be called!";
             LOGI("MID");
             LOGE(error["error"].as_string());
@@ -307,25 +307,30 @@ static bool write_exact(int fd, const char *buf, ssize_t n)
     return true;
 }
 
-bool wf::ipc::client_t::send_json(wf::ipc::json_wrapper_t json)
+bool wf::ipc::client_t::send_json(wf::json_t json)
 {
-    std::string buffer = json.serialize();
-    if (buffer.size() > MAX_MESSAGE_LEN)
+    bool status = false;
+    json.map_serialized([&] (const char *buffer, size_t size)
     {
-        LOGE("Error sending json to client: message too long!");
-        shutdown(fd, SHUT_RDWR);
-        return false;
-    }
+        if (size > MAX_MESSAGE_LEN)
+        {
+            LOGE("Error sending json to client: message too long!");
+            shutdown(fd, SHUT_RDWR);
+            return;
+        }
 
-    uint32_t len = buffer.size();
-    if (!write_exact(fd, (char*)&len, 4) || !write_exact(fd, buffer.data(), len))
-    {
-        LOGE("Error sending json to client!");
-        shutdown(fd, SHUT_RDWR);
-        return false;
-    }
+        uint32_t len = size;
+        if (!write_exact(fd, (char*)&len, 4) || !write_exact(fd, buffer, len))
+        {
+            LOGE("Error sending json to client!");
+            shutdown(fd, SHUT_RDWR);
+            return;
+        }
 
-    return true;
+        status = true;
+    });
+
+    return status;
 }
 
 namespace wf

--- a/plugins/ipc/ipc.hpp
+++ b/plugins/ipc/ipc.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <nlohmann/json.hpp> // IWYU pragma: keep
 #include <sys/un.h>
 #include <wayfire/object.hpp>
 #include <wayland-server.h>
@@ -20,7 +19,7 @@ class client_t : public client_interface_t
   public:
     client_t(server_t *server, int client_fd);
     ~client_t();
-    bool send_json(nlohmann::json json) override;
+    bool send_json(wf::ipc::json_wrapper_t json) override;
 
   private:
     int fd;
@@ -51,7 +50,7 @@ class server_t
     friend class client_t;
     wf::shared_data::ref_ptr_t<wf::ipc::method_repository_t> method_repository;
 
-    void handle_incoming_message(client_t *client, nlohmann::json message);
+    void handle_incoming_message(client_t *client, wf::ipc::json_wrapper_t message);
 
     void client_disappeared(client_t *client);
 

--- a/plugins/ipc/ipc.hpp
+++ b/plugins/ipc/ipc.hpp
@@ -19,7 +19,7 @@ class client_t : public client_interface_t
   public:
     client_t(server_t *server, int client_fd);
     ~client_t();
-    bool send_json(wf::ipc::json_wrapper_t json) override;
+    bool send_json(wf::json_t json) override;
 
   private:
     int fd;
@@ -50,7 +50,7 @@ class server_t
     friend class client_t;
     wf::shared_data::ref_ptr_t<wf::ipc::method_repository_t> method_repository;
 
-    void handle_incoming_message(client_t *client, wf::ipc::json_wrapper_t message);
+    void handle_incoming_message(client_t *client, wf::json_t message);
 
     void client_disappeared(client_t *client);
 

--- a/plugins/ipc/meson.build
+++ b/plugins/ipc/meson.build
@@ -23,4 +23,4 @@ demoipc = shared_module('demo-ipc',
     install: true,
     install_dir: conf_data.get('PLUGIN_PATH'))
 
-install_headers(['ipc-method-repository.hpp', 'ipc-helpers.hpp', 'ipc-activator.hpp', 'json-wrapper.hpp'], subdir: 'wayfire/plugins/ipc')
+install_headers(['ipc-method-repository.hpp', 'ipc-helpers.hpp', 'ipc-activator.hpp'], subdir: 'wayfire/plugins/ipc')

--- a/plugins/ipc/meson.build
+++ b/plugins/ipc/meson.build
@@ -23,4 +23,4 @@ demoipc = shared_module('demo-ipc',
     install: true,
     install_dir: conf_data.get('PLUGIN_PATH'))
 
-install_headers(['ipc-method-repository.hpp', 'ipc-helpers.hpp', 'ipc-activator.hpp'], subdir: 'wayfire/plugins/ipc')
+install_headers(['ipc-method-repository.hpp', 'ipc-helpers.hpp', 'ipc-activator.hpp', 'json-wrapper.hpp'], subdir: 'wayfire/plugins/ipc')

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -11,6 +11,7 @@
 #include <wayfire/txn/transaction-manager.hpp>
 #include "src/view/view-impl.hpp"
 #include <variant>
+#include <cstring>
 
 #define WAYFIRE_PLUGIN
 #include <wayfire/debug.hpp>
@@ -313,7 +314,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return false;
     }
 
-    ipc::method_callback layout_views = [] (wf::ipc::json_wrapper_t data) -> wf::ipc::json_wrapper_t
+    ipc::method_callback layout_views = [] (wf::json_t data) -> wf::json_t
     {
         auto views = wf::get_core().get_all_views();
         if (!data.has_member("views") || !data["views"].is_array())
@@ -367,7 +368,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback create_wayland_output = [] (wf::ipc::json_wrapper_t)
+    ipc::method_callback create_wayland_output = [] (wf::json_t)
     {
         auto backend = wf::get_core().backend;
 
@@ -384,7 +385,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback destroy_wayland_output = [] (wf::ipc::json_wrapper_t data) -> ipc::json_wrapper_t
+    ipc::method_callback destroy_wayland_output = [] (wf::json_t data) -> json_t
     {
         auto output_str = wf::ipc::json_get_string(data, "output");
         auto output     = wf::get_core().output_layout->find_output(output_str);
@@ -408,7 +409,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         int code;
     };
 
-    std::variant<key_t, std::string> parse_key(wf::ipc::json_wrapper_t data)
+    std::variant<key_t, std::string> parse_key(wf::json_t data)
     {
         auto combo = wf::ipc::json_get_string(data, "combo");
         if (combo.size() < 4)
@@ -433,7 +434,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return key_t{modifier, key};
     }
 
-    ipc::method_callback feed_key = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback feed_key = [=] (wf::json_t data)
     {
         auto key    = wf::ipc::json_get_string(data, "key");
         auto state  = wf::ipc::json_get_bool(data, "state");
@@ -454,7 +455,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback feed_button = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback feed_button = [=] (wf::json_t data)
     {
         auto result = parse_key(data);
         auto button = std::get_if<key_t>(&result);
@@ -486,7 +487,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback move_cursor = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback move_cursor = [=] (wf::json_t data)
     {
         auto x = wf::ipc::json_get_double(data, "x");
         auto y = wf::ipc::json_get_double(data, "y");
@@ -494,7 +495,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_touch = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback do_touch = [=] (wf::json_t data)
     {
         auto finger = wf::ipc::json_get_int64(data, "finger");
         auto x = wf::ipc::json_get_double(data, "x");
@@ -503,14 +504,14 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_touch_release = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback do_touch_release = [=] (wf::json_t data)
     {
         auto finger = wf::ipc::json_get_int64(data, "finger");
         input->do_touch_release(finger);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback run = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback run = [=] (wf::json_t data)
     {
         auto cmd = wf::ipc::json_get_string(data, "cmd");
         auto response = wf::ipc::json_ok();
@@ -524,20 +525,20 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return response;
     };
 
-    ipc::method_callback ping = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback ping = [=] (wf::json_t data)
     {
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback get_display = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback get_display = [=] (wf::json_t data)
     {
-        wf::ipc::json_wrapper_t dpy;
+        wf::json_t dpy;
         dpy["wayland"]  = wf::get_core().wayland_display;
         dpy["xwayland"] = wf::get_core().get_xwayland_display();
         return dpy;
     };
 
-    ipc::method_callback do_tool_proximity = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback do_tool_proximity = [=] (wf::json_t data)
     {
         auto proximity_in = wf::ipc::json_get_bool(data, "proximity_in");
         auto x = wf::ipc::json_get_double(data, "x");
@@ -546,7 +547,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_tool_button = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback do_tool_button = [=] (wf::json_t data)
     {
         auto button = wf::ipc::json_get_int64(data, "button");
         auto state  = wf::ipc::json_get_bool(data, "state");
@@ -554,7 +555,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_tool_axis = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback do_tool_axis = [=] (wf::json_t data)
     {
         auto x = wf::ipc::json_get_double(data, "x");
         auto y = wf::ipc::json_get_double(data, "y");
@@ -563,7 +564,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_tool_tip = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback do_tool_tip = [=] (wf::json_t data)
     {
         auto x     = wf::ipc::json_get_double(data, "x");
         auto y     = wf::ipc::json_get_double(data, "y");
@@ -572,7 +573,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_pad_button = [=] (wf::ipc::json_wrapper_t data)
+    ipc::method_callback do_pad_button = [=] (wf::json_t data)
     {
         auto button = wf::ipc::json_get_int64(data, "button");
         auto state  = wf::ipc::json_get_bool(data, "state");
@@ -608,7 +609,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         }
     };
 
-    ipc::method_callback delay_next_tx = [=] (wf::ipc::json_wrapper_t)
+    ipc::method_callback delay_next_tx = [=] (wf::json_t)
     {
         if (!on_new_tx.is_connected())
         {
@@ -619,14 +620,14 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback get_xwayland_pid = [=] (wf::ipc::json_wrapper_t)
+    ipc::method_callback get_xwayland_pid = [=] (wf::json_t)
     {
         auto response = wf::ipc::json_ok();
         response["pid"] = wf::xwayland_get_pid();
         return response;
     };
 
-    ipc::method_callback get_xwayland_display = [=] (wf::ipc::json_wrapper_t)
+    ipc::method_callback get_xwayland_display = [=] (wf::json_t)
     {
         auto response = wf::ipc::json_ok();
         response["display"] = wf::xwayland_get_display();

--- a/plugins/ipc/stipc.cpp
+++ b/plugins/ipc/stipc.cpp
@@ -1,3 +1,4 @@
+#include "ipc-helpers.hpp"
 #include "ipc-method-repository.hpp"
 #include "wayfire/plugin.hpp"
 #include "wayfire/plugins/common/shared-core-data.hpp"
@@ -312,56 +313,61 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return false;
     }
 
-    ipc::method_callback layout_views = [] (nlohmann::json data)
+    ipc::method_callback layout_views = [] (wf::ipc::json_wrapper_t data) -> wf::ipc::json_wrapper_t
     {
         auto views = wf::get_core().get_all_views();
-        WFJSON_EXPECT_FIELD(data, "views", array);
-        for (auto v : data["views"])
+        if (!data.has_member("views") || !data["views"].is_array())
         {
-            WFJSON_EXPECT_FIELD(v, "id", number);
-            WFJSON_EXPECT_FIELD(v, "x", number);
-            WFJSON_EXPECT_FIELD(v, "y", number);
-            WFJSON_EXPECT_FIELD(v, "width", number);
-            WFJSON_EXPECT_FIELD(v, "height", number);
+            return wf::ipc::json_error("Views not specified");
+        }
+
+        for (size_t i = 0; i < data["views"].size(); i++)
+        {
+            const auto& v = data["views"][i];
+            auto id   = wf::ipc::json_get_uint64(v, "id");
+            int x     = wf::ipc::json_get_int64(v, "x");
+            int y     = wf::ipc::json_get_int64(v, "y");
+            int width = wf::ipc::json_get_int64(v, "width");
+            int height  = wf::ipc::json_get_int64(v, "height");
+            auto output = wf::ipc::json_get_optional_string(v, "output");
 
             auto it = std::find_if(views.begin(), views.end(), [&] (auto& view)
             {
-                return view->get_id() == v["id"];
+                return view->get_id() == uint64_t(v["id"]);
             });
 
             if (it == views.end())
             {
                 return wf::ipc::json_error("Could not find view with id " +
-                    std::to_string((int)v["id"]));
+                    std::to_string(id));
             }
 
             auto toplevel = toplevel_cast(*it);
             if (!toplevel)
             {
                 return wf::ipc::json_error("View is not toplevel view id " +
-                    std::to_string((int)v["id"]));
+                    std::to_string(id));
             }
 
-            if (v.contains("output"))
+            if (output.has_value())
             {
-                WFJSON_EXPECT_FIELD(v, "output", string);
-                auto wo = wf::get_core().output_layout->find_output(v["output"]);
+                auto wo = wf::get_core().output_layout->find_output(output.value());
                 if (!wo)
                 {
-                    return wf::ipc::json_error("Unknown output " + (std::string)v["output"]);
+                    return wf::ipc::json_error("Unknown output " + (std::string)output.value());
                 }
 
                 move_view_to_output(toplevel, wo, false);
             }
 
-            wf::geometry_t g{v["x"], v["y"], v["width"], v["height"]};
+            wf::geometry_t g{x, y, width, height};
             toplevel->set_geometry(g);
         }
 
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback create_wayland_output = [] (nlohmann::json)
+    ipc::method_callback create_wayland_output = [] (wf::ipc::json_wrapper_t)
     {
         auto backend = wf::get_core().backend;
 
@@ -378,14 +384,13 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback destroy_wayland_output = [] (nlohmann::json data)
+    ipc::method_callback destroy_wayland_output = [] (wf::ipc::json_wrapper_t data) -> ipc::json_wrapper_t
     {
-        WFJSON_EXPECT_FIELD(data, "output", string);
-        auto output = wf::get_core().output_layout->find_output(data["output"]);
+        auto output_str = wf::ipc::json_get_string(data, "output");
+        auto output     = wf::get_core().output_layout->find_output(output_str);
         if (!output)
         {
-            return wf::ipc::json_error("Could not find output: \"" +
-                (std::string)data["output"] + "\"");
+            return wf::ipc::json_error("Could not find output: \"" + output_str + "\"");
         }
 
         if (!wlr_output_is_wl(output->handle))
@@ -403,14 +408,9 @@ class stipc_plugin_t : public wf::plugin_interface_t
         int code;
     };
 
-    std::variant<key_t, std::string> parse_key(nlohmann::json data)
+    std::variant<key_t, std::string> parse_key(wf::ipc::json_wrapper_t data)
     {
-        if (!data.count("combo") || !data["combo"].is_string())
-        {
-            return std::string("Missing or wrong json type for `combo`!");
-        }
-
-        std::string combo = data["combo"];
+        auto combo = wf::ipc::json_get_string(data, "combo");
         if (combo.size() < 4)
         {
             return std::string("Missing or wrong json type for `combo`!");
@@ -433,19 +433,17 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return key_t{modifier, key};
     }
 
-    ipc::method_callback feed_key = [=] (nlohmann::json data)
+    ipc::method_callback feed_key = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "key", string);
-        WFJSON_EXPECT_FIELD(data, "state", boolean);
-
-        std::string key = data["key"];
-        int keycode     = libevdev_event_code_from_name(EV_KEY, key.c_str());
+        auto key    = wf::ipc::json_get_string(data, "key");
+        auto state  = wf::ipc::json_get_bool(data, "state");
+        int keycode = libevdev_event_code_from_name(EV_KEY, key.c_str());
         if (keycode == -1)
         {
             return wf::ipc::json_error("Failed to parse evdev key \"" + key + "\"");
         }
 
-        if (data["state"])
+        if (state)
         {
             input->do_key(keycode, WL_KEYBOARD_KEY_STATE_PRESSED);
         } else
@@ -456,7 +454,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback feed_button = [=] (nlohmann::json data)
+    ipc::method_callback feed_button = [=] (wf::ipc::json_wrapper_t data)
     {
         auto result = parse_key(data);
         auto button = std::get_if<key_t>(&result);
@@ -465,13 +463,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
             return wf::ipc::json_error(std::get<std::string>(result));
         }
 
-        if (!data.count("mode") || !data["mode"].is_string())
-        {
-            return wf::ipc::json_error("No mode specified");
-        }
-
-        auto mode = data["mode"];
-
+        auto mode = wf::ipc::json_get_string(data, "mode");
         if ((mode == "press") || (mode == "full"))
         {
             if (button->modifier)
@@ -494,46 +486,35 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback move_cursor = [=] (nlohmann::json data)
+    ipc::method_callback move_cursor = [=] (wf::ipc::json_wrapper_t data)
     {
-        if (!data.count("x") || !data.count("y") ||
-            !data["x"].is_number() || !data["y"].is_number())
-        {
-            return wf::ipc::json_error("Move cursor needs double x/y arguments");
-        }
-
-        double x = data["x"];
-        double y = data["y"];
+        auto x = wf::ipc::json_get_double(data, "x");
+        auto y = wf::ipc::json_get_double(data, "y");
         input->do_motion(x, y);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_touch = [=] (nlohmann::json data)
+    ipc::method_callback do_touch = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "finger", number_integer);
-        WFJSON_EXPECT_FIELD(data, "x", number);
-        WFJSON_EXPECT_FIELD(data, "y", number);
-
-        input->do_touch(data["finger"], data["x"], data["y"]);
+        auto finger = wf::ipc::json_get_int64(data, "finger");
+        auto x = wf::ipc::json_get_double(data, "x");
+        auto y = wf::ipc::json_get_double(data, "y");
+        input->do_touch(finger, x, y);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_touch_release = [=] (nlohmann::json data)
+    ipc::method_callback do_touch_release = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "finger", number_integer);
-        input->do_touch_release(data["finger"]);
+        auto finger = wf::ipc::json_get_int64(data, "finger");
+        input->do_touch_release(finger);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback run = [=] (nlohmann::json data)
+    ipc::method_callback run = [=] (wf::ipc::json_wrapper_t data)
     {
-        if (!data.count("cmd") || !data["cmd"].is_string())
-        {
-            return wf::ipc::json_error("run command needs a cmd to run");
-        }
-
+        auto cmd = wf::ipc::json_get_string(data, "cmd");
         auto response = wf::ipc::json_ok();
-        pid_t pid     = wf::get_core().run(data["cmd"]);
+        pid_t pid     = wf::get_core().run("cmd");
         if (!pid)
         {
             return wf::ipc::json_error("failed to run command");
@@ -543,59 +524,59 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return response;
     };
 
-    ipc::method_callback ping = [=] (nlohmann::json data)
+    ipc::method_callback ping = [=] (wf::ipc::json_wrapper_t data)
     {
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback get_display = [=] (nlohmann::json data)
+    ipc::method_callback get_display = [=] (wf::ipc::json_wrapper_t data)
     {
-        nlohmann::json dpy;
+        wf::ipc::json_wrapper_t dpy;
         dpy["wayland"]  = wf::get_core().wayland_display;
         dpy["xwayland"] = wf::get_core().get_xwayland_display();
         return dpy;
     };
 
-    ipc::method_callback do_tool_proximity = [=] (nlohmann::json data)
+    ipc::method_callback do_tool_proximity = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "proximity_in", boolean);
-        WFJSON_EXPECT_FIELD(data, "x", number);
-        WFJSON_EXPECT_FIELD(data, "y", number);
-        input->do_tablet_proximity(data["proximity_in"], data["x"], data["y"]);
+        auto proximity_in = wf::ipc::json_get_bool(data, "proximity_in");
+        auto x = wf::ipc::json_get_double(data, "x");
+        auto y = wf::ipc::json_get_double(data, "y");
+        input->do_tablet_proximity(proximity_in, x, y);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_tool_button = [=] (nlohmann::json data)
+    ipc::method_callback do_tool_button = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "button", number_integer);
-        WFJSON_EXPECT_FIELD(data, "state", boolean);
-        input->do_tablet_button(data["button"], data["state"]);
+        auto button = wf::ipc::json_get_int64(data, "button");
+        auto state  = wf::ipc::json_get_bool(data, "state");
+        input->do_tablet_button(button, state);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_tool_axis = [=] (nlohmann::json data)
+    ipc::method_callback do_tool_axis = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "x", number);
-        WFJSON_EXPECT_FIELD(data, "y", number);
-        WFJSON_EXPECT_FIELD(data, "pressure", number);
-        input->do_tablet_axis(data["x"], data["y"], data["pressure"]);
+        auto x = wf::ipc::json_get_double(data, "x");
+        auto y = wf::ipc::json_get_double(data, "y");
+        auto pressure = wf::ipc::json_get_double(data, "pressure");
+        input->do_tablet_axis(x, y, pressure);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_tool_tip = [=] (nlohmann::json data)
+    ipc::method_callback do_tool_tip = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "x", number);
-        WFJSON_EXPECT_FIELD(data, "y", number);
-        WFJSON_EXPECT_FIELD(data, "state", boolean);
-        input->do_tablet_tip(data["state"], data["x"], data["y"]);
+        auto x     = wf::ipc::json_get_double(data, "x");
+        auto y     = wf::ipc::json_get_double(data, "y");
+        auto state = wf::ipc::json_get_bool(data, "state");
+        input->do_tablet_tip(state, x, y);
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback do_pad_button = [=] (nlohmann::json data)
+    ipc::method_callback do_pad_button = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "button", number_integer);
-        WFJSON_EXPECT_FIELD(data, "state", boolean);
-        input->do_tablet_pad_button(data["button"], data["state"]);
+        auto button = wf::ipc::json_get_int64(data, "button");
+        auto state  = wf::ipc::json_get_bool(data, "state");
+        input->do_tablet_pad_button(button, state);
         return wf::ipc::json_ok();
     };
 
@@ -627,7 +608,7 @@ class stipc_plugin_t : public wf::plugin_interface_t
         }
     };
 
-    ipc::method_callback delay_next_tx = [=] (nlohmann::json)
+    ipc::method_callback delay_next_tx = [=] (wf::ipc::json_wrapper_t)
     {
         if (!on_new_tx.is_connected())
         {
@@ -638,14 +619,14 @@ class stipc_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    ipc::method_callback get_xwayland_pid = [=] (nlohmann::json)
+    ipc::method_callback get_xwayland_pid = [=] (wf::ipc::json_wrapper_t)
     {
         auto response = wf::ipc::json_ok();
         response["pid"] = wf::xwayland_get_pid();
         return response;
     };
 
-    ipc::method_callback get_xwayland_display = [=] (nlohmann::json)
+    ipc::method_callback get_xwayland_display = [=] (wf::ipc::json_wrapper_t)
     {
         auto response = wf::ipc::json_ok();
         response["display"] = wf::xwayland_get_display();

--- a/plugins/single_plugins/alpha.cpp
+++ b/plugins/single_plugins/alpha.cpp
@@ -55,8 +55,8 @@ class wayfire_alpha : public wf::plugin_interface_t
         ipc_repo->register_method("wf/alpha/get-view-alpha", ipc_get_view_alpha);
     }
 
-    wf::ipc::method_callback ipc_set_view_alpha = [=] (wf::ipc::json_wrapper_t data)
-        -> wf::ipc::json_wrapper_t
+    wf::ipc::method_callback ipc_set_view_alpha = [=] (wf::json_t data)
+        -> wf::json_t
     {
         auto view_id = wf::ipc::json_get_uint64(data, "view-id");
         auto alpha   = wf::ipc::json_get_double(data, "alpha");
@@ -74,7 +74,7 @@ class wayfire_alpha : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback ipc_get_view_alpha = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback ipc_get_view_alpha = [=] (wf::json_t data)
     {
         auto view_id = wf::ipc::json_get_uint64(data, "view-id");
         auto view    = wf::ipc::find_view_by_id(view_id);

--- a/plugins/single_plugins/command.cpp
+++ b/plugins/single_plugins/command.cpp
@@ -322,7 +322,7 @@ class wayfire_command : public wf::plugin_interface_t
     }
 
     wf::ipc::method_callback_full on_register_binding =
-        [&] (const wf::ipc::json_wrapper_t& js, wf::ipc::client_interface_t *client)
+        [&] (const wf::json_t& js, wf::ipc::client_interface_t *client)
     {
         auto binding_str = wf::ipc::json_get_string(js, "binding");
         auto mode_str    = wf::ipc::json_get_optional_string(js, "mode");
@@ -389,7 +389,7 @@ class wayfire_command : public wf::plugin_interface_t
             {
                 return on_binding([client, id] () -> bool
                 {
-                    wf::ipc::json_wrapper_t event;
+                    wf::json_t event;
                     event["event"] = "command-binding";
                     event["binding-id"] = id;
                     return client->send_json(event);
@@ -401,12 +401,12 @@ class wayfire_command : public wf::plugin_interface_t
         ipc_bindings.back().client   = temporary_binding ? client : NULL;
         wf::get_core().bindings->add_activator(wf::create_option(*binding), &ipc_bindings.back().callback);
 
-        wf::ipc::json_wrapper_t response = wf::ipc::json_ok();
+        wf::json_t response = wf::ipc::json_ok();
         response["binding-id"] = id;
         return response;
     };
 
-    wf::ipc::method_callback on_unregister_binding = [&] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback on_unregister_binding = [&] (const wf::json_t& js)
     {
         auto binding_id = wf::ipc::json_get_uint64(js, "binding-id");
         ipc_bindings.remove_if([&] (const ipc_binding_t& binding)
@@ -437,7 +437,7 @@ class wayfire_command : public wf::plugin_interface_t
         });
     }
 
-    wf::ipc::method_callback on_clear_ipc_bindings = [&] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback on_clear_ipc_bindings = [&] (const wf::json_t& js)
     {
         clear_ipc_bindings([&] (const ipc_binding_t& binding)
         {

--- a/plugins/single_plugins/wsets.cpp
+++ b/plugins/single_plugins/wsets.cpp
@@ -68,33 +68,32 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
     std::list<wf::activator_callback> send_callback;
     std::map<int, std::shared_ptr<wf::workspace_set_t>> available_sets;
 
-    wf::ipc::method_callback set_output_wset = [=] (nlohmann::json data)
+    wf::ipc::method_callback set_output_wset = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "output-id", number_integer);
-        WFJSON_EXPECT_FIELD(data, "wset-index", number_integer);
-
-        wf::output_t *o = wf::ipc::find_output_by_id(data["output-id"]);
+        auto output_id  = wf::ipc::json_get_int64(data, "output-id");
+        auto wset_index = wf::ipc::json_get_int64(data, "wset-index");
+        wf::output_t *o = wf::ipc::find_output_by_id(output_id);
         if (!o)
         {
             return wf::ipc::json_error("output not found");
         }
 
-        select_workspace(data["wset-index"], o);
+        select_workspace(wset_index, o);
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback send_view_to_wset = [=] (nlohmann::json data)
+    wf::ipc::method_callback send_view_to_wset = [=] (wf::ipc::json_wrapper_t data)
     {
-        WFJSON_EXPECT_FIELD(data, "view-id", number_integer);
-        WFJSON_EXPECT_FIELD(data, "wset-index", number_integer);
+        auto view_id    = wf::ipc::json_get_int64(data, "view-id");
+        auto wset_index = wf::ipc::json_get_int64(data, "wset-index");
 
-        wayfire_toplevel_view view = toplevel_cast(wf::ipc::find_view_by_id(data["view-id"]));
+        wayfire_toplevel_view view = toplevel_cast(wf::ipc::find_view_by_id(view_id));
         if (!view)
         {
             return wf::ipc::json_error("view not found");
         }
 
-        send_window_to(data["wset-index"], view);
+        send_window_to(wset_index, view);
         return wf::ipc::json_ok();
     };
 

--- a/plugins/single_plugins/wsets.cpp
+++ b/plugins/single_plugins/wsets.cpp
@@ -68,7 +68,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
     std::list<wf::activator_callback> send_callback;
     std::map<int, std::shared_ptr<wf::workspace_set_t>> available_sets;
 
-    wf::ipc::method_callback set_output_wset = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback set_output_wset = [=] (wf::json_t data)
     {
         auto output_id  = wf::ipc::json_get_int64(data, "output-id");
         auto wset_index = wf::ipc::json_get_int64(data, "wset-index");
@@ -82,7 +82,7 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
         return wf::ipc::json_ok();
     };
 
-    wf::ipc::method_callback send_view_to_wset = [=] (wf::ipc::json_wrapper_t data)
+    wf::ipc::method_callback send_view_to_wset = [=] (wf::json_t data)
     {
         auto view_id    = wf::ipc::json_get_int64(data, "view-id");
         auto wset_index = wf::ipc::json_get_int64(data, "wset-index");

--- a/plugins/tile/tile-ipc.hpp
+++ b/plugins/tile/tile-ipc.hpp
@@ -22,11 +22,11 @@ struct json_builder_data_t
 /**
  * Get a json description of the given tiling tree.
  */
-inline wf::ipc::json_wrapper_t tree_to_json(const std::unique_ptr<tree_node_t>& root,
+inline wf::json_t tree_to_json(const std::unique_ptr<tree_node_t>& root,
     const wf::point_t& offset,
     double rel_size = 1.0)
 {
-    wf::ipc::json_wrapper_t js;
+    wf::json_t js;
     js["percent"]  = rel_size;
     js["geometry"] = wf::ipc::geometry_to_json(root->geometry - offset);
     if (auto view = root->as_view_node())
@@ -38,7 +38,7 @@ inline wf::ipc::json_wrapper_t tree_to_json(const std::unique_ptr<tree_node_t>& 
     auto split = root->as_split_node();
     wf::dassert(split != nullptr, "Expected to be split node");
 
-    wf::ipc::json_wrapper_t children = wf::ipc::json_wrapper_t::array();
+    wf::json_t children = wf::json_t::array();
     if (split->get_split_direction() == SPLIT_HORIZONTAL)
     {
         for (auto& child : split->children)
@@ -66,7 +66,7 @@ inline wf::ipc::json_wrapper_t tree_to_json(const std::unique_ptr<tree_node_t>& 
  * Go over the json description and verify that it is a valid tiling tree.
  * @return An error message if the tree is invalid.
  */
-inline std::optional<std::string> verify_json_tree(const wf::ipc::json_reference_t& json,
+inline std::optional<std::string> verify_json_tree(const json_reference_t& json,
     json_builder_data_t& data, const wf::dimensions_t& available_geometry)
 {
     if (!json.is_object())
@@ -163,7 +163,7 @@ inline std::optional<std::string> verify_json_tree(const wf::ipc::json_reference
     return {};
 }
 
-inline std::unique_ptr<tile::tree_node_t> build_tree_from_json_rec(const wf::ipc::json_reference_t& json,
+inline std::unique_ptr<tile::tree_node_t> build_tree_from_json_rec(const json_reference_t& json,
     tile_workspace_set_data_t *wdata, wf::point_t vp)
 {
     std::unique_ptr<tile::tree_node_t> root;
@@ -200,7 +200,7 @@ inline std::unique_ptr<tile::tree_node_t> build_tree_from_json_rec(const wf::ipc
  *
  * Note that the tree description first has to be verified and pre-processed by verify_json_tree().
  */
-inline std::unique_ptr<tile::tree_node_t> build_tree_from_json(const wf::ipc::json_wrapper_t& json,
+inline std::unique_ptr<tile::tree_node_t> build_tree_from_json(const wf::json_t& json,
     tile_workspace_set_data_t *wdata, wf::point_t vp)
 {
     auto root = build_tree_from_json_rec(json, wdata, vp);
@@ -215,7 +215,7 @@ inline std::unique_ptr<tile::tree_node_t> build_tree_from_json(const wf::ipc::js
     return root;
 }
 
-inline wf::ipc::json_wrapper_t handle_ipc_get_layout(const ipc::json_wrapper_t& params)
+inline wf::json_t handle_ipc_get_layout(const json_t& params)
 {
     auto wset_index = wf::ipc::json_get_uint64(params, "wset-index");
 
@@ -249,7 +249,7 @@ inline wf::ipc::json_wrapper_t handle_ipc_get_layout(const ipc::json_wrapper_t& 
     return wf::ipc::json_error("wset-index not found");
 }
 
-inline wf::ipc::json_wrapper_t handle_ipc_set_layout(ipc::json_wrapper_t params)
+inline wf::json_t handle_ipc_set_layout(json_t params)
 {
     auto wset_index = wf::ipc::json_get_uint64(params, "wset-index");
     if (!params.has_member("workspace") or !params["workspace"].is_object())

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -505,12 +505,12 @@ class tile_plugin_t : public wf::plugin_interface_t, wf::per_output_tracker_mixi
         output->erase_data<tile_output_plugin_t>();
     }
 
-    ipc::method_callback ipc_get_layout = [=] (const nlohmann::json& params)
+    ipc::method_callback ipc_get_layout = [=] (const wf::ipc::json_wrapper_t& params)
     {
         return tile::handle_ipc_get_layout(params);
     };
 
-    ipc::method_callback ipc_set_layout = [=] (nlohmann::json params) -> nlohmann::json
+    ipc::method_callback ipc_set_layout = [=] (wf::ipc::json_wrapper_t params) -> wf::ipc::json_wrapper_t
     {
         return tile::handle_ipc_set_layout(params);
     };

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -505,12 +505,12 @@ class tile_plugin_t : public wf::plugin_interface_t, wf::per_output_tracker_mixi
         output->erase_data<tile_output_plugin_t>();
     }
 
-    ipc::method_callback ipc_get_layout = [=] (const wf::ipc::json_wrapper_t& params)
+    ipc::method_callback ipc_get_layout = [=] (const wf::json_t& params)
     {
         return tile::handle_ipc_get_layout(params);
     };
 
-    ipc::method_callback ipc_set_layout = [=] (wf::ipc::json_wrapper_t params) -> wf::ipc::json_wrapper_t
+    ipc::method_callback ipc_set_layout = [=] (wf::json_t params) -> wf::json_t
     {
         return tile::handle_ipc_set_layout(params);
     };

--- a/plugins/vswitch/vswitch.cpp
+++ b/plugins/vswitch/vswitch.cpp
@@ -558,7 +558,7 @@ class wf_vswitch_global_plugin_t : public wf::per_output_plugin_t<vswitch>
         ipc_repo->unregister_method("vswitch/set-workspace");
     }
 
-    wf::ipc::method_callback request_workspace = [=] (const wf::ipc::json_wrapper_t& data)
+    wf::ipc::method_callback request_workspace = [=] (const wf::json_t& data)
     {
         uint64_t x = wf::ipc::json_get_uint64(data, "x");
         uint64_t y = wf::ipc::json_get_uint64(data, "y");

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -422,24 +422,22 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         ipc_repo->unregister_method("wm-actions/send-to-back");
     }
 
-    nlohmann::json execute_for_view(const nlohmann::json& params,
+    wf::ipc::json_wrapper_t execute_for_view(const wf::ipc::json_wrapper_t& params,
         std::function<void(wayfire_toplevel_view, bool)> view_op)
     {
-        WFJSON_EXPECT_FIELD(params, "view_id", number_integer);
-        WFJSON_EXPECT_FIELD(params, "state", boolean);
-
-        wayfire_toplevel_view view = toplevel_cast(wf::ipc::find_view_by_id(params["view_id"]));
+        uint64_t view_id = wf::ipc::json_get_uint64(params, "view_id");
+        bool state = wf::ipc::json_get_bool(params, "state");
+        wayfire_toplevel_view view = toplevel_cast(wf::ipc::find_view_by_id(view_id));
         if (!view)
         {
             return wf::ipc::json_error("toplevel view id not found!");
         }
 
-        bool state = params["state"];
         view_op(view, state);
         return wf::ipc::json_ok();
     }
 
-    wf::ipc::method_callback ipc_minimize = [=] (const nlohmann::json& js)
+    wf::ipc::method_callback ipc_minimize = [=] (const wf::ipc::json_wrapper_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -447,7 +445,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_maximize = [=] (const nlohmann::json& js)
+    wf::ipc::method_callback ipc_maximize = [=] (const wf::ipc::json_wrapper_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -455,7 +453,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_set_always_on_top = [=] (const nlohmann::json& js)
+    wf::ipc::method_callback ipc_set_always_on_top = [=] (const wf::ipc::json_wrapper_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -469,7 +467,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_set_fullscreen = [=] (const nlohmann::json& js)
+    wf::ipc::method_callback ipc_set_fullscreen = [=] (const wf::ipc::json_wrapper_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -477,7 +475,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_set_sticky = [=] (const nlohmann::json& js)
+    wf::ipc::method_callback ipc_set_sticky = [=] (const wf::ipc::json_wrapper_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -485,7 +483,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_send_to_back = [=] (const nlohmann::json& js)
+    wf::ipc::method_callback ipc_send_to_back = [=] (const wf::ipc::json_wrapper_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -422,7 +422,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         ipc_repo->unregister_method("wm-actions/send-to-back");
     }
 
-    wf::ipc::json_wrapper_t execute_for_view(const wf::ipc::json_wrapper_t& params,
+    wf::json_t execute_for_view(const wf::json_t& params,
         std::function<void(wayfire_toplevel_view, bool)> view_op)
     {
         uint64_t view_id = wf::ipc::json_get_uint64(params, "view_id");
@@ -437,7 +437,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         return wf::ipc::json_ok();
     }
 
-    wf::ipc::method_callback ipc_minimize = [=] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback ipc_minimize = [=] (const wf::json_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -445,7 +445,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_maximize = [=] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback ipc_maximize = [=] (const wf::json_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -453,7 +453,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_set_always_on_top = [=] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback ipc_set_always_on_top = [=] (const wf::json_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -467,7 +467,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_set_fullscreen = [=] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback ipc_set_fullscreen = [=] (const wf::json_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -475,7 +475,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_set_sticky = [=] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback ipc_set_sticky = [=] (const wf::json_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {
@@ -483,7 +483,7 @@ class wayfire_wm_actions_t : public wf::plugin_interface_t,
         });
     };
 
-    wf::ipc::method_callback ipc_send_to_back = [=] (const wf::ipc::json_wrapper_t& js)
+    wf::ipc::method_callback ipc_send_to_back = [=] (const wf::json_t& js)
     {
         return execute_for_view(js, [=] (wayfire_toplevel_view view, bool state)
         {

--- a/src/api/wayfire/nonstd/json.hpp
+++ b/src/api/wayfire/nonstd/json.hpp
@@ -1,0 +1,154 @@
+#pragma once
+#include <optional>
+#include <vector>
+#include <cstdint>
+#include <string_view>
+#include <functional>
+
+extern "C" {
+    struct yyjson_mut_val;
+    struct yyjson_mut_doc;
+};
+
+namespace wf
+{
+/**
+ * A temporary non-owning reference to a JSON value.
+ */
+class json_t;
+class json_reference_t
+{
+  public:
+    // ------------------------------------------- Array support ---------------------------------------------
+    bool is_array() const;
+    json_reference_t operator [](const size_t& idx) const;
+    void append(const json_reference_t& elem);
+    void append(int value);
+    void append(unsigned int value);
+    void append(int64_t value);
+    void append(uint64_t value);
+    void append(double value);
+    void append(bool value);
+    void append(const std::string_view& value);
+    void append(const char *value);
+    size_t size() const;
+
+    // ------------------------------------------- Object support --------------------------------------------
+    bool has_member(const std::string_view& key) const;
+    bool is_object() const;
+    bool is_null() const;
+    json_reference_t operator [](const char *key) const;
+    json_reference_t operator [](const std::string_view& key) const;
+    std::vector<std::string> get_member_names() const;
+    json_reference_t& operator =(const json_reference_t& v);
+    json_reference_t& operator =(const json_reference_t&& other);
+
+    // ------------------------------------- Basic data types support ----------------------------------------
+    json_reference_t& operator =(const int& v);
+    json_reference_t& operator =(const unsigned int& v);
+    json_reference_t& operator =(const int64_t& v);
+    json_reference_t& operator =(const uint64_t& v);
+    json_reference_t& operator =(const bool& v);
+    json_reference_t& operator =(const double& v);
+    json_reference_t& operator =(const std::string_view& v);
+    json_reference_t& operator =(const char *v);
+
+    bool is_int() const;
+    operator int() const;
+    int as_int() const;
+    bool is_int64() const;
+    operator int64_t() const;
+    int64_t as_int64() const;
+    bool is_uint() const;
+    operator unsigned int() const;
+    unsigned int as_uint() const;
+    bool is_uint64() const;
+    operator uint64_t() const;
+    uint64_t as_uint64() const;
+    bool is_bool() const;
+    operator bool() const;
+    bool as_bool() const;
+    bool is_double() const;
+    operator double() const;
+    double as_double() const;
+    bool is_string() const;
+    operator std::string() const;
+    std::string as_string() const;
+
+    yyjson_mut_val *get_raw_value() const
+    {
+        return v;
+    }
+
+    yyjson_mut_doc *get_raw_doc() const
+    {
+        return doc;
+    }
+
+  private:
+    friend class json_t;
+    json_reference_t()
+    {}
+    json_reference_t(yyjson_mut_doc *doc, yyjson_mut_val *val) : doc(doc), v(val)
+    {}
+
+    yyjson_mut_doc *doc = NULL;
+    yyjson_mut_val *v   = NULL;
+
+    // Non-copyable, non-moveable.
+    json_reference_t(const json_reference_t& other)  = delete;
+    json_reference_t(const json_reference_t&& other) = delete;
+};
+
+class json_t final : public json_reference_t
+{
+  public:
+    json_t();
+    json_t(const json_reference_t& ref);
+    json_t(const json_t& other);
+    json_t(yyjson_mut_doc *doc);
+    ~json_t();
+
+    json_t& operator =(const json_t& other);
+    json_t(json_t&& other);
+    json_t& operator =(json_t&& other);
+
+    json_t(int v);
+    json_t(unsigned int v);
+    json_t(int64_t v);
+    json_t(uint64_t v);
+    json_t(double v);
+    json_t(const std::string_view& v);
+    json_t(const char *v);
+    json_t(bool v);
+
+    static json_t array();
+    static json_t null();
+
+    /**
+     * Parse the given source as a JSON document.
+     *
+     * @result Where to store the parsed document on success.
+     * @return On failure, an error message describing the problem with the JSON source will be returned.
+     *   Otherwise, the function will return std::nullopt.
+     */
+    static std::optional<std::string> parse_string(const std::string_view& source,
+        json_t& result);
+
+    /**
+     * Serialize the JSON document and handle it using the provided callback.
+     *
+     * Note that the source string will be freed afterwards, so if the caller needs the data for longer,
+     * they need to make a copy of it.
+     */
+    void map_serialized(std::function<void(const char*source, size_t length)> callback) const;
+
+    /**
+     * Get a JSON string representation of the document.
+     */
+    std::string serialize() const;
+
+  private:
+    void init();
+};
+}

--- a/src/json.cpp
+++ b/src/json.cpp
@@ -1,0 +1,563 @@
+#include <wayfire/nonstd/json.hpp>
+#include "wayfire/dassert.hpp"
+#include <yyjson.h>
+#include <limits>
+
+namespace wf
+{
+bool json_reference_t::is_array() const
+{
+    return yyjson_mut_is_arr(v);
+}
+
+json_reference_t json_reference_t::operator [](const size_t& idx) const
+{
+    wf::dassert(is_array());
+    wf::dassert(size() > idx);
+    return json_reference_t{doc, yyjson_mut_arr_get(v, idx)};
+}
+
+void json_reference_t::append(const json_reference_t& elem)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_append(v, yyjson_mut_val_mut_copy(doc, elem.v));
+}
+
+void json_reference_t::append(int value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_int(doc, v, value);
+}
+
+void json_reference_t::append(unsigned int value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_uint(doc, v, value);
+}
+
+void json_reference_t::append(int64_t value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_sint(doc, v, value);
+}
+
+void json_reference_t::append(uint64_t value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_uint(doc, v, value);
+}
+
+void json_reference_t::append(double value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_real(doc, v, value);
+}
+
+void json_reference_t::append(bool value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_bool(doc, v, value);
+}
+
+void json_reference_t::append(const std::string_view& value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_strncpy(doc, v, value.data(), value.size());
+}
+
+void json_reference_t::append(const char *value)
+{
+    wf::dassert(is_array());
+    yyjson_mut_arr_add_strcpy(doc, v, value);
+}
+
+size_t json_reference_t::size() const
+{
+    wf::dassert(is_array());
+    return yyjson_mut_arr_size(v);
+}
+
+bool json_reference_t::has_member(const std::string_view& key) const
+{
+    return is_object() && (yyjson_mut_obj_getn(v, key.data(), key.size()) != NULL);
+}
+
+bool json_reference_t::is_object() const
+{
+    return yyjson_mut_is_obj(v);
+}
+
+bool json_reference_t::is_null() const
+{
+    return yyjson_mut_is_null(v);
+}
+
+json_reference_t json_reference_t::operator [](const char *key) const
+{
+    return this->operator [](std::string_view{key});
+}
+
+json_reference_t json_reference_t::operator [](const std::string_view& key) const
+{
+    wf::dassert(is_object() || is_null(), "Trying to access into JSON value that is not an object!");
+    if (is_null())
+    {
+        yyjson_mut_set_obj(v);
+    }
+
+    auto ptr = yyjson_mut_obj_getn(v, key.data(), key.size());
+    if (ptr != NULL)
+    {
+        return json_reference_t{doc, ptr};
+    }
+
+    auto key_yy = yyjson_mut_strncpy(doc, key.data(), key.size());
+    auto value  = yyjson_mut_null(doc);
+
+    yyjson_mut_obj_add(v, key_yy, value);
+    return json_reference_t{doc, value};
+}
+
+std::vector<std::string> json_reference_t::get_member_names() const
+{
+    std::vector<std::string> members;
+    yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(v);
+    while (yyjson_mut_obj_iter_has_next(&iter))
+    {
+        auto key = yyjson_mut_obj_iter_next(&iter);
+        members.push_back(yyjson_mut_get_str(key));
+    }
+
+    return members;
+}
+
+static void copy_yyjson(yyjson_mut_doc *dst_doc, yyjson_mut_val *dst, yyjson_mut_val *src)
+{
+    if (yyjson_mut_is_null(src))
+    {
+        yyjson_mut_set_null(dst);
+        return;
+    }
+
+    if (yyjson_mut_is_bool(src))
+    {
+        yyjson_mut_set_bool(dst, yyjson_mut_get_bool(src));
+        return;
+    }
+
+    if (yyjson_mut_is_sint(src))
+    {
+        yyjson_mut_set_sint(dst, yyjson_mut_get_sint(src));
+        return;
+    }
+
+    if (yyjson_mut_is_uint(src))
+    {
+        yyjson_mut_set_uint(dst, yyjson_mut_get_uint(src));
+        return;
+    }
+
+    if (yyjson_mut_is_real(src))
+    {
+        yyjson_mut_set_real(dst, yyjson_mut_get_real(src));
+        return;
+    }
+
+    if (yyjson_mut_is_str(src))
+    {
+        // copy ownership of string to dst_doc
+        auto val = yyjson_mut_val_mut_copy(dst_doc, src);
+        yyjson_mut_set_str(dst, yyjson_mut_get_str(val));
+        return;
+    }
+
+    if (yyjson_mut_is_arr(src))
+    {
+        yyjson_mut_set_arr(dst);
+        yyjson_mut_arr_iter iter = yyjson_mut_arr_iter_with(src);
+        while (yyjson_mut_arr_iter_has_next(&iter))
+        {
+            auto elem = yyjson_mut_arr_iter_next(&iter);
+            elem = yyjson_mut_val_mut_copy(dst_doc, elem);
+            yyjson_mut_arr_append(dst, elem);
+        }
+
+        return;
+    }
+
+    if (yyjson_mut_is_obj(src))
+    {
+        yyjson_mut_set_obj(dst);
+        yyjson_mut_obj_iter iter = yyjson_mut_obj_iter_with(src);
+        while (yyjson_mut_obj_iter_has_next(&iter))
+        {
+            auto key   = yyjson_mut_obj_iter_next(&iter);
+            auto value = yyjson_mut_obj_iter_get_val(key);
+            // Copy ownership to our doc
+            key   = yyjson_mut_val_mut_copy(dst_doc, key);
+            value = yyjson_mut_val_mut_copy(dst_doc, value);
+            yyjson_mut_obj_add(dst, key, value);
+        }
+
+        return;
+    }
+
+    wf::dassert(false, "Unsupported JSON type?");
+}
+
+json_reference_t& json_reference_t::operator =(const json_reference_t& other)
+{
+    copy_yyjson(doc, v, other.v);
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const json_reference_t&& other)
+{
+    // FIXME: maybe we can check whether the docs are the same or something to make this faster?
+    copy_yyjson(doc, v, other.v);
+    return *this;
+}
+
+// --------------------------------------- Basic data types support ------------------------------------------
+json_reference_t& json_reference_t::operator =(const int& v)
+{
+    yyjson_mut_set_sint(this->v, v);
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const uint& v)
+{
+    yyjson_mut_set_uint(this->v, v);
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const int64_t& v)
+{
+    yyjson_mut_set_sint(this->v, v);
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const uint64_t& v)
+{
+    yyjson_mut_set_uint(this->v, v);
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const bool& v)
+{
+    yyjson_mut_set_bool(this->v, v);
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const double& v)
+{
+    yyjson_mut_set_real(this->v, v);
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const std::string_view& v)
+{
+    // copy ownership of string to doc
+    auto our_v = yyjson_mut_strncpy(doc, v.data(), v.size());
+    yyjson_mut_set_str(this->v, yyjson_mut_get_str(our_v));
+    return *this;
+}
+
+json_reference_t& json_reference_t::operator =(const char *v)
+{
+    // copy ownership of string to doc
+    auto our_v = yyjson_mut_strcpy(doc, v);
+    yyjson_mut_set_str(this->v, yyjson_mut_get_str(our_v));
+    return *this;
+}
+
+bool json_reference_t::is_int() const
+{
+    if (yyjson_mut_is_sint(v))
+    {
+        return (std::numeric_limits<int>::min() <= yyjson_mut_get_sint(v)) &&
+               (yyjson_mut_get_sint(v) <= std::numeric_limits<int>::max());
+    }
+
+    if (yyjson_mut_is_uint(v))
+    {
+        return (yyjson_mut_get_uint(v) <= std::numeric_limits<int>::max());
+    }
+
+    return false;
+}
+
+json_reference_t::operator int() const
+{
+    wf::dassert(is_int());
+    return yyjson_mut_get_int(v);
+}
+
+int json_reference_t::as_int() const
+{
+    return (int)(*this);
+}
+
+bool json_reference_t::is_int64() const
+{
+    if (yyjson_mut_is_uint(v))
+    {
+        return yyjson_mut_get_uint(v) <= std::numeric_limits<int64_t>::max();
+    }
+
+    return yyjson_mut_is_sint(v);
+}
+
+json_reference_t::operator int64_t() const
+{
+    wf::dassert(is_int64());
+    if (yyjson_mut_is_uint(v))
+    {
+        return yyjson_mut_get_uint(v);
+    } else
+    {
+        return yyjson_mut_get_sint(v);
+    }
+}
+
+int64_t json_reference_t::as_int64() const
+{
+    return (int64_t)(*this);
+}
+
+bool json_reference_t::is_uint() const
+{
+    return yyjson_mut_is_uint(v) &&
+           (yyjson_mut_get_uint(v) <= std::numeric_limits<unsigned int>::max());
+}
+
+json_reference_t::operator uint() const
+{
+    wf::dassert(is_uint());
+    return yyjson_mut_get_uint(v);
+}
+
+unsigned int json_reference_t::as_uint() const
+{
+    return (unsigned int)(*this);
+}
+
+bool json_reference_t::is_uint64() const
+{
+    return yyjson_mut_is_uint(v);
+}
+
+json_reference_t::operator uint64_t() const
+{
+    wf::dassert(is_uint64());
+    return yyjson_mut_get_uint(v);
+}
+
+uint64_t json_reference_t::as_uint64() const
+{
+    return (uint64_t)(*this);
+}
+
+bool json_reference_t::is_bool() const
+{
+    return yyjson_mut_is_bool(v);
+}
+
+json_reference_t::operator bool() const
+{
+    wf::dassert(is_bool());
+    return yyjson_mut_get_bool(v);
+}
+
+bool json_reference_t::as_bool() const
+{
+    return (bool)(*this);
+}
+
+bool json_reference_t::is_double() const
+{
+    return yyjson_mut_is_num(v);
+}
+
+json_reference_t::operator double() const
+{
+    wf::dassert(is_double());
+    return yyjson_mut_get_num(v);
+}
+
+double json_reference_t::as_double() const
+{
+    return (double)(*this);
+}
+
+bool json_reference_t::is_string() const
+{
+    return yyjson_mut_is_str(v);
+}
+
+json_reference_t::operator std::string() const {
+    wf::dassert(is_string());
+    return std::string(yyjson_mut_get_str(v));
+}
+
+std::string json_reference_t::as_string() const
+{
+    return (std::string)*this;
+}
+
+void json_t::init()
+{
+    this->doc = yyjson_mut_doc_new(NULL);
+    this->v   = yyjson_mut_null(this->doc);
+    yyjson_mut_doc_set_root(doc, v);
+}
+
+json_t::json_t()
+{
+    init();
+}
+
+json_t::~json_t()
+{
+    yyjson_mut_doc_free(doc);
+}
+
+json_t::json_t(const json_reference_t& ref) : json_t()
+{
+    copy_yyjson(doc, this->v, ref.get_raw_value());
+}
+
+json_t::json_t(yyjson_mut_doc *doc)
+{
+    this->doc = doc;
+    this->v   = yyjson_mut_doc_get_root(this->doc);
+}
+
+json_t::json_t(const json_t& other)
+{
+    *this = other;
+}
+
+json_t& json_t::operator =(const json_t& other)
+{
+    if (this != &other)
+    {
+        yyjson_mut_doc_free(doc);
+        init();
+        copy_yyjson(doc, this->v, other.v);
+    }
+
+    return *this;
+}
+
+json_t::json_t(json_t&& other)
+{
+    *this = std::move(other);
+}
+
+json_t& json_t::operator =(json_t&& other)
+{
+    if (this != &other)
+    {
+        yyjson_mut_doc_free(doc);
+        this->doc = other.doc;
+        this->v   = other.v;
+
+        other.doc = NULL;
+        other.v   = NULL;
+    }
+
+    return *this;
+}
+
+json_t::json_t(int v) : json_t()
+{
+    *this = v;
+}
+
+json_t::json_t(unsigned v) : json_t()
+{
+    *this = v;
+}
+
+json_t::json_t(int64_t v) : json_t()
+{
+    *this = v;
+}
+
+json_t::json_t(uint64_t v) : json_t()
+{
+    *this = v;
+}
+
+json_t::json_t(double v) : json_t()
+{
+    *this = v;
+}
+
+json_t::json_t(const std::string_view& v) : json_t()
+{
+    *this = v;
+}
+
+json_t::json_t(const char *v) : json_t()
+{
+    *this = v;
+}
+
+json_t::json_t(bool v) : json_t()
+{
+    *this = v;
+}
+
+json_t json_t::array()
+{
+    json_t r;
+    yyjson_mut_set_arr(r.v);
+    return r;
+}
+
+json_t json_t::null()
+{
+    json_t r;
+    yyjson_mut_set_null(r.v);
+    return r;
+}
+
+std::optional<std::string> json_t::parse_string(const std::string_view& source,
+    json_t& result)
+{
+    yyjson_read_err error;
+    auto doc = yyjson_read_opts((char*)source.data(), source.length(), 0, NULL, &error);
+
+    if (!doc)
+    {
+        return std::string("Failed to parse JSON, error ") +
+               std::to_string(error.code) + ": " + error.msg + std::string("(at offset ") +
+               std::to_string(error.pos) + ")";
+    }
+
+    result = json_t{yyjson_doc_mut_copy(doc, NULL)};
+    yyjson_doc_free(doc);
+    return std::nullopt;
+}
+
+void json_t::map_serialized(std::function<void(const char*source, size_t length)> callback) const
+{
+    size_t len;
+    char *result = yyjson_mut_write(this->doc, 0, &len);
+    callback(result, len);
+    free(result);
+}
+
+std::string json_t::serialize() const
+{
+    std::string result;
+    map_serialized([&] (const char *source, size_t length)
+    {
+        result.append(source, length);
+    });
+
+    return result;
+}
+} // namespace wf

--- a/src/meson.build
+++ b/src/meson.build
@@ -2,6 +2,7 @@ wayfire_sources = ['geometry.cpp',
                    'region.cpp',
                    'debug.cpp',
                    'util.cpp',
+                   'json.cpp',
 
                    'core/window-manager.cpp',
                    'core/output-layout.cpp',


### PR DESCRIPTION
This is the last of my attempts to improve compile time performance.
One of the big issues with plugins is the use of nlohmann, which has a very nice interface but very slow compilation times and is not very performant.

To solve this, this PR migrates Wayfire to a custom json wrapper which has very simple syntax for the basic operations.
In addition, the wrapper is currently implemented using yyjson, which is one of the fastest json parsers available.
The wrapper can be very easily changed to use a different json library if it turns out yyjson has issues.
The use of a wrapper ensures that subsequent changes won't be huge breaking changes for plugins.

Needs more testing as yyjson has a very basic interface so a lot of the operations had to be implemented manually like copying.
