### PR TITLE
resize: handle overflow due to margins

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,23 +21,15 @@ jobs:
     container:
         image: archlinux:latest
     steps:
-    - run: sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
     - run: pacman --noconfirm --noprogressbar -Syyu
-    - run: pacman-key --init
-    - run: pacman-key --recv-key 7DD85120C491D581 --keyserver keyserver.ubuntu.com
-    - run: pacman-key --lsign-key 7DD85120C491D581
-    - run: printf '[stefanwimmer128]\nServer = https://repo.stefanwimmer128.xyz/$repo/$arch/' >> /etc/pacman.conf
-
-    - run: pacman --noconfirm --noprogressbar -Syyu
-    - run: pacman --noconfirm --noprogressbar -Sy git clang17 lld libc++ pkgconf cmake meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd hwdata libdisplay-info openmp doctest yyjson
+    - run: pacman --noconfirm --noprogressbar -Sy git clang lld libc++ pkgconf cmake meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd hwdata libdisplay-info openmp doctest yyjson
 
       # Build Wayfire
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
-    - run: find /usr/bin/ | grep clang
-    - run: (cd subprojects/wlroots && env CC=clang-17 CXX=clang++-17 CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build --prefix=/usr && ninja -C build install)
-    - run: env CC=clang-17 CXX=clang++-17 CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true -Dcustom_pch=true -Duse_system_wlroots=enabled --unity on
+    - run: (cd subprojects/wlroots && env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build --prefix=/usr && ninja -C build install)
+    - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true -Dcustom_pch=true -Duse_system_wlroots=enabled --unity on
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_code_style:

--- a/plugins/single_plugins/resize.cpp
+++ b/plugins/single_plugins/resize.cpp
@@ -315,27 +315,34 @@ class wayfire_resize : public wf::per_output_plugin_instance_t, public wf::point
     {
         // Max size is whatever is set by the client, if not set, then it is MAX_INT
         wf::dimensions_t max_size = view->toplevel()->get_max_size();
+        int64_t width, height;
         if (max_size.width > 0)
         {
-            max_size.width += view->toplevel()->pending().margins.left +
+            width = static_cast<int64_t>(max_size.width) +
+                view->toplevel()->pending().margins.left +
                 view->toplevel()->pending().margins.right;
         } else
         {
-            max_size.width = std::numeric_limits<decltype(max_size.width)>::max();
+            width = std::numeric_limits<decltype(max_size.width)>::max();
         }
 
         if (max_size.height > 0)
         {
-            max_size.height += view->toplevel()->pending().margins.top +
+            height = static_cast<int64_t>(max_size.height) +
+                view->toplevel()->pending().margins.top +
                 view->toplevel()->pending().margins.bottom;
         } else
         {
-            max_size.height = std::numeric_limits<decltype(max_size.height)>::max();
+            height = std::numeric_limits<decltype(max_size.height)>::max();
         }
 
         // Sanitize values in case desired.width/height gets negative for example.
-        max_size.width  = std::max(max_size.width, min.width);
-        max_size.height = std::max(max_size.height, min.height);
+        max_size.width = static_cast<decltype(max_size.width)>(std::clamp(width,
+            static_cast<int64_t>(min.width),
+            static_cast<int64_t>(std::numeric_limits<decltype(max_size.width)>::max())));
+        max_size.height = static_cast<decltype(max_size.height)>(std::clamp(height,
+            static_cast<int64_t>(min.height),
+            static_cast<int64_t>(std::numeric_limits<decltype(max_size.height)>::max())));
 
         return max_size;
     }


### PR DESCRIPTION
Some apps, notably a lot of Electron apps, set maximum size to INT_MAX, which will overflow the int32_t type when the margins of the server side decorations are added on top.

Use a larger integer type to calculate margins, then clamp as necessary, based on the actual type.

Fixes 099fea49800a5c2ed1a39f8c8513543e10362c18