### PR TITLE
Decoration plugin - add font color option

### DIFF
--- a/metadata/decoration.xml
+++ b/metadata/decoration.xml
@@ -9,6 +9,11 @@
 			<_long>Sets the font to use for the title bars.</_long>
 			<default>sans-serif</default>
 		</option>
+		<option name="font_color" type="color">
+			<_short>Font color</_short>
+			<_long>Sets the font color to use for the title bars.</_long>
+			<default>#ffffffff</default>
+		</option>
 		<option name="title_height" type="int">
 			<_short>Title bar height</_short>
 			<_long>Sets the height of the title bars in pixels.</_long>

--- a/plugins/decor/deco-theme.cpp
+++ b/plugins/decor/deco-theme.cpp
@@ -59,6 +59,7 @@ cairo_surface_t*decoration_theme_t::render_text(std::string text,
         return surface;
     }
 
+    wf::color_t color = font_color;
     auto cr = cairo_create(surface);
 
     const float font_scale = 0.8;
@@ -74,7 +75,7 @@ cairo_surface_t*decoration_theme_t::render_text(std::string text,
     layout = pango_cairo_create_layout(cr);
     pango_layout_set_font_description(layout, font_desc);
     pango_layout_set_text(layout, text.c_str(), text.size());
-    cairo_set_source_rgba(cr, 1, 1, 1, 1);
+    cairo_set_source_rgba(cr, color.r, color.g, color.b, color.a);
     pango_cairo_show_layout(cr, layout);
     pango_font_description_free(font_desc);
     g_object_unref(layout);

--- a/plugins/decor/deco-theme.hpp
+++ b/plugins/decor/deco-theme.hpp
@@ -66,6 +66,7 @@ class decoration_theme_t
 
   private:
     wf::option_wrapper_t<std::string> font{"decoration/font"};
+    wf::option_wrapper_t<wf::color_t> font_color{"decoration/font_color"};
     wf::option_wrapper_t<int> title_height{"decoration/title_height"};
     wf::option_wrapper_t<int> border_size{"decoration/border_size"};
     wf::option_wrapper_t<wf::color_t> active_color{"decoration/active_color"};


### PR DESCRIPTION
Simple change - one option for titlebar font color instead of hardcoded white,  to improve looks for light themes.