### PR TITLE
Add support for tilde (~) expansion in file paths

### DIFF
--- a/plugins/cube/skydome.cpp
+++ b/plugins/cube/skydome.cpp
@@ -4,7 +4,6 @@
 
 #include <wayfire/output.hpp>
 #include <wayfire/workspace-set.hpp>
-#include <wayfire/utils.hpp>
 
 #include <glm/gtc/matrix_transform.hpp>
 #include "shaders.tpp"

--- a/plugins/cube/skydome.cpp
+++ b/plugins/cube/skydome.cpp
@@ -4,7 +4,7 @@
 
 #include <wayfire/output.hpp>
 #include <wayfire/workspace-set.hpp>
-
+#include <wayfire/utils.hpp>
 
 #include <glm/gtc/matrix_transform.hpp>
 #include "shaders.tpp"
@@ -55,7 +55,8 @@ void wf_cube_background_skydome::reload_texture()
 
     GL_CALL(glBindTexture(GL_TEXTURE_2D, tex));
 
-    if (image_io::load_from_file(last_background_image, GL_TEXTURE_2D))
+    auto full_path_background_image = wf::get_expanded_path(last_background_image);
+    if (image_io::load_from_file(full_path_background_image, GL_TEXTURE_2D))
     {
         GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR));
         GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR));
@@ -63,8 +64,8 @@ void wf_cube_background_skydome::reload_texture()
         GL_CALL(glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
     } else
     {
-        LOGE("Failed to load skydome image from \"%s\".",
-            last_background_image.c_str());
+        LOGE("Failed to load skydome image from ",
+            full_path_background_image.c_str());
         GL_CALL(glDeleteTextures(1, &tex));
         tex = -1;
     }

--- a/src/api/wayfire/util.hpp
+++ b/src/api/wayfire/util.hpp
@@ -7,6 +7,11 @@
 
 namespace wf
 {
+/**
+ * Expands a file path by replacing '~' with the user's home directory.
+ */
+std::string get_expanded_path(const std::string& path);
+
 /** Convert timespect to milliseconds. */
 int64_t timespec_to_msec(const timespec& ts);
 

--- a/src/api/wayfire/util.hpp
+++ b/src/api/wayfire/util.hpp
@@ -5,7 +5,6 @@
 #include <wayland-server.h>
 #include <functional>
 #include <wordexp.h>
-#include <iostream>
 
 namespace wf
 {

--- a/src/api/wayfire/util.hpp
+++ b/src/api/wayfire/util.hpp
@@ -4,11 +4,14 @@
 #include <algorithm>
 #include <wayland-server.h>
 #include <functional>
+#include <wordexp.h>
+#include <iostream>
 
 namespace wf
 {
 /**
- * Expands a file path by replacing '~' with the user's home directory.
+ * Expands a file path using wordexp().
+ * Supports ~ (tilde), $VAR (environment variables), and other shell-like expansions.
  */
 std::string get_expanded_path(const std::string& path);
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -34,12 +34,18 @@ static int handle_timeout(void *data)
 
 namespace wf
 {
-std::string get_expanded_path(const std::string& path) {
-    if (path.empty() || path[0] != '~') return path;
-    
-    if (const char* home = std::getenv("HOME")) {
+std::string get_expanded_path(const std::string& path)
+{
+    if (path.empty() || (path[0] != '~'))
+    {
+        return path;
+    }
+
+    if (const char *home = std::getenv("HOME"))
+    {
         return home + path.substr(1);
     }
+
     return path;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -34,6 +34,15 @@ static int handle_timeout(void *data)
 
 namespace wf
 {
+std::string get_expanded_path(const std::string& path) {
+    if (path.empty() || path[0] != '~') return path;
+    
+    if (const char* home = std::getenv("HOME")) {
+        return home + path.substr(1);
+    }
+    return path;
+}
+
 wl_idle_call::wl_idle_call() = default;
 wl_idle_call::~wl_idle_call()
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -34,8 +34,9 @@ static int handle_timeout(void *data)
 
 namespace wf
 {
-std::string get_expanded_path(const std::string& path) {
-    if (path.empty()) 
+std::string get_expanded_path(const std::string& path)
+{
+    if (path.empty())
     {
         return path;
     }
@@ -43,35 +44,41 @@ std::string get_expanded_path(const std::string& path) {
     wordexp_t result;
     int ret = wordexp(path.c_str(), &result, WRDE_NOCMD);
 
-    if (ret == 0 && result.we_wordc > 0) 
+    if ((ret == 0) && (result.we_wordc > 0))
     {
         std::string expanded_path = result.we_wordv[0];
         wordfree(&result);
         return expanded_path;
-    } else 
-    
+    } else
     {
         wordfree(&result);
-        switch (ret) {
-            case WRDE_BADCHAR:
-                LOGE("get_expanded_path: Invalid character in input path: ", path);
-                break;
-            case WRDE_BADVAL:
-                LOGE("get_expanded_path: Undefined variable in input path: ", path);
-                break;
-            case WRDE_CMDSUB:
-                LOGE("get_expanded_path: Command substitution is disabled for safety: ", path);
-                break;
-            case WRDE_SYNTAX:
-                LOGE("get_expanded_path: Syntax error in input path: ", path);
-                break;
-            case WRDE_NOSPACE:
-                LOGE("get_expanded_path: Out of memory while expanding path: ", path);
-                break;
-            default:
-                LOGE("get_expanded_path: Unknown error while expanding path: ", path);
-                break;
+        switch (ret)
+        {
+          case WRDE_BADCHAR:
+            LOGE("get_expanded_path: Invalid character in input path: ", path);
+            break;
+
+          case WRDE_BADVAL:
+            LOGE("get_expanded_path: Undefined variable in input path: ", path);
+            break;
+
+          case WRDE_CMDSUB:
+            LOGE("get_expanded_path: Command substitution is disabled for safety: ", path);
+            break;
+
+          case WRDE_SYNTAX:
+            LOGE("get_expanded_path: Syntax error in input path: ", path);
+            break;
+
+          case WRDE_NOSPACE:
+            LOGE("get_expanded_path: Out of memory while expanding path: ", path);
+            break;
+
+          default:
+            LOGE("get_expanded_path: Unknown error while expanding path: ", path);
+            break;
         }
+
         return path;
     }
 }


### PR DESCRIPTION
- Adds `get_expanded_path` to expand ~ to the user's home directory.
- Modifies the cube plugin's skydome texture loading to support ~ in paths.

fix #2612