### PR TITLE
output/layout: move 'loaded mode' message to debug logging

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -528,9 +528,6 @@ struct output_layout_output_t
         wf::output_config::mode_t mode = mode_opt;
         wlr_output_mode tmp;
 
-        LOGD("loaded mode ",
-            ((wf::option_sptr_t<wf::output_config::mode_t>)mode_opt)->get_value_str());
-
         switch (mode.get_type())
         {
           case output_config::MODE_AUTO:

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -528,7 +528,7 @@ struct output_layout_output_t
         wf::output_config::mode_t mode = mode_opt;
         wlr_output_mode tmp;
 
-        LOGI("loaded mode ",
+        LOGD("loaded mode ",
             ((wf::option_sptr_t<wf::output_config::mode_t>)mode_opt)->get_value_str());
 
         switch (mode.get_type())


### PR DESCRIPTION
The 'loaded mode' message is emitted during output initialization when enumerating available display modes. Since backend/drm/drm.c already handles that info, repeating this information at INFO level in Wayfire results in redundant output.

Fix #2787


