### PR TITLE
window-manager: do not ignore fullscreen requests when already fullscreen

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -612,6 +612,11 @@ void wf::start_move_view_to_wset(wayfire_toplevel_view v, std::shared_ptr<wf::wo
 
 void wf::move_view_to_output(wayfire_toplevel_view v, wf::output_t *new_output, bool reconfigure)
 {
+    if (v->get_output() == new_output)
+    {
+        return;
+    }
+
     wf::dassert(!v->parent, "Cannot move a dialog to a different output than its parent!");
 
     auto old_output = v->get_output();

--- a/src/core/window-manager.cpp
+++ b/src/core/window-manager.cpp
@@ -251,22 +251,14 @@ void window_manager_t::tile_request(wayfire_toplevel_view view,
 void window_manager_t::fullscreen_request(wayfire_toplevel_view view,
     wf::output_t *output, bool state, std::optional<wf::point_t> ws)
 {
-    if (view->toplevel()->pending().fullscreen == state)
-    {
-        return;
-    }
-
     wf::output_t *wo = output ?: (view->get_output() ?: wf::get_core().seat->get_active_output());
     const wf::point_t workspace = ws.value_or(wo->wset()->get_current_workspace());
     wf::dassert(wo != nullptr, "Fullscreening should not happen with null output!");
 
     /* TODO: what happens if the view is moved to the other output, but not
      * fullscreened? We should make sure that it stays visible there */
-    if (view->get_output() != wo)
-    {
-        // TODO: move_view_to_output seems like a good candidate for inclusion in window-manager
-        wf::move_view_to_output(view, wo, false);
-    }
+    // TODO: move_view_to_output seems like a good candidate for inclusion in window-manager
+    wf::move_view_to_output(view, wo, false);
 
     view_fullscreen_request_signal data;
     data.view  = view;


### PR DESCRIPTION
It could be that we request the view to be fullscreened on another
output, or on another workspace. The function might even be called to
readjust the geometry of a view which is already fullscreen.
