### PR TITLE
Prevent sending views to non-existent workspace sets

### DIFF
--- a/plugins/single_plugins/wsets.cpp
+++ b/plugins/single_plugins/wsets.cpp
@@ -93,12 +93,13 @@ class wayfire_wsets_plugin_t : public wf::plugin_interface_t
             return wf::ipc::json_error("view not found");
         }
 
-        auto all_wsets = wf::workspace_set_t::get_all();
+        auto all_wsets    = wf::workspace_set_t::get_all();
         auto target_index = static_cast<uint64_t>(wset_index);
         auto it = std::find_if(all_wsets.begin(), all_wsets.end(),
-            [&] (auto wset) { 
-                return wset->get_index() == target_index; 
-            });
+            [&] (auto wset)
+        {
+            return wset->get_index() == target_index;
+        });
 
         if (it == all_wsets.end())
         {


### PR DESCRIPTION

We could use `sock.send_view_to_wset(id, non_existent_wset_index)` to hide a view, but this may confuse those unfamiliar with IPC. 

They might set the wrong index and the view would disappear. I recommend either logging when a view is sent to a nonexistent wset index or disabling the option entirely like in the PR.