### PR TITLE
Fix plugin include path

### DIFF
--- a/plugins/ipc-rules/ipc-rules-common.hpp
+++ b/plugins/ipc-rules/ipc-rules-common.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "plugins/ipc/ipc-helpers.hpp"
+#include "wayfire/plugins/ipc/ipc-helpers.hpp"
 #include <wayfire/output.hpp>
 #include <wayfire/workarea.hpp>
 #include <wayfire/workspace-set.hpp>


### PR DESCRIPTION
This fix is required so that projects such as [wf-info](https://github.com/soreau/wf-info) can make use of this header without problems.