### PR TITLE
workaround to disable middle click

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -78,5 +78,10 @@
 			<_long>Maximum size in pixels of graphics buffers used for rendering. Needs to be set lower on some systems to avoid crashes and other issues.</_long>
 			<default>16384</default>
 		</option>
+		<option name="disable_primary_selection" type="bool">
+			<_short>Disable primary selection</_short>
+			<_long>Disable primary selection (middle-click copy/paste).</_long>
+			<default>false</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -117,8 +117,15 @@ void wf::compositor_core_impl_t::init()
     }
 
     protocols.data_device = wlr_data_device_manager_create(display);
-    protocols.primary_selection_v1 =
-        wlr_primary_selection_v1_device_manager_create(display);
+    wf::option_wrapper_t<bool> disable_primary_selection{"workarounds/disable_primary_selection"};
+    if (disable_primary_selection)
+    {
+        protocols.primary_selection_v1 = nullptr;
+    } else
+    {
+        protocols.primary_selection_v1 =
+            wlr_primary_selection_v1_device_manager_create(display);
+    }
     protocols.data_control = wlr_data_control_manager_v1_create(display);
 
     output_layout = std::make_unique<wf::output_layout_t>(backend);


### PR DESCRIPTION
Close #2425 

If apps internally handle middle-click paste, there's nothing Wayfire can do about that: https://github.com/swaywm/sway/issues/4511#issuecomment-2561951039
