### PR TITLE
place: add "pointer" mode

### DIFF
--- a/metadata/place.xml
+++ b/metadata/place.xml
@@ -24,6 +24,10 @@
 				<value>random</value>
 				<_name>Random</_name>
 			</desc>
+			<desc>
+				<value>pointer</value>
+				<_name>Pointer</_name>
+			</desc>
 		</option>
 	</plugin>
 </wayfire>

--- a/plugins/single_plugins/place.cpp
+++ b/plugins/single_plugins/place.cpp
@@ -83,6 +83,9 @@ class wayfire_place_window : public wf::plugin_interface_t
         } else if (mode == "random")
         {
             random(view, workarea);
+        } else if (mode == "pointer")
+        {
+            pointer(view, workarea);
         } else
         {
             center(view, workarea);
@@ -157,6 +160,24 @@ class wayfire_place_window : public wf::plugin_interface_t
         wf::geometry_t window = view->get_pending_geometry();
         view->toplevel()->pending().geometry.x = workarea.x + (workarea.width / 2) - (window.width / 2);
         view->toplevel()->pending().geometry.y = workarea.y + (workarea.height / 2) - (window.height / 2);
+    }
+
+    void pointer(wayfire_toplevel_view & view, wf::geometry_t workarea)
+    {
+        wf::output_t *output = view->get_output();
+        if (!output)
+        {
+            return;
+        }
+
+        wf::point_t pos = output->get_cursor_position().round_down();
+        wf::geometry_t window = view->get_pending_geometry();
+        window.x = workarea.x + std::clamp(pos.x - window.width / 2,
+            0, workarea.width - window.width);
+        window.y = workarea.y + std::clamp(pos.y - window.height / 2,
+            0, workarea.height - window.height);
+        view->toplevel()->pending().geometry.x = window.x;
+        view->toplevel()->pending().geometry.y = window.y;
     }
 
     void maximize(wayfire_toplevel_view & view, wf::geometry_t workarea)


### PR DESCRIPTION
This adds a new mode to the "place" plug-in to position new windows centered under the mouse pointer, while keeping them fully within the workarea.

The advantage is that the user can control where the new window would be placed by pointing the mouse before starting an app (might be useless when starting apps from a panel, but works well when using wofi or starting apps via key binding, e.g. terminal). And the user can immediately interact with the new window or move it out of the way with minimal mouse effort.

No idea what this would do in a mouseless, touch-screen scenario.
