### PR TITLE
layer-shell: fix crash with too large margins

### DIFF
--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -630,6 +630,7 @@ void wayfire_layer_shell_view::configure(wf::geometry_t box)
     {
         LOGE("layer-surface has calculated width and height < 0");
         close();
+        return;
     }
 
     // TODO: transactions here could make sense, since we want to change x,y,w,h together, but have to wait


### PR DESCRIPTION
Fixes #2926 

Avoid trying to position a view after it is closed due to setting too large margins (set on opposite screen edges and larger in total than the screen size).

Note: I was wondering if closing the view is the best course of action here, since this could happen to an "innocent" app due to a race between it setting the margin and changing output geometry. However, the protocol actually says quite explicitly that apps should be prepared to have their surface closed and try to create a new surface instead: https://wayland.app/protocols/wlr-layer-shell-unstable-v1#zwlr_layer_surface_v1:event:closed -- so likely it is OK (even though some clients might not be prepared for it).