### PR TITLE
Fix scale deactivate refocus

### DIFF
--- a/plugins/scale/scale.cpp
+++ b/plugins/scale/scale.cpp
@@ -1390,11 +1390,10 @@ class wayfire_scale : public wf::per_output_plugin_instance_t,
             }
         }
 
-        if (output == wf::get_core().seat->get_active_output() && current_focus_view)
+        if ((output == wf::get_core().seat->get_active_output()) && current_focus_view)
         {
             refocus();
-        }
-        else if (current_focus_view)
+        } else if (current_focus_view)
         {
             wf::view_bring_to_front(current_focus_view);
         }


### PR DESCRIPTION
```
output_id_a = 1
output_id_b = 2

sock.scale_toggle(output_id_b) #from output_id_a will turn output_id_b the focused output
```

The pr goal is to prevent output_id_a losing focus and keep the current focused view

