### PR TITLE
Fix crash when applying window rules to constrained dialogs

### DIFF
--- a/plugins/window-rules/view-action-interface.cpp
+++ b/plugins/window-rules/view-action-interface.cpp
@@ -442,6 +442,11 @@ void view_action_interface_t::_start_on_output(std::string name)
         return;
     }
 
+    if (_view->parent)
+    {
+        return;
+    }
+
     if (_view->get_output() == output)
     {
         return;

--- a/plugins/window-rules/window-rules.cpp
+++ b/plugins/window-rules/window-rules.cpp
@@ -111,27 +111,6 @@ void wayfire_window_rules_t::apply(const std::string & signal, wayfire_view view
         return;
     }
 
-    // Check if the view is a transient dialog
-    if (toplevel && toplevel->parent)
-    {
-        bool is_constrained = true;
-        auto parent_geom    = toplevel->parent->get_pending_geometry();
-        auto dialog_geom    = toplevel->get_pending_geometry();
-
-        if ((dialog_geom.x < parent_geom.x) ||
-            (dialog_geom.y < parent_geom.y) ||
-            (dialog_geom.x + dialog_geom.width > parent_geom.x + parent_geom.width) ||
-            (dialog_geom.y + dialog_geom.height > parent_geom.y + parent_geom.height))
-        {
-            is_constrained = false;
-        }
-
-        if (is_constrained)
-        {
-            return;
-        }
-    }
-
     for (const auto & rule : _rules)
     {
         _access_interface.set_view(view);

--- a/plugins/window-rules/window-rules.cpp
+++ b/plugins/window-rules/window-rules.cpp
@@ -111,6 +111,27 @@ void wayfire_window_rules_t::apply(const std::string & signal, wayfire_view view
         return;
     }
 
+    // Check if the view is a transient dialog
+    if (toplevel && toplevel->parent)
+    {
+        bool is_constrained = true;
+        auto parent_geom = toplevel->parent->get_pending_geometry();
+        auto dialog_geom = toplevel->get_pending_geometry();
+
+        if (dialog_geom.x < parent_geom.x ||
+            dialog_geom.y < parent_geom.y ||
+            dialog_geom.x + dialog_geom.width > parent_geom.x + parent_geom.width ||
+            dialog_geom.y + dialog_geom.height > parent_geom.y + parent_geom.height)
+        {
+            is_constrained = false;
+        }
+
+        if (is_constrained)
+        {
+            return;
+        }
+    }
+
     for (const auto & rule : _rules)
     {
         _access_interface.set_view(view);

--- a/plugins/window-rules/window-rules.cpp
+++ b/plugins/window-rules/window-rules.cpp
@@ -115,13 +115,13 @@ void wayfire_window_rules_t::apply(const std::string & signal, wayfire_view view
     if (toplevel && toplevel->parent)
     {
         bool is_constrained = true;
-        auto parent_geom = toplevel->parent->get_pending_geometry();
-        auto dialog_geom = toplevel->get_pending_geometry();
+        auto parent_geom    = toplevel->parent->get_pending_geometry();
+        auto dialog_geom    = toplevel->get_pending_geometry();
 
-        if (dialog_geom.x < parent_geom.x ||
-            dialog_geom.y < parent_geom.y ||
-            dialog_geom.x + dialog_geom.width > parent_geom.x + parent_geom.width ||
-            dialog_geom.y + dialog_geom.height > parent_geom.y + parent_geom.height)
+        if ((dialog_geom.x < parent_geom.x) ||
+            (dialog_geom.y < parent_geom.y) ||
+            (dialog_geom.x + dialog_geom.width > parent_geom.x + parent_geom.width) ||
+            (dialog_geom.y + dialog_geom.height > parent_geom.y + parent_geom.height))
         {
             is_constrained = false;
         }


### PR DESCRIPTION
Added logic to skip rule application for transient dialogs that are constrained to their parent window. 

The issue occurred because Wayfire tried to apply \`start_on_output\` rules to dialogs that could not leave their parent window. The fix ensures that such dialogs are ignored when applying output-changing rules.

fix #2619 