### PR TITLE
move-drag-interface: Fix move drag maximize snap off

### DIFF
--- a/plugins/common/move-drag-interface.cpp
+++ b/plugins/common/move-drag-interface.cpp
@@ -415,6 +415,7 @@ void core_drag_t::handle_motion(wf::point_t to)
                 set_tiled_wobbly(v.view, false);
             }
 
+            update_current_output(to);
             snap_off_signal data;
             data.focus_output = current_output;
             emit(&data);


### PR DESCRIPTION
We were sending a null output because the current output is not updated until after the snapoff signal is sent. Fix this by updating the output to the location of the grab when snapping off.