### PR TITLE
fix: clamp layer-shell margins to prevent invalid geometry (#2623)

### DIFF
--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -608,11 +608,12 @@ void wayfire_layer_shell_view::configure(wf::geometry_t box)
     * the max screen size could result in a layer exceeding the dimensions of an individual output. 
     * max_margin need to be lower than total size
     */
-    int max_margin = get_output()->get_screen_size().width / 1.1;
-    state->margin.left = std::clamp(state->margin.left, -max_margin, max_margin);
-    state->margin.right = std::clamp(state->margin.right, -max_margin, max_margin);
-    state->margin.top = std::clamp(state->margin.top, -max_margin, max_margin);
-    state->margin.bottom = std::clamp(state->margin.bottom, -max_margin, max_margin);
+    int max_width_margin = get_output()->get_screen_size().width / 1.1;
+    int max_height_margin = get_output()->get_screen_size().height / 1.1;
+    state->margin.left = std::clamp(state->margin.left, -max_width_margin, max_width_margin);
+    state->margin.right = std::clamp(state->margin.right, -max_width_margin, max_width_margin);
+    state->margin.top = std::clamp(state->margin.top, -max_height_margin, max_height_margin);
+    state->margin.bottom = std::clamp(state->margin.bottom, -max_height_margin, max_height_margin);
 
     if ((state->anchor & both_horiz) == both_horiz)
     {

--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -603,6 +603,17 @@ void wayfire_layer_shell_view::close()
 void wayfire_layer_shell_view::configure(wf::geometry_t box)
 {
     auto state = &lsurface->current;
+    /* 
+    * In multi-output setups, 
+    * the max screen size could result in a layer exceeding the dimensions of an individual output. 
+    * max_margin need to be lower than total size
+    */
+    int max_margin = get_output()->get_screen_size().width / 1.1;
+    state->margin.left = std::clamp(state->margin.left, -max_margin, max_margin);
+    state->margin.right = std::clamp(state->margin.right, -max_margin, max_margin);
+    state->margin.top = std::clamp(state->margin.top, -max_margin, max_margin);
+    state->margin.bottom = std::clamp(state->margin.bottom, -max_margin, max_margin);
+
     if ((state->anchor & both_horiz) == both_horiz)
     {
         box.x     += state->margin.left;

--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -603,16 +603,16 @@ void wayfire_layer_shell_view::close()
 void wayfire_layer_shell_view::configure(wf::geometry_t box)
 {
     auto state = &lsurface->current;
-    /* 
-    * In multi-output setups, 
-    * the max screen size could result in a layer exceeding the dimensions of an individual output. 
-    * max_margin need to be lower than total size
-    */
-    int max_width_margin = get_output()->get_screen_size().width / 1.1;
+    /*
+     * In multi-output setups,
+     * the max screen size could result in a layer exceeding the dimensions of an individual output.
+     * max_margin need to be lower than total size
+     */
+    int max_width_margin  = get_output()->get_screen_size().width / 1.1;
     int max_height_margin = get_output()->get_screen_size().height / 1.1;
-    state->margin.left = std::clamp(state->margin.left, -max_width_margin, max_width_margin);
-    state->margin.right = std::clamp(state->margin.right, -max_width_margin, max_width_margin);
-    state->margin.top = std::clamp(state->margin.top, -max_height_margin, max_height_margin);
+    state->margin.left   = std::clamp(state->margin.left, -max_width_margin, max_width_margin);
+    state->margin.right  = std::clamp(state->margin.right, -max_width_margin, max_width_margin);
+    state->margin.top    = std::clamp(state->margin.top, -max_height_margin, max_height_margin);
     state->margin.bottom = std::clamp(state->margin.bottom, -max_height_margin, max_height_margin);
 
     if ((state->anchor & both_horiz) == both_horiz)


### PR DESCRIPTION
- Introduced clamping for layer-shell margins to ensure they remain within valid bounds.
- Prevented excessive margins that could cause crashes or misalignment in multi-output setups.
- Ensured layer surfaces stay within the visible area of individual outputs.

Fixes: #2623