### PR TITLE
Prevent use-after-free in auxilliary_buffer_t

### DIFF
--- a/src/render.cpp
+++ b/src/render.cpp
@@ -24,11 +24,8 @@ wf::auxilliary_buffer_t& wf::auxilliary_buffer_t::operator =(auxilliary_buffer_t
         return *this;
     }
 
-    this->texture = other.texture;
-    this->buffer  = other.buffer;
-    other.buffer.buffer = NULL;
-    other.texture     = NULL;
-    other.buffer.size = {0, 0};
+    this->texture = std::exchange(other.texture, nullptr);
+    this->buffer  = std::exchange(other.buffer, {});
     return *this;
 }
 


### PR DESCRIPTION
I'm not sure you want this, but it does look cleaner and safer than the old way.
   
```
this->texture = other.texture; 
this->buffer  = other.buffer;    
other.buffer.buffer = NULL;     
```

Old code seems unsafe and confusing? It copies the buffer first, then sets the original to NULL