### PR TITLE
New xdg_shell_stable surface log fix

### DIFF
--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -528,9 +528,6 @@ struct output_layout_output_t
         wf::output_config::mode_t mode = mode_opt;
         wlr_output_mode tmp;
 
-        LOGD("loaded mode ",
-            ((wf::option_sptr_t<wf::output_config::mode_t>)mode_opt)->get_value_str());
-
         switch (mode.get_type())
         {
           case output_config::MODE_AUTO:

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -528,7 +528,7 @@ struct output_layout_output_t
         wf::output_config::mode_t mode = mode_opt;
         wlr_output_mode tmp;
 
-        LOGI("loaded mode ",
+        LOGD("loaded mode ",
             ((wf::option_sptr_t<wf::output_config::mode_t>)mode_opt)->get_value_str());
 
         switch (mode.get_type())

--- a/src/view/xdg-shell/xdg-toplevel-view.cpp
+++ b/src/view/xdg-shell/xdg-toplevel-view.cpp
@@ -26,7 +26,6 @@
 wf::xdg_toplevel_view_base_t::xdg_toplevel_view_base_t(wlr_xdg_toplevel *toplevel, bool autocommit)
 {
     this->xdg_toplevel = toplevel;
-    LOGI("new xdg_shell_stable surface: ", xdg_toplevel->title, " app-id: ", xdg_toplevel->app_id);
 
     this->main_surface = std::make_shared<scene::wlr_surface_node_t>(toplevel->base->surface, autocommit);
 
@@ -43,8 +42,15 @@ wf::xdg_toplevel_view_base_t::xdg_toplevel_view_base_t(wlr_xdg_toplevel *topleve
     on_set_app_id.set_callback([&] (void*)
     {
         handle_app_id_changed(nonull(xdg_toplevel->app_id));
+
+        on_set_title.set_callback([&] (void*)
+        {
+            LOGI("new xdg_shell_stable surface: ",  "(title: '", xdg_toplevel->title, "' app-id: '", xdg_toplevel->app_id, "')");
+        });
+
     });
     on_ping_timeout.set_callback([&] (void*)
+
     {
         wf::view_implementation::emit_ping_timeout_signal(self());
     });


### PR DESCRIPTION
Not sure you will like the log in a set_callback but the result is this:

```
II 2025-09-09 11:55:17.631 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: 'fish' app-id: 'kitty')
II 2025-09-09 11:55:17.642 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: '~' app-id: 'kitty')
II 2025-09-09 11:55:17.932 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: 'kitty' app-id: 'kitty')
II 2025-09-09 11:55:18.021 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: 'fish' app-id: 'kitty')
II 2025-09-09 11:55:18.029 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: '~' app-id: 'kitty')
II 2025-09-09 11:55:20.534 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: 'neo - Thunar' app-id: 'thunar')
II 2025-09-09 11:55:24.205 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: 'FVD Speed Dial - Most Visited - Chromium' app-id: 'chromium')
II 2025-09-09 11:55:24.452 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: 'chrome://newtab - Chromium' app-id: 'chromium')
II 2025-09-09 11:55:24.648 - [src/view/xdg-shell/xdg-toplevel-view.cpp:48] new xdg_shell_stable surface: (title: 'FVD Speed Dial - Most Visited - Chromium' app-id: 'chromium')
```


before that, was just [src/view/xdg-shell/xdg-toplevel-view.cpp:29] new xdg_shell_stable surface: (null) app-id: (null)