### PR TITLE
Make focusing newly mapped views optional (strict focus stealing prevention)

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -88,6 +88,11 @@
 			<_long>Whether to pass buttons through to the client when switching the focus via clicking</_long>
 			<default>true</default>
 		</option>
+		<option name="focus_on_map" type="bool">
+			<_short>Focus newly opened views</_short>
+			<_long>If unset, newly opened views will only be focused by using the xdg-activation protocol.</_long>
+			<default>true</default>
+		</option>
 		<option name="exit" type="key">
 			<_short>Wayfire Shutdown</_short>
 			<_long>Calls the shutdown routines for wayfire.</_long>

--- a/metadata/xdg-activation.xml
+++ b/metadata/xdg-activation.xml
@@ -14,6 +14,11 @@
 			<_long>Whether to reject activation requests if a newer request has arrived since their creation.</_long>
 			<default>false</default>
 		</option>
+		<option name="focus_stealing_prevention" type="bool">
+			<_short>Prevent stealing focus by an activation request</_short>
+			<_long>Whether to reject an activation request if the user interacted with a different view since its creation.</_long>
+			<default>true</default>
+		</option>
 		<option name="timeout" type="int">
 			<_short>Timeout for activation (in seconds)</_short>
 			<_long>Focus requests will be ignored if at least this amount of time has elapsed between creating and using it.</_long>

--- a/plugins/protocols/xdg-activation.cpp
+++ b/plugins/protocols/xdg-activation.cpp
@@ -36,6 +36,12 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
         xdg_activation_new_token.disconnect();
         xdg_activation_token_destroy.disconnect();
         last_token = nullptr;
+        if (last_view)
+        {
+            last_view->disconnect(&on_view_unmapped);
+            last_view->disconnect(&on_view_deactivated);
+            last_view = nullptr;
+        }
     }
 
     bool is_unloadable() override
@@ -63,6 +69,17 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
             }
 
             last_token = nullptr; // avoid reusing the same token
+
+            if (last_view)
+            {
+                last_view->disconnect(&on_view_unmapped);
+                last_view->disconnect(&on_view_deactivated);
+                last_view = nullptr;
+            } else if (prevent_focus_stealing)
+            {
+                LOGI("Denying focus request, requesting view has been deactivated");
+                return;
+            }
 
             wayfire_view view = wf::wl_surface_to_wayfire_view(event->surface->resource);
             if (!view)
@@ -100,6 +117,25 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
                 return;
             }
 
+            // unset any previously saved view
+            if (last_view)
+            {
+                last_view->disconnect(&on_view_unmapped);
+                last_view->disconnect(&on_view_deactivated);
+                last_view = nullptr;
+            }
+
+            wayfire_view view = wf::wl_surface_to_wayfire_view(token->surface->resource);
+            if (view)
+            {
+                last_view = wf::toplevel_cast(view); // might return nullptr
+                if (last_view)
+                {
+                    last_view->connect(&on_view_unmapped);
+                    last_view->connect(&on_view_deactivated);
+                }
+            }
+
             // update our token and connect its destroy signal
             last_token = token;
             xdg_activation_token_destroy.disconnect();
@@ -125,14 +161,43 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
         }
     };
 
+    wf::signal::connection_t<wf::view_unmapped_signal> on_view_unmapped = [this] (auto)
+    {
+        last_view->disconnect(&on_view_unmapped);
+        last_view->disconnect(&on_view_deactivated);
+        // handle the case when last_view was a dialog that is closed by user interaction
+        last_view = last_view->parent;
+        if (last_view)
+        {
+            last_view->connect(&on_view_unmapped);
+            last_view->connect(&on_view_deactivated);
+        }
+    };
+
+    wf::signal::connection_t<wf::view_activated_state_signal> on_view_deactivated = [this] (auto)
+    {
+        if (last_view->activated)
+        {
+            // could be a spurious event, e.g. activating the parent
+            // view after closing a dialog
+            return;
+        }
+
+        last_view->disconnect(&on_view_unmapped);
+        last_view->disconnect(&on_view_deactivated);
+        last_view = nullptr;
+    };
+
     struct wlr_xdg_activation_v1 *xdg_activation;
     wf::wl_listener_wrapper xdg_activation_request_activate;
     wf::wl_listener_wrapper xdg_activation_new_token;
     wf::wl_listener_wrapper xdg_activation_token_destroy;
     struct wlr_xdg_activation_token_v1 *last_token = nullptr;
+    wayfire_toplevel_view last_view = nullptr; // view that created the token
 
     wf::option_wrapper_t<bool> check_surface{"xdg-activation/check_surface"};
     wf::option_wrapper_t<bool> only_last_token{"xdg-activation/only_last_request"};
+    wf::option_wrapper_t<bool> prevent_focus_stealing{"xdg-activation/focus_stealing_prevention"};
     wf::option_wrapper_t<int> timeout{"xdg-activation/timeout"};
 };
 

--- a/plugins/protocols/xdg-activation.cpp
+++ b/plugins/protocols/xdg-activation.cpp
@@ -35,6 +35,7 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
         xdg_activation_request_activate.disconnect();
         xdg_activation_new_token.disconnect();
         xdg_activation_token_destroy.disconnect();
+        on_view_mapped.disconnect();
         last_token = nullptr;
         if (last_view)
         {
@@ -70,33 +71,49 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
 
             last_token = nullptr; // avoid reusing the same token
 
-            if (last_view)
-            {
-                last_view->disconnect(&on_view_unmapped);
-                last_view->disconnect(&on_view_deactivated);
-                last_view = nullptr;
-            } else if (prevent_focus_stealing)
+            if (prevent_focus_stealing && !last_view)
             {
                 LOGI("Denying focus request, requesting view has been deactivated");
                 return;
             }
 
+            bool should_focus = true;
             wayfire_view view = wf::wl_surface_to_wayfire_view(event->surface->resource);
             if (!view)
             {
                 LOGE("Could not get view");
-                return;
+                should_focus = false;
             }
 
             auto toplevel = wf::toplevel_cast(view);
             if (!toplevel)
             {
                 LOGE("Could not get toplevel view");
-                return;
+                should_focus = false;
             }
 
-            LOGD("Activating view");
-            wf::get_core().default_wm->focus_request(toplevel);
+            if (should_focus)
+            {
+                if (toplevel->toplevel()->current().mapped)
+                {
+                    LOGD("Activating view");
+                    wf::get_core().default_wm->focus_request(toplevel);
+                } else
+                {
+                    /* This toplevel is not mapped yet, we want to focus it
+                     * when it it first mapped. */
+                    on_view_mapped.disconnect();
+                    view->connect(&on_view_mapped);
+                    return; // avoid disconnecting last_view's signals
+                }
+            }
+
+            if (last_view)
+            {
+                last_view->disconnect(&on_view_unmapped);
+                last_view->disconnect(&on_view_deactivated);
+                last_view = nullptr;
+            }
         });
 
         xdg_activation_new_token.set_callback([this] (void *data)
@@ -186,6 +203,26 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
         last_view->disconnect(&on_view_unmapped);
         last_view->disconnect(&on_view_deactivated);
         last_view = nullptr;
+    };
+
+    wf::signal::connection_t<wf::view_mapped_signal> on_view_mapped = [this] (auto signal)
+    {
+        signal->view->disconnect(&on_view_mapped);
+
+        // re-check focus stealing prevention
+        if (last_view)
+        {
+            last_view->disconnect(&on_view_unmapped);
+            last_view->disconnect(&on_view_deactivated);
+            last_view = nullptr;
+        } else if (prevent_focus_stealing)
+        {
+            LOGI("Denying focus request, requesting view has been deactivated");
+            return;
+        }
+
+        LOGD("Activating view");
+        wf::get_core().default_wm->focus_request(signal->view);
     };
 
     struct wlr_xdg_activation_v1 *xdg_activation;

--- a/plugins/protocols/xdg-activation.cpp
+++ b/plugins/protocols/xdg-activation.cpp
@@ -8,6 +8,7 @@
 #include <wayfire/nonstd/wlroots-full.hpp>
 #include <wayfire/window-manager.hpp>
 #include <wayfire/util.hpp>
+#include <wayfire/seat.hpp>
 #include "config.h"
 
 class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
@@ -28,6 +29,7 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
 
         xdg_activation_request_activate.connect(&xdg_activation->events.request_activate);
         xdg_activation_new_token.connect(&xdg_activation->events.new_token);
+        wf::get_core().connect(&on_run_command);
     }
 
     void fini() override
@@ -35,6 +37,7 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
         xdg_activation_request_activate.disconnect();
         xdg_activation_new_token.disconnect();
         xdg_activation_token_destroy.disconnect();
+        xdg_activation_token_self_destroy.disconnect();
         on_view_mapped.disconnect();
         last_token = nullptr;
         if (last_view)
@@ -43,6 +46,8 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
             last_view->disconnect(&on_view_deactivated);
             last_view = nullptr;
         }
+
+        wf::get_core().disconnect(&on_run_command);
     }
 
     bool is_unloadable() override
@@ -57,19 +62,23 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
         {
             auto event = static_cast<const struct wlr_xdg_activation_v1_request_activate_event*>(data);
 
-            if (!event->token->seat)
+            if (event->token != last_self_token)
             {
-                LOGI("Denying focus request, token was rejected at creation");
-                return;
-            }
+                if (!event->token->seat)
+                {
+                    LOGI("Denying focus request, token was rejected at creation");
+                    return;
+                }
 
-            if (only_last_token && (event->token != last_token))
-            {
-                LOGI("Denying focus request, token is expired");
-                return;
+                if (only_last_token && (event->token != last_token))
+                {
+                    LOGI("Denying focus request, token is expired");
+                    return;
+                }
             }
 
             last_token = nullptr; // avoid reusing the same token
+            last_self_token = nullptr;
 
             if (prevent_focus_stealing && !last_view)
             {
@@ -166,6 +175,13 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
             xdg_activation_token_destroy.disconnect();
         });
 
+        xdg_activation_token_self_destroy.set_callback([this] (void *data)
+        {
+            last_self_token = nullptr;
+
+            xdg_activation_token_self_destroy.disconnect();
+        });
+
         timeout.set_callback(timeout_changed);
     }
 
@@ -225,11 +241,59 @@ class wayfire_xdg_activation_protocol_impl : public wf::plugin_interface_t
         wf::get_core().default_wm->focus_request(signal->view);
     };
 
+    wf::signal::connection_t<wf::command_run_signal> on_run_command = [this] (auto signal)
+    {
+        if (wf::get_core().default_wm->focus_on_map)
+        {
+            // no need to do anything if views are focused anyway
+            return;
+        }
+
+        if (last_self_token)
+        {
+            // TODO: invalidate our last token !
+            last_self_token = nullptr;
+        }
+
+        auto active_view = wf::get_core().seat->get_active_view();
+        if (active_view && (active_view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT))
+        {
+            active_view = nullptr;
+        }
+
+        auto active_toplevel = active_view ? wf::toplevel_cast(active_view) : nullptr;
+
+        if (!active_toplevel)
+        {
+            // if there is no active view, we don't need a token
+            return;
+        }
+
+        if (last_view)
+        {
+            // TODO: we need a separate last_view actually !
+            last_view->disconnect(&on_view_unmapped);
+            last_view->disconnect(&on_view_deactivated);
+        }
+
+        last_view = active_toplevel;
+        last_view->connect(&on_view_unmapped);
+        last_view->connect(&on_view_deactivated);
+        last_self_token = wlr_xdg_activation_token_v1_create(xdg_activation);
+        xdg_activation_token_self_destroy.disconnect();
+        xdg_activation_token_self_destroy.connect(&last_self_token->events.destroy);
+        const char *token_id = wlr_xdg_activation_token_v1_get_name(last_self_token);
+        signal->env.emplace_back("XDG_ACTIVATION_TOKEN", token_id);
+        signal->env.emplace_back("DESKTOP_STARTUP_ID", token_id);
+    };
+
     struct wlr_xdg_activation_v1 *xdg_activation;
     wf::wl_listener_wrapper xdg_activation_request_activate;
     wf::wl_listener_wrapper xdg_activation_new_token;
     wf::wl_listener_wrapper xdg_activation_token_destroy;
+    wf::wl_listener_wrapper xdg_activation_token_self_destroy;
     struct wlr_xdg_activation_token_v1 *last_token = nullptr;
+    struct wlr_xdg_activation_token_v1 *last_self_token = nullptr;
     wayfire_toplevel_view last_view = nullptr; // view that created the token
 
     wf::option_wrapper_t<bool> check_surface{"xdg-activation/check_surface"};

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -204,6 +204,21 @@ struct idle_inhibit_changed_signal
 };
 
 /**
+ * on: core
+ * when: before running a command in compositor_core_t::run().
+ *   Plugins can listen to this signal and add environment variables to
+ *   set in env.
+ */
+struct command_run_signal
+{
+    const std::string& command;
+    std::vector<std::pair<std::string, std::string>> env;
+
+    command_run_signal(const std::string& cmd) : command(cmd)
+    {}
+};
+
+/**
  * on: output, core(output-)
  * when: Immediately after the output becomes focused.
  */

--- a/src/api/wayfire/window-manager.hpp
+++ b/src/api/wayfire/window-manager.hpp
@@ -13,6 +13,11 @@ class window_manager_t
     virtual ~window_manager_t() = default;
 
     /**
+     * Option that sets whether newly mapped views get focus by default.
+     */
+    wf::option_wrapper_t<bool> focus_on_map{"core/focus_on_map"};
+
+    /**
      * Update the remembered last windowed geometry.
      *
      * When a view is being tiled or fullscreened, we usually want to remember its size and position so that

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -442,6 +442,9 @@ pid_t wf::compositor_core_impl_t::run(std::string command)
         return 0;
     }
 
+    wf::command_run_signal signal(command);
+    wf::get_core().emit(&signal);
+
     /* The following is a "hack" for disowning the child processes,
      * otherwise they will simply stay as zombie processes */
     pid_t pid = fork();
@@ -462,6 +465,11 @@ pid_t wf::compositor_core_impl_t::run(std::string command)
             }
 
 #endif
+            for (const auto& var : signal.env)
+            {
+                setenv(var.first.c_str(), var.second.c_str(), 1);
+            }
+
             if (discard_command_output)
             {
                 int dev_null = open("/dev/null", O_WRONLY);

--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -310,7 +310,19 @@ void wf::xdg_toplevel_view_t::map()
     adjust_view_output_on_map(this);
 
     xdg_toplevel_view_base_t::map();
-    wf::get_core().default_wm->focus_request(self());
+
+    /* We only focus a newly mapped view if the corresponding option is
+     * set or if there is no currently active view. */
+    auto active_view = wf::get_core().seat->get_active_view();
+    if (active_view && (active_view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT))
+    {
+        active_view = nullptr;
+    }
+
+    if (wf::get_core().default_wm->focus_on_map || (active_view == nullptr))
+    {
+        wf::get_core().default_wm->focus_request(self());
+    }
 
     /* Might trigger repositioning */
     set_toplevel_parent(this->parent);

--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -378,7 +378,18 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
         const bool wants_focus = (wlr_xwayland_icccm_input_model(xw) != WLR_ICCCM_INPUT_MODEL_NONE);
         if (wants_focus)
         {
-            wf::get_core().default_wm->focus_request(self());
+            /* We only focus a newly mapped view if the corresponding option is
+             * set or if there is no currently active view. */
+            auto active_view = wf::get_core().seat->get_active_view();
+            if (active_view && (active_view->role == wf::VIEW_ROLE_DESKTOP_ENVIRONMENT))
+            {
+                active_view = nullptr;
+            }
+
+            if (wf::get_core().default_wm->focus_on_map || (active_view == nullptr))
+            {
+                wf::get_core().default_wm->focus_request(self());
+            }
         }
 
         /* Might trigger repositioning */


### PR DESCRIPTION
Also continuation of #2527 and #2626, creating a (mostly) complete solution for focus stealing prevention.

This adds an option (`core/focus_on_map`) that determines whether newly mapped (opened) views are focused. The default is `true` which keeps the current behavior (as I imagine the newly introduced behavior would be too restrictive for most users). When set to false, views must explicitly use the xdg-activation protocol to gain focus, even when first mapped.

This PR is organized into 4 parts:
 - commit d3c872bea44e3271c7a8a6f56dd5c43725784c2a is just the same as #2626 (as I don't think there is much sense in merging this only)
 - the next two commits (b29982fea5fa72ccb81c2af6a257b257f63c6354 and 95ebff8bec296f531de9b0e815b776605631099d) implement this option
 - commit 65a1338efa754b9fd35db6cf2eb52142bbf693a5 adapts xdg-activation to be able to focus newly mapped views with a valid token
 - the last two commits (e7af9084a3a295950cf84da33f1484ac9e3a17d3 and 228478f15db7d97aa199b457f678ae80d6454607) generate and pass valid tokens to commands that are run by Wayfire, so that when starting GUI apps, they can still receive focus

This is currently a draft, since some functionality is still missing:
 - The main issue is that currently, newly mapped views are still stacked on top, but do not receive keyboard focus; ideally, they would be stacked below the currently active view, but I haven't yet figured out how to do this.
 - From a UI perspective, I actually don't like putting this option in `core`. it would be nice to collect all focus stealing / activation related options in one place (i.e. with xdg-activation); however, since this option needs to be accessed from core, I don't like the idea of putting it under a plugin. Maybe an alternative would be introducing one more signal, but that also sounds overkill.
 - Also, I'm unsure if this handles XWayland views correctly; I'm wondering if I should prevent focus [here](https://github.com/WayfireWM/wayfire/blob/099fea49800a5c2ed1a39f8c8513543e10362c18/src/view/xwayland/xwayland-unmanaged-view.hpp#L174) as well; in any case, I haven't tested with XWayland yet, but will do so next.
 - I'll need to do more testing, but potentially I want to separately track the active view for normal and self-generated tokens (my main concern is that some commands will not result in a new view opening, so they should not invalidate normal tokens, but this is of course and edge case).



