### PR TITLE
Log config options set by IPC

### DIFF
--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -281,6 +281,9 @@ class ipc_rules_utility_methods_t
             return wf::ipc::json_error("Options must be an object!");
         }
 
+        const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
+        std::string config_file_str = config_file ? config_file : "wayfire.ini";
+
         for (auto& option : data.get_member_names())
         {
             auto opt = wf::get_core().config->get_option(option);
@@ -304,6 +307,9 @@ class ipc_rules_utility_methods_t
                         std::string(json_to_string(data[option])) + "!");
                 }
             }
+            LOGW("Config option '", option, "' modified via IPC. ",
+                "Changes in ", config_file_str, " will not affect this option ",
+                "until Wayfire is restarted.");
 
             opt->set_locked(true);
         }

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -23,6 +23,8 @@ class ipc_rules_utility_methods_t
   private:
     wlr_backend *headless_backend = NULL;
     std::set<uint64_t> our_outputs;
+    int warning_count = 0;
+    const int MAX_WARNINGS = 5;
 
   public:
     void init_utility_methods(ipc::method_repository_t *method_repository)
@@ -284,7 +286,11 @@ class ipc_rules_utility_methods_t
         const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
         std::string config_file_str = config_file ? config_file : "wayfire.ini";
   
-        LOGW("Config options set via IPC will not update from ", config_file_str, " until Wayfire restart.");
+        if (warning_count <= MAX_WARNINGS)
+        {
+            LOGW("Config options set via IPC will not update from ", config_file_str, " until Wayfire restart.");
+            warning_count++;
+        }
 
         for (auto& option : data.get_member_names())
         {

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -283,12 +283,13 @@ class ipc_rules_utility_methods_t
             return wf::ipc::json_error("Options must be an object!");
         }
 
-        const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
+        const char *config_file     = std::getenv("WAYFIRE_CONFIG_FILE");
         std::string config_file_str = config_file ? config_file : "wayfire.ini";
-  
+
         if (warning_count <= MAX_WARNINGS)
         {
-            LOGW("Config options set via IPC will not update from ", config_file_str, " until Wayfire restart.");
+            LOGW("Config options set via IPC will not update from ", config_file_str,
+                " until Wayfire restart.");
             warning_count++;
         }
 

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -281,7 +281,10 @@ class ipc_rules_utility_methods_t
             return wf::ipc::json_error("Options must be an object!");
         }
 
-
+        const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
+        std::string config_file_str = config_file ? config_file : "wayfire.ini";
+  
+        LOGW("Config options set via IPC will not update from ", config_file_str, " until Wayfire restart.");
 
         for (auto& option : data.get_member_names())
         {
@@ -306,13 +309,6 @@ class ipc_rules_utility_methods_t
                         std::string(json_to_string(data[option])) + "!");
                 }
             }
-
-            const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
-            std::string config_file_str = config_file ? config_file : "wayfire.ini";
-
-            LOGW("Config option '", option, "' modified via IPC. ",
-                "Changes in ", config_file_str, " will not affect this option ",
-                "until Wayfire is restarted.");
 
             opt->set_locked(true);
         }

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -281,8 +281,7 @@ class ipc_rules_utility_methods_t
             return wf::ipc::json_error("Options must be an object!");
         }
 
-        const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
-        std::string config_file_str = config_file ? config_file : "wayfire.ini";
+
 
         for (auto& option : data.get_member_names())
         {
@@ -307,6 +306,10 @@ class ipc_rules_utility_methods_t
                         std::string(json_to_string(data[option])) + "!");
                 }
             }
+
+            const char *config_file = std::getenv("WAYFIRE_CONFIG_FILE");
+            std::string config_file_str = config_file ? config_file : "wayfire.ini";
+
             LOGW("Config option '", option, "' modified via IPC. ",
                 "Changes in ", config_file_str, " will not affect this option ",
                 "until Wayfire is restarted.");


### PR DESCRIPTION
fixes https://github.com/WayfireWM/wayfire/issues/2707

**Message format:**
[plugins/ipc-rules/ipc-utility-methods.hpp:287] Config options set via IPC will not update from /home/myuser/.config/wayfire.ini until Wayfire restart
