### PR TITLE
ipc-rules: add events and methods to query keyboard layout

### DIFF
--- a/plugins/ipc-rules/ipc-events.hpp
+++ b/plugins/ipc-rules/ipc-events.hpp
@@ -115,6 +115,7 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
         {"view-app-id-changed", get_generic_core_registration_cb(&on_app_id_changed)},
         {"plugin-activation-state-changed", get_generic_core_registration_cb(&on_plugin_activation_changed)},
         {"output-gain-focus", get_generic_core_registration_cb(&on_output_gain_focus)},
+        {"keyboard-modifier-state-changed", get_generic_core_registration_cb(&on_keyboard_modifiers)},
 
         {"view-tiled", get_generic_output_registration_cb(&_tiled)},
         {"view-minimized", get_generic_output_registration_cb(&_minimized)},
@@ -317,6 +318,22 @@ class ipc_rules_events_methods_t : public wf::per_output_tracker_mixin_t<>
         wf::json_t data;
         data["event"]  = "output-gain-focus";
         data["output"] = output_to_json(ev->output);
+        send_event_to_subscribes(data, data["event"]);
+    };
+
+    wf::signal::connection_t<wf::input_event_signal<mwlr_keyboard_modifiers_event>> on_keyboard_modifiers =
+        [=] (wf::input_event_signal<mwlr_keyboard_modifiers_event> *ev)
+    {
+        auto seat     = wf::get_core().get_current_seat();
+        auto keyboard = wlr_seat_get_keyboard(seat);
+        if (ev->device != &keyboard->base)
+        {
+            return;
+        }
+
+        wf::json_t data;
+        data["event"] = "keyboard-modifier-state-changed";
+        data["state"] = get_keyboard_state(keyboard);
         send_event_to_subscribes(data, data["event"]);
     };
 

--- a/plugins/ipc-rules/ipc-rules-common.hpp
+++ b/plugins/ipc-rules/ipc-rules-common.hpp
@@ -228,3 +228,32 @@ static inline wf::json_t wset_to_json(wf::workspace_set_t *wset)
     response["workspace"]["grid_height"] = wset->get_workspace_grid_size().height;
     return response;
 }
+
+static inline wf::json_t get_keyboard_state(wlr_keyboard *keyboard)
+{
+    const auto& get_layout_name = [&] (xkb_layout_index_t layout)
+    {
+        auto layout_name = xkb_keymap_layout_get_name(keyboard->keymap, layout);
+        return layout_name ? layout_name : "unknown";
+    };
+
+    wf::json_t state;
+    state["possible-layouts"] = wf::json_t::array();
+    if (keyboard)
+    {
+        auto layout = xkb_state_serialize_layout(keyboard->xkb_state, XKB_STATE_LAYOUT_EFFECTIVE);
+        state["layout"] = get_layout_name(layout);
+        state["layout-index"] = layout;
+
+        auto n_layouts = xkb_keymap_num_layouts(keyboard->keymap);
+        for (size_t i = 0; i < n_layouts; i++)
+        {
+            state["possible-layouts"].append(get_layout_name(i));
+        }
+    } else
+    {
+        state["layout"] = "unknown";
+    }
+
+    return state;
+}

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -31,6 +31,7 @@ class ipc_rules_utility_methods_t
         method_repository->register_method("wayfire/destroy-headless-output", destroy_headless_output);
         method_repository->register_method("wayfire/get-config-option", get_config_option);
         method_repository->register_method("wayfire/set-config-options", set_config_options);
+        method_repository->register_method("wayfire/get-keyboard-state", get_kb_state);
     }
 
     void fini_utility_methods(ipc::method_repository_t *method_repository)
@@ -40,6 +41,7 @@ class ipc_rules_utility_methods_t
         method_repository->unregister_method("wayfire/destroy-headless-output");
         method_repository->unregister_method("wayfire/get-config-option");
         method_repository->unregister_method("wayfire/set-config-option");
+        method_repository->unregister_method("wayfire/get-keyboard-state");
     }
 
     wf::ipc::method_callback get_wayfire_configuration_info = [=] (wf::json_t)
@@ -280,6 +282,13 @@ class ipc_rules_utility_methods_t
         reload_config_signal event;
         wf::get_core().emit(&event);
         return wf::ipc::json_ok();
+    };
+
+    wf::ipc::method_callback get_kb_state = [=] (const wf::json_t& data) -> json_t
+    {
+        auto seat     = wf::get_core().get_current_seat();
+        auto keyboard = wlr_seat_get_keyboard(seat);
+        return get_keyboard_state(keyboard);
     };
 };
 }

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -101,7 +101,7 @@ enum class input_event_processing_mode_t
  *   pointer_motion, pointer_motion_absolute, pointer_button, pointer_axis,
  *   pointer_swipe_begin, pointer_swipe_update, pointer_swipe_end, pointer_pinch_begin, pointer_pinch_update,
  *   pointer_pinch_end, pointer_hold_begin, pointer_hold_end,
- *   keyboard_key,
+ *   keyboard_key, keyboard_modifiers (mwlr_keyboard_modifiers),
  *   touch_down, touch_up, touch_motion,
  *   tablet_proximity, tablet_axis, tablet_button, tablet_tip
  *


### PR DESCRIPTION
Fixes #2419

See also https://github.com/WayfireWM/pywayfire/pull/24
