### PR TITLE
Fix scanout on empty output

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -1048,6 +1048,10 @@ class wf::render_manager::impl
      */
     bool do_direct_scanout()
     {
+        auto views = output->wset()->get_views(wf::WSET_MAPPED_ONLY | wf::WSET_CURRENT_WORKSPACE);
+        if (views.empty()) {
+            return false;
+        }
         const bool can_scanout = !output_inhibit_counter && effects->can_scanout() &&
             postprocessing->can_scanout() && wlr_output_is_direct_scanout_allowed(output->handle) &&
             (icc_color_transform == nullptr);


### PR DESCRIPTION
Fix the following:
```
[render/allocator/gbm.c:146] Allocated 1920x1038 GBM buffer with format AR24 (0x34325241), modifier LINEAR (0x0000000000000000)
[render/vulkan/renderer.c:885] vulkan create_render_buffer: AR24, 1920x1038
[backend/drm/fb.c:147] Failed to get DMA-BUF from buffer
[backend/drm/drm.c:769] connector DP-2: Failed to import buffer for scan-out
```

This error mean, fullscreen in a view from DP-1 and do_direct_scanout on DP-2 which has no views (empty active workspace)