### PR TITLE
feat: Add config reload delay option and refactor reload logic

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -93,5 +93,12 @@
 			<_long>Automatically reload the config file when it's modified.</_long>
 			<default>true</default>
 		</option>
+		<option name="config_reload_delay" type="int">
+			<_short>Config reload delay</_short>
+			<_long>Delay in milliseconds after a config file change before reloading.</_long>
+			<default>20</default>
+			<min>0</min>
+			<max>500</max>
+		</option>
 	</plugin>
 </wayfire>


### PR DESCRIPTION
Fixes #2493 and potentially other long standing issues related to config reload.

An open question is whether we want to set the default to something like 50 or leave it to 0 to keep the old behavior. Thoughts?
