### PR TITLE
meson: Improve devenv support

### DIFF
--- a/metadata/meson.build
+++ b/metadata/meson.build
@@ -43,3 +43,7 @@ install_data('wsets.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('wayfire-shell.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('xdg-activation.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
 install_data('session-lock.xml', install_dir: conf_data.get('PLUGIN_XML_DIR'))
+
+devenv = environment()
+devenv.append('WAYFIRE_PLUGIN_XML_PATH', meson.current_source_dir())
+meson.add_devenv(devenv)

--- a/plugins/meson.build
+++ b/plugins/meson.build
@@ -52,18 +52,27 @@ endif
 wobbly_inc = include_directories('wobbly/')
 subdir('common')
 
-subdir('ipc')
-subdir('protocols')
-subdir('vswitch')
-subdir('wobbly')
-subdir('grid')
-subdir('decor')
-subdir('animate')
-subdir('cube')
-subdir('window-rules')
-subdir('blur')
-subdir('tile')
-subdir('wm-actions')
-subdir('scale')
-subdir('single_plugins')
-subdir('ipc-rules')
+plugins = [
+  'ipc',
+  'protocols',
+  'vswitch',
+  'wobbly',
+  'grid',
+  'decor',
+  'animate',
+  'cube',
+  'window-rules',
+  'blur',
+  'tile',
+  'wm-actions',
+  'scale',
+  'single_plugins',
+  'ipc-rules',
+]
+
+devenv = environment()
+foreach plugin : plugins
+  devenv.append('WAYFIRE_PLUGIN_PATH', meson.current_build_dir() + '/' + plugin)
+  subdir(plugin)
+endforeach
+meson.add_devenv(devenv)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,6 +290,10 @@ int main(int argc, char *argv[])
     std::vector<std::string> extended_debug_categories;
     bool allow_root = false;
 
+    if (char *default_config_backend = getenv("WAYFIRE_DEFAULT_CONFIG_BACKEND")) {
+        config_backend = default_config_backend;
+    }
+
     int c, i;
     while ((c = getopt_long(argc, argv, "c:B:d::DhRlrv", opts, &i)) != -1)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,7 +290,8 @@ int main(int argc, char *argv[])
     std::vector<std::string> extended_debug_categories;
     bool allow_root = false;
 
-    if (char *default_config_backend = getenv("WAYFIRE_DEFAULT_CONFIG_BACKEND")) {
+    if (char *default_config_backend = getenv("WAYFIRE_DEFAULT_CONFIG_BACKEND"))
+    {
         config_backend = default_config_backend;
     }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -165,3 +165,7 @@ pkgconfig.generate(
                    'icondir=${prefix}/share/wayfire/icons',
                    'pkgdatadir='+pkgdatadir]
     )
+
+devenv = environment()
+devenv.set('WAYFIRE_DEFAULT_CONFIG_BACKEND', meson.current_build_dir() + '/libdefault-config-backend.so')
+meson.add_devenv(devenv)


### PR DESCRIPTION
`meson devenv -C build` allows entering a build folder with all environment variables prepared for easy execution without system-wide installation, automatically fixes things like the LD_LIBRARY_PATH.

Wayfire's plugin and backend loader systems rely on their own path discovery and configuration that devenv is unaware of, and so wayfire cannot launch out of the box in a devenv.

Adjust meson build files to augment WAYFIRE_PLUGIN_PATH and WAYFIRE_PLUGIN_XML_PATH so that plugins and XML files work by default. Add the WAYFIRE_DEFAULT_CONFIG_BACKEND environment variable to allow the devenv to provide a default for that as well, as it does not live together with the plugins.

With this, running wayfire straight from the repository is as simple as:

    meson setup build
    ninja -C build
    meson devenv -C build
    ./src/wayfire