### PR TITLE
wlr_layer-shell: Fix init timing and surface validation

### DIFF
--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -496,7 +496,6 @@ void wayfire_layer_shell_view::map()
     {
         this->app_id = nonull(lsurface->namespace_t);
         wf::view_implementation::emit_app_id_changed_signal(self());
-        wf_layer_shell_manager::get_instance().arrange_unmapped_view(this);
     }
 
     // Disconnect, from now on regular commits will work
@@ -605,7 +604,7 @@ void wayfire_layer_shell_view::close()
 
 void wayfire_layer_shell_view::configure(wf::geometry_t box)
 {
-    if (!lsurface || !lsurface->resource)
+    if (!lsurface)
     {
         return;
     }
@@ -679,10 +678,7 @@ class layer_shell_view_controller_t
 
     ~layer_shell_view_controller_t()
     {
-        if (view)
-        {
-            view->handle_destroy();
-        }
+        view->handle_destroy();
     }
 };
 

--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -350,7 +350,8 @@ struct wf_layer_shell_manager
 
     void arrange_unmapped_view(wayfire_layer_shell_view *view)
     {
-        if (!view->get_output()) {
+        if (!view->get_output())
+        {
             return;
         }
 
@@ -604,9 +605,11 @@ void wayfire_layer_shell_view::close()
 
 void wayfire_layer_shell_view::configure(wf::geometry_t box)
 {
-    if (!lsurface || !lsurface->resource) {
+    if (!lsurface || !lsurface->resource)
+    {
         return;
     }
+
     auto state = &lsurface->current;
     if ((state->anchor & both_horiz) == both_horiz)
     {
@@ -676,7 +679,8 @@ class layer_shell_view_controller_t
 
     ~layer_shell_view_controller_t()
     {
-        if (view) {
+        if (view)
+        {
             view->handle_destroy();
         }
     }

--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -604,7 +604,7 @@ void wayfire_layer_shell_view::close()
 
 void wayfire_layer_shell_view::configure(wf::geometry_t box)
 {
-    if (!lsurface) {
+    if (!lsurface || !lsurface->resource) {
         return;
     }
     auto state = &lsurface->current;


### PR DESCRIPTION
fix: EE 05-04-25 21:47:56.528 - [types/wlr_layer_shell_v1.c:296] A configure is sent to an uninitialized wlr_layer_surface_v1 0x5b50eeb11b00