### PR TITLE
window-rules: allow using X11-style geometry

### DIFF
--- a/plugins/window-rules/view-action-interface.hpp
+++ b/plugins/window-rules/view-action-interface.hpp
@@ -33,6 +33,7 @@ class view_action_interface_t : public action_interface_t
         std::size_t position);
     std::tuple<bool, int> _expect_int(const std::vector<variant_t> & args,
         std::size_t position);
+    std::optional<wf::geometry_t> _parse_x11_geometry(std::string geometry);
 
     std::tuple<bool, float> _validate_alpha(const std::vector<variant_t> & args);
     std::tuple<bool, int, int, int, int> _validate_geometry(


### PR DESCRIPTION
As an alternative to integer x/y/w/h geometry, allow an X11-style geometry "WxH+x-y" as string value for the "set geometry" action.

It has two advantages:
- it allows the window position to be specified from the right or bottom edge of the workarea (e.g. "-0-0" puts the view into the lower right corner)
- it allows to specify the positon without changing the size (use the applications default size)

Maybe use of the X11 geometry syntax is controversial, but this functionality is missing, I hope it could be added to wayfire in one way or other.
