### PR TITLE
output-layout: Add different automatic modes

### DIFF
--- a/include/wayfire/config/types.hpp
+++ b/include/wayfire/config/types.hpp
@@ -506,19 +506,12 @@ enum mode_type_t
 struct mode_t
 {
     /**
-     * Initialize an OFF or AUTO mode.
+     * Initialize a mode.
      *
-     * @param auto_on If true, the created mode will be an AUTO mode.
+     * @param mode One of: MODE_AUTO, MODE_HIGHRR, MODE_HIGHRES, MODE_OFF. MODE_HIGHRR prioritizes refresh rate, MODE_HIGHRES prioritises resolution and MODE_AUTO chooses whatever the display tells it to use.
+     * @throws std::invalid_argument if the mode isn't MODE_AUTO, MODEHIGHRR, MODEHIGHRES or MODE_OFF.
      */
-    mode_t(bool auto_on = false);
-
-    /**
-     * Initialize an alternative AUTO mode.
-     *
-     * @param auto_on Must be true in order to choose an alternative mode. Otherwise always OFF mode.
-     * @param prioritize_res If true, the created mode will be an HIGHRES mode. Otherwise, HIGHRR.
-     */
-    mode_t(int prioritize_res = 3);
+    mode_t(output_config::mode_type_t mode);
 
     /**
      * Initialize the mode with source self.

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1067,14 +1067,11 @@ std::string wf::option_type::to_string(
 }
 
 /* ------------------------- Output config types ---------------------------- */
-wf::output_config::mode_t::mode_t(bool auto_on)
+wf::output_config::mode_t::mode_t(output_config::mode_type_t mode)
 {
-    this->type = auto_on ? MODE_AUTO : MODE_OFF;
-}
-
-wf::output_config::mode_t::mode_t(int prioritize_res)
-{
-    this->type = prioritize_res == 3 ? MODE_HIGHRES : MODE_HIGHRR;
+    if(mode == MODE_RESOLUTION || mode == MODE_MIRROR)
+        throw std::invalid_argument("Invalid mode definition");
+    this->type = mode;
 }
 
 wf::output_config::mode_t::mode_t(int32_t width, int32_t height, int32_t refresh)
@@ -1152,22 +1149,22 @@ std::optional<wf::output_config::mode_t> wf::option_type::from_string(
 {
     if (string == "off")
     {
-        return wf::output_config::mode_t{false};
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_OFF};
     }
 
     if ((string == "auto") || (string == "default"))
     {
-        return wf::output_config::mode_t{true};
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_AUTO};
     }
 
     if ((string == "highres"))
     {
-        return wf::output_config::mode_t{3};
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_HIGHRES};
     }
 
     if ((string == "highrr"))
     {
-        return wf::output_config::mode_t{2};
+        return wf::output_config::mode_t{wf::output_config::mode_type_t::MODE_HIGHRR};
     }
 
     if (string.substr(0, 6) == "mirror")

--- a/test/types_test.cpp
+++ b/test/types_test.cpp
@@ -416,11 +416,11 @@ TEST_CASE("wf::output_config::mode_t")
     using namespace wf::output_config;
 
     std::vector<mt> modes = {
-        mt{3},
-        mt{2},
-        mt{true},
-        mt{true},
-        mt{false},
+        mt{MODE_HIGHRES},
+        mt{MODE_HIGHRR},
+        mt{MODE_AUTO},
+        mt{MODE_AUTO},
+        mt{MODE_OFF},
         mt{1920, 1080, 0},
         mt{1920, 1080, 59000},
         mt{1920, 1080, 59000},


### PR DESCRIPTION
This adds two extra `AUTO` modes, whose behaviors differ from the main `AUTO` one.

`AUTO_HIGHRR` checks which mode has the highest refresh rate, then find the highest resolution which can still provide the refresh rate.

`AUTO_HIGHRES` just chooses the highest resolution mode available (which matches `AUTO` if no preferred video mode is specified by the display).

Depends on https://github.com/WayfireWM/wf-config/pull/87