### PR TITLE
render-manager: set output damage properly

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -349,6 +349,7 @@ struct swapchain_damage_manager_t
 
         frame_damage.clear();
         wlr_output_state_set_buffer(&next_frame->state, next_frame->buffer);
+        wlr_output_state_set_damage(&next_frame->state, const_cast<wf::region_t&>(swap_damage).to_pixman());
         wlr_buffer_unlock(next_frame->buffer);
 
         if (!wlr_output_test_state(output, &next_frame->state))


### PR DESCRIPTION
Not setting the swap damage can confuse wlroots, especially in the
wayland backend. Without this, zoom and similar don't work properly in
the wayland backend.

Fixes #2596
