### PR TITLE
layer-shell: notify scenegraph of geometry changes

### DIFF
--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -106,6 +106,7 @@ class wayfire_layer_shell_view : public wf::view_interface_t
         last_bounding_box = get_bounding_box();
         damage |= last_bounding_box;
         wf::scene::damage_node(get_root_node(), last_bounding_box);
+        wf::scene::update(get_root_node(), wf::scene::update_flag::GEOMETRY);
     }
 
     wlr_surface *get_keyboard_focus_surface() override


### PR DESCRIPTION
Updating the geometry triggers a recomputation of surface visibility. Without it, once the layer-shell view goes offscreen (for ex. during autohide), it is computed as not visible on an output and does not receive `wl_surface.frame` events, leading to choppy animations.

Fixes https://github.com/WayfireWM/wf-shell/issues/189
Fixes https://github.com/WayfireWM/wf-shell/issues/276
Fixes https://github.com/WayfireWM/wf-shell/issues/287