### PR TITLE
Bugfix: use view_id.value() instead of view_id.has_value() when finding the view

### DIFF
--- a/plugins/ipc/wayfire/plugins/ipc/ipc-activator.hpp
+++ b/plugins/ipc/wayfire/plugins/ipc/ipc-activator.hpp
@@ -97,7 +97,7 @@ class ipc_activator_t
         wayfire_view view;
         if (view_id.has_value())
         {
-            view = ipc::find_view_by_id(view_id.has_value());
+            view = ipc::find_view_by_id(view_id.value());
             if (!view)
             {
                 return ipc::json_error("view id not found!");


### PR DESCRIPTION
Corrects a minor bug [here](https://github.com/WayfireWM/wayfire/blob/master/plugins/ipc/wayfire/plugins/ipc/ipc-activator.hpp#L100)

```
view = ipc::find_view_by_id(view_id.has_value());
```

should be 
```
view = ipc::find_view_by_id(view_id.value());
```