### PR TITLE
Add an option "core/auto_reload" to control whether to auto reload the config file

### DIFF
--- a/metadata/core.xml
+++ b/metadata/core.xml
@@ -98,5 +98,10 @@
 			<_long>Calls the shutdown routines for wayfire.</_long>
 			<default>&lt;ctrl&gt; &lt;alt&gt; KEY_BACKSPACE</default>
 		</option>
+		<option name="auto_reload" type="bool">
+			<_short>Auto-reload Config</_short>
+			<_long>Automatically reload the config file when it's modified.</_long>
+			<default>false</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/src/default-config-backend.cpp
+++ b/src/default-config-backend.cpp
@@ -16,6 +16,7 @@
 
 static std::string config_dir, config_file;
 wf::config::config_manager_t *cfg_manager;
+static int handle_config_updated(int fd, uint32_t mask, void *data);
 
 static int wd_cfg_dir, wd_cfg_file;
 
@@ -25,9 +26,95 @@ static void add_watch(int fd)
     wd_cfg_file = inotify_add_watch(fd, config_file.c_str(), IN_CLOSE_WRITE);
 }
 
-static void reload_config(int fd)
+static void reload_config()
 {
     wf::config::load_configuration_options_from_file(*cfg_manager, config_file);
+}
+
+static const char *CONFIG_FILE_ENV = "WAYFIRE_CONFIG_FILE";
+
+namespace wf
+{
+class dynamic_ini_config_t : public wf::config_backend_t
+{
+  private:
+    struct wl_event_source *inotify_evtsrc;
+    int inotify_fd = -1;
+
+  public:
+    void init(wl_display *display, config::config_manager_t& config,
+        const std::string& cfg_file) override
+    {
+        cfg_manager = &config;
+
+        config_file = choose_cfg_file(cfg_file);
+        std::filesystem::path path = std::filesystem::absolute(config_file);
+        config_dir = path.parent_path();
+        LOGI("Using config file: ", config_file.c_str());
+        setenv(CONFIG_FILE_ENV, config_file.c_str(), 1);
+
+        config = wf::config::build_configuration(
+            get_xml_dirs(), SYSCONFDIR "/wayfire/defaults.ini", config_file);
+
+        if (check_auto_reload_option(true))
+        {
+            inotify_fd = inotify_init1(IN_CLOEXEC);
+            add_watch(inotify_fd);
+
+            inotify_evtsrc = wl_event_loop_add_fd(wl_display_get_event_loop(display),
+                inotify_fd, WL_EVENT_READABLE, handle_config_updated, this);
+        }
+    }
+
+    std::string choose_cfg_file(const std::string& cmdline_cfg_file)
+    {
+        std::string env_cfg_file = nonull(getenv(CONFIG_FILE_ENV));
+        if (!cmdline_cfg_file.empty())
+        {
+            if ((env_cfg_file != nonull(NULL)) &&
+                (cmdline_cfg_file != env_cfg_file))
+            {
+                LOGW("Wayfire config file specified in the environment is ",
+                    "overridden by the command line arguments!");
+            }
+
+            return cmdline_cfg_file;
+        }
+
+        if (env_cfg_file != nonull(NULL))
+        {
+            return env_cfg_file;
+        }
+
+        std::string env_cfg_home = getenv("XDG_CONFIG_HOME") ?:
+            (std::string(nonull(getenv("HOME"))) + "/.config");
+
+        std::string vendored_cfg_file = env_cfg_home + "/wayfire/wayfire.ini";
+        if (std::filesystem::exists(vendored_cfg_file))
+        {
+            return vendored_cfg_file;
+        }
+
+        return env_cfg_home + "/wayfire.ini";
+    }
+
+    bool check_auto_reload_option(bool init)
+    {
+        wf::option_wrapper_t<bool> auto_reload{"core/auto_reload"};
+
+        if (auto_reload)
+        {
+            return true;
+        } else if (!init)
+        {
+            wl_event_source_remove(inotify_evtsrc);
+            close(inotify_fd);
+            inotify_fd = -1;
+        }
+
+        return false;
+    }
+};
 }
 
 static int handle_config_updated(int fd, uint32_t mask, void *data)
@@ -84,75 +171,15 @@ static int handle_config_updated(int fd, uint32_t mask, void *data)
     {
         LOGD("Reloading configuration file");
 
-        reload_config(fd);
+        reload_config();
         wf::reload_config_signal ev;
         wf::get_core().emit(&ev);
+
+        auto self = reinterpret_cast<wf::dynamic_ini_config_t*>(data);
+        self->check_auto_reload_option(false);
     }
 
     return 0;
-}
-
-static const char *CONFIG_FILE_ENV = "WAYFIRE_CONFIG_FILE";
-
-namespace wf
-{
-class dynamic_ini_config_t : public wf::config_backend_t
-{
-  public:
-    void init(wl_display *display, config::config_manager_t& config,
-        const std::string& cfg_file) override
-    {
-        cfg_manager = &config;
-
-        config_file = choose_cfg_file(cfg_file);
-        std::filesystem::path path = std::filesystem::absolute(config_file);
-        config_dir = path.parent_path();
-        LOGI("Using config file: ", config_file.c_str());
-        setenv(CONFIG_FILE_ENV, config_file.c_str(), 1);
-
-        config = wf::config::build_configuration(
-            get_xml_dirs(), SYSCONFDIR "/wayfire/defaults.ini", config_file);
-
-        int inotify_fd = inotify_init1(IN_CLOEXEC);
-        reload_config(inotify_fd);
-        add_watch(inotify_fd);
-
-        wl_event_loop_add_fd(wl_display_get_event_loop(display),
-            inotify_fd, WL_EVENT_READABLE, handle_config_updated, NULL);
-    }
-
-    std::string choose_cfg_file(const std::string& cmdline_cfg_file)
-    {
-        std::string env_cfg_file = nonull(getenv(CONFIG_FILE_ENV));
-        if (!cmdline_cfg_file.empty())
-        {
-            if ((env_cfg_file != nonull(NULL)) &&
-                (cmdline_cfg_file != env_cfg_file))
-            {
-                LOGW("Wayfire config file specified in the environment is ",
-                    "overridden by the command line arguments!");
-            }
-
-            return cmdline_cfg_file;
-        }
-
-        if (env_cfg_file != nonull(NULL))
-        {
-            return env_cfg_file;
-        }
-
-        std::string env_cfg_home = getenv("XDG_CONFIG_HOME") ?:
-            (std::string(nonull(getenv("HOME"))) + "/.config");
-
-        std::string vendored_cfg_file = env_cfg_home + "/wayfire/wayfire.ini";
-        if (std::filesystem::exists(vendored_cfg_file))
-        {
-            return vendored_cfg_file;
-        }
-
-        return env_cfg_home + "/wayfire.ini";
-    }
-};
 }
 
 DECLARE_WAYFIRE_CONFIG_BACKEND(wf::dynamic_ini_config_t);


### PR DESCRIPTION
This option is false by default.

Moved the "handle_config_updated" function so that it gets the necessary class definition. This makes the diff large...

Also removed an unneeded "reload_config" call in "init", and removed its unused argument.