### PR TITLE
pointer: re-start implicit grab on subsequent button press

### DIFF
--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -243,7 +243,7 @@ void wf::pointer_t::check_implicit_grab()
 {
     /* start a button held grab, so that the window will receive all the
      * subsequent events, no matter what happens */
-    if ((count_pressed_buttons == 1) && cursor_focus)
+    if ((count_pressed_buttons >= 1) && cursor_focus)
     {
         grab_surface(cursor_focus);
     }


### PR DESCRIPTION
Fixes #2759
Fixes #2760

It is possible that for example the move operation is aborted while a button is still pressed. In IPC scenarios, this can lead to a button being stuck while pressed (and in real usage it is possible that a user uses a different button while holding the first one). In such cases, we still want to start an implicit grab on the second button, as we don't have an implicit grab from the first button anymore due to the node being gone.
