### PR TITLE
Fix ipc activator callback

### DIFF
--- a/plugins/ipc/wayfire/plugins/ipc/ipc-activator.hpp
+++ b/plugins/ipc/wayfire/plugins/ipc/ipc-activator.hpp
@@ -97,7 +97,7 @@ class ipc_activator_t
         wayfire_view view;
         if (view_id.has_value())
         {
-            view = ipc::find_view_by_id(view_id.has_value());
+            view = ipc::find_view_by_id(view_id.value());
             if (!view)
             {
                 return ipc::json_error("view id not found!");

--- a/plugins/vswitch/vswitch.cpp
+++ b/plugins/vswitch/vswitch.cpp
@@ -550,12 +550,14 @@ class wf_vswitch_global_plugin_t : public wf::per_output_plugin_t<vswitch>
     {
         per_output_plugin_t::init();
         ipc_repo->register_method("vswitch/set-workspace", request_workspace);
+        ipc_repo->register_method("vswitch/send-view", send_view);
     }
 
     void fini() override
     {
         per_output_plugin_t::fini();
         ipc_repo->unregister_method("vswitch/set-workspace");
+        ipc_repo->unregister_method("vswitch/send-view");
     }
 
     wf::ipc::method_callback request_workspace = [=] (const wf::json_t& data)
@@ -606,6 +608,67 @@ class wf_vswitch_global_plugin_t : public wf::per_output_plugin_t<vswitch>
             wf::point_t delta = new_viewport - cur_viewport;
             output_instance[wo]->add_direction(delta, switch_with_view);
         }
+
+        return wf::ipc::json_ok();
+    };
+
+    wf::ipc::method_callback send_view = [=] (const wf::json_t& data)
+    {
+        uint64_t x = wf::ipc::json_get_uint64(data, "x");
+        uint64_t y = wf::ipc::json_get_uint64(data, "y");
+        uint64_t output_id = wf::ipc::json_get_uint64(data, "output-id");
+        std::optional<uint64_t> view_id = wf::ipc::json_get_optional_uint64(data, "view-id");
+
+        auto wo = wf::ipc::find_output_by_id(output_id);
+        if (!wo)
+        {
+            return wf::ipc::json_error("Invalid output!");
+        }
+
+        auto grid_size = wo->wset()->get_workspace_grid_size();
+        if ((int(data["x"]) >= grid_size.width) || (int(data["y"]) >= grid_size.height))
+        {
+            return wf::ipc::json_error("Workspace coordinates are too big!");
+        }
+
+        wayfire_toplevel_view switch_with_view;
+        if (!view_id.has_value())
+        {
+            return wf::ipc::json_error("view-id not specified!");
+        }
+
+        auto view = toplevel_cast(wf::ipc::find_view_by_id(view_id.value()));
+        if (!view)
+        {
+            return wf::ipc::json_error("Invalid view or view not toplevel!");
+        }
+
+        if (!view->is_mapped())
+        {
+            return wf::ipc::json_error("Cannot grab unmapped view!");
+        }
+
+        if (view->get_output() != wo)
+        {
+            return wf::ipc::json_error("Cannot grab view on a different output!");
+        }
+
+        wf::view_change_workspace_signal signal;
+        signal.view = view;
+        signal.from = wo->wset()->get_current_workspace();
+        signal.to   = {x, y};
+
+        auto size  = wo->get_screen_size();
+        auto delta = signal.to - signal.from;
+
+        for (auto& v : view->enumerate_views(false))
+        {
+            auto origin = wf::origin(v->get_pending_geometry());
+            v->move(origin.x + delta.x * size.width, origin.y + delta.y * size.height);
+        }
+
+        wo->emit(&signal);
+        wf::get_core().seat->refocus();
 
         return wf::ipc::json_ok();
     };

--- a/plugins/vswitch/vswitch.cpp
+++ b/plugins/vswitch/vswitch.cpp
@@ -656,7 +656,7 @@ class wf_vswitch_global_plugin_t : public wf::per_output_plugin_t<vswitch>
         wf::view_change_workspace_signal signal;
         signal.view = view;
         signal.from = wo->wset()->get_current_workspace();
-        signal.to   = {x, y};
+        signal.to   = {(int)x, (int)y};
 
         auto size  = wo->get_screen_size();
         auto delta = signal.to - signal.from;


### PR DESCRIPTION
Corrects a minor bug [here](https://github.com/WayfireWM/wayfire/blob/master/plugins/ipc/wayfire/plugins/ipc/ipc-activator.hpp#L100)

```
view = ipc::find_view_by_id(view_id.has_value());
```

should be 
```
view = ipc::find_view_by_id(view_id.value());
```