### PR TITLE
IPC method to list all config options

### DIFF
--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -120,16 +120,21 @@ class ipc_rules_utility_methods_t
 
     wf::ipc::method_callback list_config_options = [=] (const wf::json_t& data)
     {
-        auto response     = wf::ipc::json_ok();
-        auto options_json = wf::json_t::array();
+        auto response = wf::ipc::json_ok();
+        wf::json_t sections_json;
+        sections_json = wf::json_t();
 
         for (auto& section : wf::get_core().config->get_all_sections())
         {
+            std::string section_name = section->get_name();
+            wf::json_t section_obj;
+            section_obj = wf::json_t();
+
             for (auto& opt : section->get_registered_options())
             {
                 wf::json_t entry;
-                entry["name"]    = opt->get_name();
-                entry["section"] = section->get_name();
+                entry = wf::json_t();
+                std::string option_name = opt->get_name();
 
                 auto compound = std::dynamic_pointer_cast<wf::config::compound_option_t>(opt);
                 if (compound)
@@ -154,11 +159,13 @@ class ipc_rules_utility_methods_t
                     entry["default"] = opt->get_default_value_str();
                 }
 
-                options_json.append(entry);
+                section_obj[option_name] = entry;
             }
+
+            sections_json[section_name] = section_obj;
         }
 
-        response["options"] = options_json;
+        response["options"] = sections_json;
         return response;
     };
 

--- a/plugins/ipc-rules/ipc-utility-methods.hpp
+++ b/plugins/ipc-rules/ipc-utility-methods.hpp
@@ -43,6 +43,7 @@ class ipc_rules_utility_methods_t
         method_repository->unregister_method("wayfire/create-headless-output");
         method_repository->unregister_method("wayfire/destroy-headless-output");
         method_repository->unregister_method("wayfire/get-config-option");
+        method_repository->unregister_method("wayfire/list-config-options");
         method_repository->unregister_method("wayfire/set-config-option");
         method_repository->unregister_method("wayfire/get-keyboard-state");
         method_repository->unregister_method("wayfire/set-keyboard-state");

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -528,9 +528,6 @@ struct output_layout_output_t
         wf::output_config::mode_t mode = mode_opt;
         wlr_output_mode tmp;
 
-        LOGD("loaded mode ",
-            ((wf::option_sptr_t<wf::output_config::mode_t>)mode_opt)->get_value_str());
-
         switch (mode.get_type())
         {
           case output_config::MODE_AUTO:

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -528,7 +528,7 @@ struct output_layout_output_t
         wf::output_config::mode_t mode = mode_opt;
         wlr_output_mode tmp;
 
-        LOGI("loaded mode ",
+        LOGD("loaded mode ",
             ((wf::option_sptr_t<wf::output_config::mode_t>)mode_opt)->get_value_str());
 
         switch (mode.get_type())


### PR DESCRIPTION
There is no straightforward or optimal method to list all configuration options via IPC.

This would help debug Wayfire issues by providing a full list of current options instead of relying on the config file, which scripts may have altered during the session.

Another use case: if a user has many options set and needs to verify whether the current config remains unchanged, for instance, after restarting an app that must decide whether to reapply settings, a complete option list simplifies comparison and skipping. I’m sure there are even more applications, personally, I find it quite useful.


```
In [3]: sock.list_config_options()["options"]["expo"]
Out[3]: 
{'background': {'value': '#01010180', 'default': '#1A1A1AFF'},
 'duration': {'value': '300ms circle', 'default': '300ms circle'},
 'inactive_brightness': {'value': '0.700000', 'default': '0.700000'},
 'keyboard_interaction': {'value': 'true', 'default': 'true'},
 'offset': {'value': '10', 'default': '10'},
 'toggle': {'value': '<super> KEY_E', 'default': '<super> KEY_E'},
 'transition_length': {'value': '100', 'default': '200'},
 'workspace_bindings': {'value': []}}

In [4]: sock.list_config_options()["result"]
Out[4]: 'ok'

In [5]: len(sock.list_config_options()["options"])
Out[5]: 94
```