### PR TITLE
fix: decoration plugin title-bar/border height size issue

### DIFF
--- a/metadata/decoration.xml
+++ b/metadata/decoration.xml
@@ -13,11 +13,15 @@
 			<_short>Title bar height</_short>
 			<_long>Sets the height of the title bars in pixels.</_long>
 			<default>30</default>
+			<max>100</max>
+			<min>0</min>
 		</option>
 		<option name="border_size" type="int">
 			<_short>Border size</_short>
 			<_long>Sets the border size in pixels.</_long>
 			<default>4</default>
+			<max>100</max>
+			<min>0</min>
 		</option>
 		<option name="button_order" type="string">
 			<_short>Order of window buttons</_short>


### PR DESCRIPTION
close #2205 

Setting the title-bar or border height to 500 makes the view almost disappear, making wayfire unusable. The only fix is editing wayfire.ini from another desktop or compositor.

![wtf](https://github.com/user-attachments/assets/6fde7424-6271-4d4a-80a3-a2456c0e9bf0)

same for negative values, the view would disappear.

