### PR TITLE
layer-shell: disconnect from unmapped commit handler on destroy

### DIFF
--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -450,6 +450,7 @@ void wayfire_layer_shell_view::handle_destroy()
     on_map.disconnect();
     on_unmap.disconnect();
     on_new_popup.disconnect();
+    on_commit_unmapped.disconnect();
     remove_anchored(true);
 }
 


### PR DESCRIPTION
This could happen in very rare cases like described in #2623. Probably
we need an animation to keep the layer-shell view alive while it is
being unmapped, then potentially mapped again but crash during the
sequence.

Fixes #2623
