### PR TITLE
archlinux ci: stop using clang17 repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,23 +21,15 @@ jobs:
     container:
         image: archlinux:latest
     steps:
-    - run: sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
     - run: pacman --noconfirm --noprogressbar -Syyu
-    - run: pacman-key --init
-    - run: pacman-key --recv-key 7DD85120C491D581 --keyserver keyserver.ubuntu.com
-    - run: pacman-key --lsign-key 7DD85120C491D581
-    - run: printf '[stefanwimmer128]\nServer = https://repo.stefanwimmer128.xyz/$repo/$arch/' >> /etc/pacman.conf
-
-    - run: pacman --noconfirm --noprogressbar -Syyu
-    - run: pacman --noconfirm --noprogressbar -Sy git clang17 lld libc++ pkgconf cmake meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd hwdata libdisplay-info openmp doctest yyjson
+    - run: pacman --noconfirm --noprogressbar -Sy git clang lld libc++ pkgconf cmake meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd hwdata libdisplay-info openmp doctest yyjson
 
       # Build Wayfire
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
-    - run: find /usr/bin/ | grep clang
-    - run: (cd subprojects/wlroots && env CC=clang-17 CXX=clang++-17 CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build --prefix=/usr && ninja -C build install)
-    - run: env CC=clang-17 CXX=clang++-17 CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true -Dcustom_pch=true -Duse_system_wlroots=enabled --unity on
+    - run: (cd subprojects/wlroots && env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build --prefix=/usr && ninja -C build install)
+    - run: env CC=clang CXX=clang++ CXXFLAGS="-stdlib=libc++" LDFLAGS="-fuse-ld=lld -stdlib=libc++" meson build -Db_pch=true -Dcustom_pch=true -Duse_system_wlroots=enabled --unity on
     - run: ninja -v -Cbuild
     - run: ninja -v -Cbuild test
   test_code_style:


### PR DESCRIPTION
This should no longer be necessary now that clang 19 is in the repos.

Undoes 1ceafa69edb00b8bb373793bb1090446cc5f5550