### PR TITLE
Use partial_dependency for wf-json library

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -63,10 +63,11 @@ wayfire_sources = ['geometry.cpp',
                    'output/workspace-stream.cpp',
                    'output/workspace-impl.cpp']
 
+json_flags = json.partial_dependency(compile_args: true, includes: true, link_args: true)
 wayfire_dependencies = [wayland_server, wlroots, xkbcommon, libinput,
                        pixman, drm, egl, glesv2, glm, wf_protos, libdl,
                        wfconfig, libinotify, backtrace, wfutils, xcb,
-                       wftouch, json, udev]
+                       wftouch, json_flags, udev]
 
 if conf_data.get('BUILD_WITH_IMAGEIO')
     wayfire_dependencies += [jpeg, png]
@@ -114,7 +115,7 @@ git_branch_info = vcs_tag(
 # First build a static library of all sources, so that it can be reused
 # in tests
 libwayfire_sta = static_library('libwayfire', wayfire_sources,
-    dependencies: wayfire_dependencies,
+    dependencies: [wayfire_dependencies, json.as_link_whole()],
     include_directories: [wayfire_conf_inc, wayfire_api_inc],
     cpp_args: debug_arguments,
     install: false, cpp_pch: 'pch/pch.h')


### PR DESCRIPTION
When using i.e. wf::ipc_activator_t in external plugins, they will not load due to missing symbols such as this:

libpixdecor.so: undefined symbol: _ZNK2wf16json_reference_t9is_uint64Ev

This is due to the fact that wayfire/plugins/ipc/ipc-activator.hpp ultimately includes subprojects/wf-json/wayfire/nonstd/json.hpp which houses declaration of functions but not the definitions. The definitions are in the static library wf-json. However, without this patch, even though external plugins still compile, they fail to load at runtime (unless some other plugin is loaded that provides the symbols).

Co-authored-by: Ilia Bozhinov <ammen99@gmail.com>