### PR TITLE
Fix black screen on DPMS-on: Emit config change before damage

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -990,8 +990,8 @@ struct output_layout_output_t
             pending_state.commit(handle);
 
             ensure_wayfire_output(get_effective_size());
-            output->render->damage_whole();
             emit_configuration_changed(changed_fields);
+            output->render->damage_whole();
         } else /* state.source == OUTPUT_IMAGE_SOURCE_MIRROR */
         {
             destroy_wayfire_output();


### PR DESCRIPTION
I need to test it for a while.

I assume you're already aware of why this may fix, so no explanation is necessary.

fix #2793 #2494