### PR TITLE
build: Add wrap file for when yyjson is not available

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,15 @@ pixman         = dependency('pixman-1')
 xkbcommon      = dependency('xkbcommon')
 libdl          = cpp.find_library('dl')
 udev           = dependency('libudev')
-json           = dependency('yyjson')
+json           = dependency('yyjson', required: false)
+
+if not json.found()
+	cmake = import('cmake')
+	cmake_opts = cmake.subproject_options()
+	cmake_opts.add_cmake_defines({'CMAKE_POSITION_INDEPENDENT_CODE': true})
+	sub_proj = cmake.subproject('yyjson', options: cmake_opts)
+	json = sub_proj.dependency('yyjson')
+endif
 
 # We're not to use system wlroots: So we'll use the subproject
 if get_option('use_system_wlroots').disabled()

--- a/subprojects/yyjson.wrap
+++ b/subprojects/yyjson.wrap
@@ -1,0 +1,5 @@
+[wrap-git]
+url = https://github.com/ibireme/yyjson.git
+revision = HEAD
+depth = 1
+method = cmake


### PR DESCRIPTION
This attempts to find a yyjson installation and falls back to building as a subproject via wrap file.