### PR TITLE
surface-node: do not send frame events to unmapped surfaces

### DIFF
--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -111,11 +111,6 @@ wf::scene::wlr_surface_node_t::wlr_surface_node_t(wlr_surface *surface, bool aut
 
     this->on_surface_commit.set_callback([=] (void*)
     {
-        if (!wlr_surface_has_buffer(this->surface) && this->visibility.empty())
-        {
-            send_frame_done(false);
-        }
-
         if (this->autocommit)
         {
             apply_current_surface_state();


### PR DESCRIPTION
Fixes #2749.

@stefonarch Can you test with thunderbird too? I was reproducing this issue with `firefox -P`, but I hope thunderbird's issue is the same.
