### PR TITLE
log config options changed via IPC

### DIFF
--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -281,6 +281,9 @@ class ipc_rules_utility_methods_t
             return wf::ipc::json_error("Options must be an object!");
         }
 
+        const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
+        std::string config_file_str = config_file ? config_file : "wayfire.ini";
+
         for (auto& option : data.get_member_names())
         {
             auto opt = wf::get_core().config->get_option(option);
@@ -304,6 +307,9 @@ class ipc_rules_utility_methods_t
                         std::string(json_to_string(data[option])) + "!");
                 }
             }
+            LOGW("Config option '", option, "' modified via IPC. ",
+                "Changes in ", config_file_str, " will not affect this option ",
+                "until Wayfire is restarted.");
 
             opt->set_locked(true);
         }

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -281,8 +281,7 @@ class ipc_rules_utility_methods_t
             return wf::ipc::json_error("Options must be an object!");
         }
 
-        const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
-        std::string config_file_str = config_file ? config_file : "wayfire.ini";
+
 
         for (auto& option : data.get_member_names())
         {
@@ -307,6 +306,10 @@ class ipc_rules_utility_methods_t
                         std::string(json_to_string(data[option])) + "!");
                 }
             }
+
+            const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
+            std::string config_file_str = config_file ? config_file : "wayfire.ini";
+
             LOGW("Config option '", option, "' modified via IPC. ",
                 "Changes in ", config_file_str, " will not affect this option ",
                 "until Wayfire is restarted.");


### PR DESCRIPTION
the output format:

`
 [plugins/ipc-rules/ipc-utility-methods.hpp:310] Config option 'core/plugins' modified via IPC. Changes in /home/username/.config/wayfire.ini will not affect this option until Wayfire is restarted.
`

I no longer need this since I migrated my wayfire.ini config to wayfire.toml. Still, this PR might help users understand the implications of setting config options via IPC.