### PR TITLE
Unset WAYFIRE_SOCKET when wayfire starts

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -508,6 +508,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
+    unsetenv("WAYFIRE_SOCKET");
     setenv("WAYLAND_DISPLAY", core.wayland_display.c_str(), 1);
     core.post_init();
 


### PR DESCRIPTION
WAYFIRE_SOCKET will be inherited in nested sessions if the parent has it set and the ipc plugin is disabled in the nested instance. Unset the environment variable explicitly when wayfire starts, to avoid confused ipc clients.