### PR TITLE
workarounds: add keep_last_toplevel_activated option

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -88,6 +88,11 @@
 			<_long>Focus the main surface instead of popup menus. Works around some bugs in Qt-based apps related to copy-paste.</_long>
 			<default>false</default>
 		</option>
+		<option name="keep_last_toplevel_activated" type="bool">
+			<_short>Keep last focused toplevel activated</_short>
+			<_long>When a layer-shell view grabs keyboard focus, keep the last focused toplevel view as activated.</_long>
+			<default>true</default>
+		</option>
 		<option name="auto_reload_config" type="bool">
 			<_short>Auto-reload Config</_short>
 			<_long>Automatically reload the config file when it's modified.</_long>

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -86,6 +86,8 @@ wayfire_view wf::seat_t::get_active_view() const
 
 void wf::seat_t::impl::update_active_view(wf::scene::node_ptr new_focus)
 {
+    static wf::option_wrapper_t<bool> keep_last_focus_activated{"workarounds/keep_last_toplevel_activated"};
+
     auto view = node_to_view(new_focus);
     auto last_active = _last_active_view.lock();
     if (view.get() == last_active.get())
@@ -94,7 +96,7 @@ void wf::seat_t::impl::update_active_view(wf::scene::node_ptr new_focus)
     }
 
     LOGC(KBD, "Active view becomes ", view);
-    if ((view == nullptr) || toplevel_cast(view))
+    if ((view == nullptr) || toplevel_cast(view) || !keep_last_focus_activated)
     {
         auto last_toplevel = _last_active_toplevel.lock();
         if (last_toplevel.get() != view.get())


### PR DESCRIPTION
By default, if a grabbing layer-shell view is opened, Wayfire will keep the last focused toplevel activated. This makes it so that for example when you open bemenu, the focused view does change appearance. However, as seen in #1204, not everyone likes that. If you want to make sure that the currently focused toplevel loses the activated state when you open a keyboard-interactive layer-shell surface, set `workarounds/keep_last_toplevel_activated` to true.

Fixes #1204
