### PR TITLE
output-layout: Move output request state handler from render-manager to output-layout

### DIFF
--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -38,7 +38,6 @@ struct swapchain_damage_manager_t
 
     wf::wl_listener_wrapper on_needs_frame;
     wf::wl_listener_wrapper on_damage;
-    wf::wl_listener_wrapper on_request_state;
     wf::wl_listener_wrapper on_gamma_changed;
 
     wf::region_t frame_damage;
@@ -125,14 +124,6 @@ struct swapchain_damage_manager_t
             damage_buffer(rotated, true);
         });
 
-        on_request_state.set_callback([=] (void *data)
-        {
-            auto ev = static_cast<wlr_output_event_request_state*>(data);
-            wlr_output_commit_state(output->handle, ev->state);
-            damage_whole();
-            schedule_repaint();
-        });
-
         on_gamma_changed.set_callback([=] (void *data)
         {
             auto event = (const wlr_gamma_control_manager_v1_set_gamma_event*)data;
@@ -145,7 +136,6 @@ struct swapchain_damage_manager_t
 
         on_needs_frame.connect(&output->handle->events.needs_frame);
         on_damage.connect(&output->handle->events.damage);
-        on_request_state.connect(&output->handle->events.request_state);
         on_gamma_changed.connect(&wf::get_core().protocols.gamma_v1->events.set_gamma);
     }
 


### PR DESCRIPTION
This fixes i.e. wlr-randr always reporting the mode dimensions in config wayland backend WL-1. This also fixes direct scanout criteria for client geometry must match output geometry.