### PR TITLE
output-layout: Use the same transform for output as configured

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -89,32 +89,30 @@ class wlr_output_state_setter_t
 
 static wl_output_transform get_transform_from_string(std::string transform)
 {
-    // Most compositors like Sway and Weston use clockwise rotations.
-    // We try to follow the 'convention'.
     if (transform == "normal")
     {
         return WL_OUTPUT_TRANSFORM_NORMAL;
     } else if (transform == "90")
     {
-        return WL_OUTPUT_TRANSFORM_270;
+        return WL_OUTPUT_TRANSFORM_90;
     } else if (transform == "180")
     {
-        return WL_OUTPUT_TRANSFORM_270;
+        return WL_OUTPUT_TRANSFORM_180;
     } else if (transform == "270")
     {
-        return WL_OUTPUT_TRANSFORM_90;
+        return WL_OUTPUT_TRANSFORM_270;
     } else if (transform == "flipped")
     {
         return WL_OUTPUT_TRANSFORM_FLIPPED;
+    } else if (transform == "90_flipped")
+    {
+        return WL_OUTPUT_TRANSFORM_FLIPPED_90;
     } else if (transform == "180_flipped")
     {
         return WL_OUTPUT_TRANSFORM_FLIPPED_180;
-    } else if (transform == "90_flipped")
-    {
-        return WL_OUTPUT_TRANSFORM_FLIPPED_270;
     } else if (transform == "270_flipped")
     {
-        return WL_OUTPUT_TRANSFORM_FLIPPED_90;
+        return WL_OUTPUT_TRANSFORM_FLIPPED_270;
     }
 
     LOGE("Bad output transform in config: ", transform);


### PR DESCRIPTION
Before, we were using the wrong transforms i.e. the transform sent to wlroots and clients was not what was in the configuration file. Now we map the transform configuration input 1-1 to the actual transform used.