### PR TITLE
input method: make sure down edge is inside screen even the submitted coordinates aren't

### DIFF
--- a/src/core/seat/input-method-popup.cpp
+++ b/src/core/seat/input-method-popup.cpp
@@ -165,6 +165,9 @@ void wf::text_input_v3_popup::update_geometry()
         {
             y -= cursor.height;
         }
+
+        // make sure down edge is inside screen even the submitted coordinates aren't
+        y = std::min(y, g_output.height - height);
     }
 
     // make sure top edge is on screen, sliding down and sacrificing down edge if unavoidable


### PR DESCRIPTION
Observed in patched minecraft (https://github.com/glfw/glfw/pull/2130#issuecomment-4003750413) that the client submitted a point outside the screen, thus that even after flipping it is still too low.