### PR TITLE
Add keybinding to toggle tiling in current workspace

### DIFF
--- a/metadata/simple-tile.xml
+++ b/metadata/simple-tile.xml
@@ -30,15 +30,6 @@
 			<_long>Toggles tiling mode with the specified key.</_long>
 			<default>&lt;super&gt; KEY_T</default>
 		</option>
-		<option name="key_toggle_all" type="key">
-			<_short>Toggle tiling for all views</_short>
-			<_long>
-			Toggles tiling mode for all currently tileable views from the current workspace.
-			When enabled, eligible views are added to the tiling layout.
-			When disabled, tiled views are removed from the layout and maximized.
-			</_long>
-			<default>&lt;ctrl&gt;&lt;super&gt; KEY_T</default>
-		</option>
 		<option name="key_focus_left" type="key">
 			<_short>Key focus left</_short>
 			<_long>Moves focus to the window left with the specified key.</_long>
@@ -58,6 +49,15 @@
 			<_short>Key focus below</_short>
 			<_long>Moves focus to the window below with the specified key.</_long>
 			<default>&lt;super&gt; KEY_J</default>
+		</option>
+		<option name="key_toggle_current_ws" type="key">
+			<_short>Toggle tiling in current workspace</_short>
+			<_long>
+			Toggles tiling mode for all currently tileable views from the current workspace.
+			When enabled, eligible views are added to the tiling layout.
+			When disabled, tiled views are removed from the layout and maximized.
+			</_long>
+			<default>&lt;ctrl&gt;&lt;super&gt; KEY_T</default>
 		</option>
 		<option name="inner_gap_size" type="int">
 			<_short>Inner gap size</_short>

--- a/metadata/simple-tile.xml
+++ b/metadata/simple-tile.xml
@@ -33,7 +33,7 @@
 		<option name="key_toggle_all" type="key">
 			<_short>Toggle tiling for all views</_short>
 			<_long>
-			Toggles tiling mode for all currently tileable views.
+			Toggles tiling mode for all currently tileable views from the current workspace.
 			When enabled, eligible views are added to the tiling layout.
 			When disabled, tiled views are removed from the layout and maximized.
 			</_long>

--- a/metadata/simple-tile.xml
+++ b/metadata/simple-tile.xml
@@ -30,6 +30,15 @@
 			<_long>Toggles tiling mode with the specified key.</_long>
 			<default>&lt;super&gt; KEY_T</default>
 		</option>
+		<option name="key_toggle_all" type="key">
+			<_short>Toggle tiling for all views</_short>
+			<_long>
+			Toggles tiling mode for all currently tileable views.
+			When enabled, eligible views are added to the tiling layout.
+			When disabled, tiled views are removed from the layout and maximized.
+			</_long>
+			<default>&lt;ctrl&gt;&lt;super&gt; KEY_T</default>
+		</option>
 		<option name="key_focus_left" type="key">
 			<_short>Key focus left</_short>
 			<_long>Moves focus to the window left with the specified key.</_long>

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -276,36 +276,38 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
     {
         auto output = this->output;
         auto wset   = output->wset();
+        auto views = wset->get_views(wf::WSET_MAPPED_ONLY | wf::WSET_CURRENT_WORKSPACE);
         bool any_tiled = false;
-
-        for (auto& view : wset->get_views())
-        {
+    
+        for (auto& view : views)
+        {  
             if (tile::view_node_t::get_node(view))
             {
                 any_tiled = true;
                 break;
             }
         }
-
-        for (auto& view : wset->get_views())
-        {
-            if (!view->is_mapped() || !can_tile_view(view))
+     
+        for (auto& view : views)
+        {   
+            if (!can_tile_view(view))
             {
                 continue;
             }
-
+    
             auto node = tile::view_node_t::get_node(view);
             if (any_tiled && node)
             {
                 detach_view(view);
                 wf::get_core().default_wm->tile_request(view, 0);
                 wf::get_core().default_wm->tile_request(view, wf::TILED_EDGES_ALL);
-            } else if (!any_tiled && !node)
+            }
+            else if (!any_tiled && !node)
             {
                 attach_view(view);
             }
         }
-
+    
         return true;
     };
 

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -276,38 +276,37 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
     {
         auto output = this->output;
         auto wset   = output->wset();
-        auto views = wset->get_views(wf::WSET_MAPPED_ONLY | wf::WSET_CURRENT_WORKSPACE);
+        auto views  = wset->get_views(wf::WSET_MAPPED_ONLY | wf::WSET_CURRENT_WORKSPACE);
         bool any_tiled = false;
-    
+
         for (auto& view : views)
-        {  
+        {
             if (tile::view_node_t::get_node(view))
             {
                 any_tiled = true;
                 break;
             }
         }
-     
+
         for (auto& view : views)
-        {   
+        {
             if (!can_tile_view(view))
             {
                 continue;
             }
-    
+
             auto node = tile::view_node_t::get_node(view);
             if (any_tiled && node)
             {
                 detach_view(view);
                 wf::get_core().default_wm->tile_request(view, 0);
                 wf::get_core().default_wm->tile_request(view, wf::TILED_EDGES_ALL);
-            }
-            else if (!any_tiled && !node)
+            } else if (!any_tiled && !node)
             {
                 attach_view(view);
             }
         }
-    
+
         return true;
     };
 

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -274,9 +274,11 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
 
     wf::key_callback on_toggle_tile_current_ws = [=] (auto)
     {
+        auto last_focused_view = wf::get_core().seat->get_active_view();
         auto output = this->output;
         auto wset   = output->wset();
         auto views  = wset->get_views(wf::WSET_MAPPED_ONLY | wf::WSET_CURRENT_WORKSPACE);
+        
         bool any_tiled = false;
 
         for (auto& view : views)
@@ -307,6 +309,8 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
             }
         }
 
+        wf::get_core().default_wm->focus_raise_view(last_focused_view);
+        
         return true;
     };
 

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -272,40 +272,40 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
         });
     };
 
-    wf::key_callback on_toggle_tile_all = [=] (auto) 
+    wf::key_callback on_toggle_tile_all = [=] (auto)
     {
-        auto output = this->output; 
-        auto wset = output->wset(); 
+        auto output = this->output;
+        auto wset   = output->wset();
         bool any_tiled = false;
-    
-        for (auto& view : wset->get_views()) 
+
+        for (auto& view : wset->get_views())
         {
-            if (tile::view_node_t::get_node(view)) 
+            if (tile::view_node_t::get_node(view))
             {
                 any_tiled = true;
                 break;
             }
         }
-    
-        for (auto& view : wset->get_views()) 
+
+        for (auto& view : wset->get_views())
         {
-            if (!view->is_mapped() || !can_tile_view(view)) 
+            if (!view->is_mapped() || !can_tile_view(view))
             {
                 continue;
             }
-    
+
             auto node = tile::view_node_t::get_node(view);
-            if (any_tiled && node) 
+            if (any_tiled && node)
             {
                 detach_view(view);
                 wf::get_core().default_wm->tile_request(view, 0);
-                wf::get_core().default_wm->tile_request(view, wf::TILED_EDGES_ALL); 
-            } else if (!any_tiled && !node) 
+                wf::get_core().default_wm->tile_request(view, wf::TILED_EDGES_ALL);
+            } else if (!any_tiled && !node)
             {
                 attach_view(view);
             }
         }
-    
+
         return true;
     };
 

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -278,7 +278,7 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
         auto output = this->output;
         auto wset   = output->wset();
         auto views  = wset->get_views(wf::WSET_MAPPED_ONLY | wf::WSET_CURRENT_WORKSPACE);
-        
+
         bool any_tiled = false;
 
         for (auto& view : views)
@@ -310,7 +310,7 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
         }
 
         wf::get_core().default_wm->focus_raise_view(last_focused_view);
-        
+
         return true;
     };
 

--- a/plugins/tile/tile-plugin.cpp
+++ b/plugins/tile/tile-plugin.cpp
@@ -55,7 +55,7 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
     wf::option_wrapper_t<wf::buttonbinding_t> button_resize{"simple-tile/button_resize"};
 
     wf::option_wrapper_t<wf::keybinding_t> key_toggle_tile{"simple-tile/key_toggle"};
-    wf::option_wrapper_t<wf::keybinding_t> key_toggle_tile_all{"simple-tile/key_toggle_all"};
+    wf::option_wrapper_t<wf::keybinding_t> key_toggle_tile_current_ws{"simple-tile/key_toggle_current_ws"};
     wf::option_wrapper_t<wf::keybinding_t> key_focus_left{"simple-tile/key_focus_left"};
     wf::option_wrapper_t<wf::keybinding_t> key_focus_right{"simple-tile/key_focus_right"};
     wf::option_wrapper_t<wf::keybinding_t> key_focus_above{"simple-tile/key_focus_above"};
@@ -272,7 +272,7 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
         });
     };
 
-    wf::key_callback on_toggle_tile_all = [=] (auto)
+    wf::key_callback on_toggle_tile_current_ws = [=] (auto)
     {
         auto output = this->output;
         auto wset   = output->wset();
@@ -387,7 +387,7 @@ class tile_output_plugin_t : public wf::pointer_interaction_t, public wf::custom
         output->add_button(button_move, &on_move_view);
         output->add_button(button_resize, &on_resize_view);
         output->add_key(key_toggle_tile, &on_toggle_tiled_state);
-        output->add_key(key_toggle_tile_all, &on_toggle_tile_all);
+        output->add_key(key_toggle_tile_current_ws, &on_toggle_tile_current_ws);
 
         output->add_key(key_focus_left, &on_focus_adjacent);
         output->add_key(key_focus_right, &on_focus_adjacent);


### PR DESCRIPTION
close #2317

**feature:**
Toggles tiling mode for all currently tileable views from the current workspace. When enabled, eligible views are added to the tiling layout. 		When disabled, tiled views are removed from the layout and maximized