### PR TITLE
Decoration plugin optionally force decorations

### DIFF
--- a/metadata/decoration.xml
+++ b/metadata/decoration.xml
@@ -40,5 +40,10 @@
 			<_long>Disables window decoration for windows matching the specified criteria.</_long>
 			<default>none</default>
 		</option>
+		<option name="override_client_side" type="bool">
+			<_short>Override client side decorations</_short>
+			<_long>Specifies whether to add decorations around windows even if server side decorations aren't requested.</_long>
+			<default>false</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/decor/decoration.cpp
+++ b/plugins/decor/decoration.cpp
@@ -17,6 +17,9 @@
 class wayfire_decoration : public wf::plugin_interface_t
 {
     wf::view_matcher_t ignore_views{"decoration/ignore_views"};
+	wf::option_wrapper_t<bool> override_client_side{
+		"decoration/override_client_side"
+	};
 
     wf::signal::connection_t<wf::txn::new_transaction_signal> on_new_tx =
         [=] (wf::txn::new_transaction_signal *ev)
@@ -104,7 +107,8 @@ class wayfire_decoration : public wf::plugin_interface_t
 
     bool should_decorate_view(wayfire_toplevel_view view)
     {
-        return view->should_be_decorated() && !ignore_decoration_of_view(view);
+		return !ignore_decoration_of_view(view) &&
+		       (override_client_side || view->should_be_decorated());
     }
 
     void adjust_new_decorations(wayfire_toplevel_view view)


### PR DESCRIPTION
This PR adds an option to the decoration plugin that ignores the clients request for client side decorations, see issue [2598](https://github.com/WayfireWM/wayfire/issues/2598).