### PR TITLE
xdg-popup: fix focus_main_surface_instead_of_popup for non-focusable parents

### DIFF
--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -421,7 +421,10 @@ wlr_surface*wayfire_xdg_popup::get_keyboard_focus_surface()
     {
         if (auto parent = this->popup_parent.lock())
         {
-            return parent->get_keyboard_focus_surface();
+            if (auto parent_focus = parent->get_keyboard_focus_surface())
+            {
+                return parent_focus;
+            }
         }
     }
 


### PR DESCRIPTION
Ref #2600

@tsujan Waiting for you to confirm this doesn't cause unforeseen issues.
