### PR TITLE
window-rules: fix view-action-interface output detection logic

### DIFF
--- a/plugins/window-rules/view-action-interface.cpp
+++ b/plugins/window-rules/view-action-interface.cpp
@@ -544,11 +544,6 @@ void view_action_interface_t::_start_on_output(std::string name)
             std::string model  = wo->handle->model ? wo->handle->model : "";
             std::string serial = wo->handle->serial ? wo->handle->serial : "";
 
-            LOGD("Output detected: connector=", wo->to_string(),
-                " make=", make,
-                " model=", model,
-                " serial=", serial);
-
             // Build identifiers
             std::string make_model = make + " " + model;
 


### PR DESCRIPTION
I added logic so the  make+model+serial number could be used with window-rules in addition to the usual connector names like DP-1, HDMI-A-1. This helps when connector names change especially when using a laptop dock connected to external monitors.

I had to update literal.cpp in wf-utils. see separate PR for that. thanks
