### PR TITLE
Send view to back / bring forward

### DIFF
--- a/metadata/wm-actions.xml
+++ b/metadata/wm-actions.xml
@@ -39,5 +39,10 @@
 			<_long>Send the active view to behind all other views.</_long>
 			<default>disabled</default>
 		</option>
+		<option name="bring_to_front" type="activator">
+			<_short>Bring to front</_short>
+			<_long>Raise the active view above all other views.</_long>
+			<default>disabled</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/wm-actions/wm-actions.cpp
+++ b/plugins/wm-actions/wm-actions.cpp
@@ -14,6 +14,7 @@
 #include "wayfire/signal-definitions.hpp"
 #include "wayfire/signal-provider.hpp"
 #include "wayfire/toplevel-view.hpp"
+#include <wayfire/view-helpers.hpp>
 #include "wayfire/window-manager.hpp"
 #include "wayfire/seat.hpp"
 #include "wayfire/nonstd/reverse.hpp"
@@ -48,6 +49,8 @@ class wayfire_wm_actions_output_t : public wf::per_output_plugin_instance_t
         "wm-actions/toggle_sticky"};
     wf::option_wrapper_t<wf::activatorbinding_t> send_to_back{
         "wm-actions/send_to_back"};
+    wf::option_wrapper_t<wf::activatorbinding_t> bring_to_front{
+        "wm-actions/bring_to_front"};
 
     wf::plugin_activation_data_t grab_interface = {
         .name = "wm-actions",
@@ -339,6 +342,15 @@ class wayfire_wm_actions_output_t : public wf::per_output_plugin_instance_t
         });
     };
 
+    wf::activator_callback on_bring_to_front = [=] (auto ev) -> bool
+    {
+        return execute_for_selected_view(ev.source, [this] (wayfire_view view)
+        {
+            view_bring_to_front(view);
+            return true;
+        });
+    };
+
     void disable_showdesktop()
     {
         view_set_output.disconnect();
@@ -369,6 +381,7 @@ class wayfire_wm_actions_output_t : public wf::per_output_plugin_instance_t
         output->add_activator(toggle_fullscreen, &on_toggle_fullscreen);
         output->add_activator(toggle_sticky, &on_toggle_sticky);
         output->add_activator(send_to_back, &on_send_to_back);
+        output->add_activator(bring_to_front, &on_bring_to_front);
         output->connect(&on_set_above_state_signal);
         output->connect(&on_view_minimized);
         wf::get_core().connect(&on_view_output_changed);
@@ -391,6 +404,7 @@ class wayfire_wm_actions_output_t : public wf::per_output_plugin_instance_t
         output->rem_binding(&on_toggle_fullscreen);
         output->rem_binding(&on_toggle_sticky);
         output->rem_binding(&on_send_to_back);
+        output->rem_binding(&on_bring_to_front);
     }
 };
 


### PR DESCRIPTION
#1269 discussed adding activators for sending a view to back or raise ot to the front, but in PR #1270 only the send-to-back functionality was added. This PR adds the missing bring-to-front functionality. Additionally it changes the focus behavior of send-to-back to focus the view which is under the cursor after the stacking change, which seems to be more natural, causing less unexpected focus changes.

This is useful with focus-follows-mouse and overlapping floating views. When core.focus_buttons is set appropriately it allows typing and copy/paste in partially obscured views, which results in more productive use of screen real estate. But when typing in a partially obscured view it is desirable to be able to raise the view using a keyboard action instead of the mouse.

@JordanL2 if you wish to comment
