### PR TITLE
keyboard: Don't reset depressed mods on config reload

### DIFF
--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -217,7 +217,7 @@ void wf::keyboard_t::reload_input_options()
 
     wlr_keyboard_set_repeat_info(handle, repeat_rate, repeat_delay);
 
-    wlr_keyboard_notify_modifiers(handle, 0, 0, locked_mods, 0);
+    wlr_keyboard_notify_modifiers(handle, handle->modifiers.depressed, 0, locked_mods, 0);
 }
 
 wf::keyboard_t::~keyboard_t()


### PR DESCRIPTION
When the config was reloaded, we were blindly resetting modifiers, despite the fact that some might be still pressed. This patch makes it so one can call i.e. set_option_values() from an ipc script without worrying about modifiers being reset. This can be tested with the following ipc script, that aims to disable wayfire-shell's `toggle_menu` \<super\> binding when there is a fullscreen window present. Without this patch, the script makes it so using '\<super\> KEY_F' to toggle a fullscreen window without releasing the <super> modifier types the letter 'f' instead of toggling fullscreen. This is easiest to observe with a window that accepts textual input, such as a terminal or text editor. With this patch, the window can be freely toggled fullscreen, without releasing \<super\> modifier, whilst still disabling the wayfire-shell plugin's `toggle_menu` binding when a fullscreen window is present on the focused output.

```
    #!/usr/bin/python3

    import sys
    import time

    from wayfire import WayfireSocket
    from wayfire.extra.ipc_utils import WayfireUtils as Utils

    sock = WayfireSocket()
    utils = Utils(sock)

    remove_menu_binding = {"wayfire-shell/toggle_menu" : "none"}
    restore_menu_binding = {"wayfire-shell/toggle_menu" : "<super>"}

    sock.watch(["output-gain-focus", "view-fullscreen", "view-unmapped"])

    while True:
        msg = sock.read_next_event()
        if not "event" in msg:
            continue
        view_id = utils.get_focused_view_id()
        if view_id is None:
            continue
        view_data = sock.get_view(view_id)
        if view_data["fullscreen"] is True:
            sock.set_option_values(remove_menu_binding)
        else:
            sock.set_option_values(restore_menu_binding)
```