### PR TITLE
wayfire-portals.conf: Fix idle inhibit

### DIFF
--- a/wayfire-portals.conf
+++ b/wayfire-portals.conf
@@ -1,2 +1,3 @@
 [preferred]
 default=wlr;*
+org.freedesktop.impl.portal.Inhibit=none


### PR DESCRIPTION
This is needed for Firefox and similar, since xdg-desktop-portal-wlr does not implement idle inhibit protocol, and Firefox will not fall back to the Wayland implementation otherwise.