### PR TITLE
Link all symbols from wf-json library

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -66,7 +66,7 @@ wayfire_sources = ['geometry.cpp',
 wayfire_dependencies = [wayland_server, wlroots, xkbcommon, libinput,
                        pixman, drm, egl, glesv2, glm, wf_protos, libdl,
                        wfconfig, libinotify, backtrace, wfutils, xcb,
-                       wftouch, json, udev]
+                       wftouch, udev]
 
 if conf_data.get('BUILD_WITH_IMAGEIO')
     wayfire_dependencies += [jpeg, png]
@@ -114,7 +114,7 @@ git_branch_info = vcs_tag(
 # First build a static library of all sources, so that it can be reused
 # in tests
 libwayfire_sta = static_library('libwayfire', wayfire_sources,
-    dependencies: wayfire_dependencies,
+    dependencies: [wayfire_dependencies, json.as_link_whole()],
     include_directories: [wayfire_conf_inc, wayfire_api_inc],
     cpp_args: debug_arguments,
     install: false, cpp_pch: 'pch/pch.h')


### PR DESCRIPTION
When using i.e. `wf::ipc_activator_t` in external plugins, they will not load due to missing symbols such as this:

`libpixdecor.so: undefined symbol: _ZNK2wf16json_reference_t9is_uint64Ev`

This is due to the fact that `wayfire/plugins/ipc/ipc-activator.hpp` ultimately includes `subprojects/wf-json/wayfire/nonstd/json.hpp` which houses declaration of functions but not the definitions. The definitions are in the static library wf-json. However, if we do not link whole, even though external plugins still compile, they fail to load at runtime. Linking whole means the symbols are avaialable at runtime because they are included in the wayfire binary.

Note that we cannot merely use json.link_as_whole() in wayfire dependencies list, as we will get multiple definition erros at link time. So, we directly include it in the dependencies for the wayfire static library, and this fixes the problem.