### PR TITLE
window-manager: Ignore unfullscreen requests if already windowed

### DIFF
--- a/src/core/window-manager.cpp
+++ b/src/core/window-manager.cpp
@@ -251,6 +251,11 @@ void window_manager_t::tile_request(wayfire_toplevel_view view,
 void window_manager_t::fullscreen_request(wayfire_toplevel_view view,
     wf::output_t *output, bool state, std::optional<wf::point_t> ws)
 {
+    if ((view->toplevel()->pending().fullscreen == state) && (state == false))
+    {
+        return;
+    }
+
     wf::output_t *wo = output ?: (view->get_output() ?: wf::get_core().seat->get_active_output());
     const wf::point_t workspace = ws.value_or(wo->wset()->get_current_workspace());
     wf::dassert(wo != nullptr, "Fullscreening should not happen with null output!");


### PR DESCRIPTION
This fixes dragging gtk4 apps with grid and/or wobbly disabled. The gtk4 toolkit sends a request for unfullscreen even though it is windowed, and this caused wayfire to set the geometry when dragging by titlebar, which made the window jump to an offset when grabbing the titlebar to move it. This was fixed before but broken by 60231d5d.