### PR TITLE
Support for custom vulkan effects

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -9,6 +9,7 @@
 #mesondefine BUILD_WITH_IMAGEIO
 #mesondefine USE_GLES32
 #mesondefine WF_HAS_XWAYLAND
+#mesondefine WF_HAS_VULKANFX
 
 
 #endif /* end of include guard: CONFIG_H */

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ pangocairo     = dependency('pangocairo')
 drm            = dependency('libdrm')
 egl            = dependency('egl')
 glesv2         = dependency('glesv2')
-vulkan         = dependency('vulkan', required: false)
+vulkan         = dependency('vulkan', required: get_option('vulkan_effects'))
 glm            = dependency('glm', required: false)
 libinput       = dependency('libinput', version: '>=1.7.0')
 pixman         = dependency('pixman-1')
@@ -46,7 +46,12 @@ udev           = dependency('libudev')
 json           = subproject('wf-json', default_options: ['install_header=true']).get_variable('wfjson')
 
 wlroots_base_version = '0.20'
-wlroots_dep_name = 'wlroots-' + wlroots_base_version
+if get_option('vulkan_effects')
+  wlroots_dep_name = 'wlroots-vkfx-' + wlroots_base_version
+else
+  wlroots_dep_name = 'wlroots-' + wlroots_base_version
+endif
+
 wlroots_min_version = '>=' + wlroots_base_version + '.0'
 wlroots_max_version = '<=' + wlroots_base_version + '.99'
 
@@ -60,7 +65,6 @@ elif get_option('use_system_wlroots').enabled()
 	wlroots = dependency(wlroots_dep_name, version: [wlroots_min_version, wlroots_max_version], required: true)
 
 elif get_option('use_system_wlroots').auto()
-	message( 'SEARCHING FOR WLROOTS' )
 	wlroots = dependency(wlroots_dep_name, version: [wlroots_min_version, wlroots_max_version], required: false)
 	use_system_wlroots = true
 	if not wlroots.found()
@@ -194,6 +198,14 @@ else
   conf_data.set('BUILD_WITH_IMAGEIO', false)
 endif
 
+
+use_vulkan = vulkan.found() and wlroots_features['vulkan_renderer'] and get_option('vulkan_effects')
+if use_vulkan
+  conf_data.set('WF_HAS_VULKANFX', 1)
+else
+  conf_data.set('WF_HAS_VULKANFX', 0)
+endif
+
 wayfire_conf_inc = include_directories(['.'])
 
 add_project_arguments(['-Wno-unused-parameter'], language: 'cpp')
@@ -231,6 +243,9 @@ else
   has_asan = false
 endif
 
+if use_vulkan
+  subdir('shaders')
+endif
 subdir('proto')
 subdir('src')
 subdir('man')
@@ -266,6 +281,7 @@ summary = [
     '    x11-backend: @0@'.format(wlroots_features['x11_backend']),
     '        imageio: @0@'.format(conf_data.get('BUILD_WITH_IMAGEIO')),
     '         gles32: @0@'.format(conf_data.get('USE_GLES32')),
+    ' vulkan effects: @0@'.format(conf_data.get('WF_HAS_VULKANFX')),
     '    print trace: @0@'.format(print_trace),
     '     unit tests: @0@'.format(doctest.found()),
     '----------------',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,4 @@ option('print_trace', type: 'boolean', value: true, description: 'Print stack tr
 option('tests', type: 'feature', value: 'auto', description: 'Enable unit tests')
 option('custom_pch', type: 'boolean', value: false, description: 'Use custom PCH for plugins. May not work with all compilers and setups.')
 option('build_locales', type: 'feature', value: 'auto', description: 'Build supported locale translations')
+option('vulkan_effects', type: 'boolean', value: false, description: 'Build with custom Vulkan effects')

--- a/plugins/animate/unmapped-view-node.hpp
+++ b/plugins/animate/unmapped-view-node.hpp
@@ -50,7 +50,7 @@ class unmapped_view_snapshot_node : public wf::scene::node_t
         using simple_render_instance_t::simple_render_instance_t;
         void render(const wf::scene::render_instruction_t& data)
         {
-            wf::texture_t texture = wf::texture_t{self->snapshot.get_texture()};
+            auto texture = wf::texture_t::from_aux(self->snapshot);
             data.pass->add_texture(texture, data.target, self->get_bounding_box(), data.damage);
         }
     };

--- a/plugins/common/wayfire/plugins/common/cairo-util.hpp
+++ b/plugins/common/wayfire/plugins/common/cairo-util.hpp
@@ -26,7 +26,7 @@ struct owned_texture_t
 
     owned_texture_t(owned_texture_t&& other) : owned_texture_t()
     {
-        std::swap(tex, other.tex);
+        std::swap(texture, other.texture);
         std::swap(size, other.size);
     }
 
@@ -37,30 +37,19 @@ struct owned_texture_t
             return *this;
         }
 
-        if (tex)
-        {
-            wlr_texture_destroy(tex);
-        }
-
-        tex = other.tex;
-        other.tex = NULL;
-
+        this->texture = other.texture;
+        other.texture = nullptr;
         size = other.size;
         other.size = {0, 0};
         return *this;
     }
 
     ~owned_texture_t()
-    {
-        if (tex)
-        {
-            wlr_texture_destroy(tex);
-        }
-    }
+    {}
 
-    wf::texture_t get_texture() const
+    std::shared_ptr<wf::texture_t> get_texture() const
     {
-        return wf::texture_t{tex};
+        return texture;
     }
 
     wf::dimensions_t get_size() const
@@ -75,7 +64,7 @@ struct owned_texture_t
     // Assumes ownership of the texture!
     owned_texture_t(wlr_texture *new_tex)
     {
-        tex = new_tex;
+        this->texture = wf::texture_t::from_texture(new_tex);
     }
 
     owned_texture_t(cairo_surface_t *surface)
@@ -102,13 +91,14 @@ struct owned_texture_t
             wf::dassert(false, "Unsupported cairo format: " + std::to_string(fmt) + "!");
         }
 
-        this->tex = wlr_texture_from_pixels(wf::get_core().renderer, drm_fmt, stride, width, height,
+        auto wlr_tex = wlr_texture_from_pixels(wf::get_core().renderer, drm_fmt, stride, width, height,
             cairo_image_surface_get_data(surface));
-        this->size = {width, height};
+        this->texture = wf::texture_t::from_texture(wlr_tex);
+        this->size    = {width, height};
     }
 
   private:
-    wlr_texture *tex = NULL;
+    std::shared_ptr<wf::texture_t> texture;
     wf::dimensions_t size = {0, 0};
 };
 
@@ -334,7 +324,7 @@ struct cairo_text_t
         return surface_size;
     }
 
-    wf::texture_t get_texture() const
+    std::shared_ptr<wf::texture_t> get_texture() const
     {
         return this->tex.get_texture();
     }

--- a/plugins/common/workspace-wall.cpp
+++ b/plugins/common/workspace-wall.cpp
@@ -205,15 +205,15 @@ class workspace_wall_t::workspace_wall_node_t : public scene::node_t
                     float dim = self->wall->get_color_for_workspace({i, j});
                     const auto& subbox = self->aux_buffer_current_subbox[i][j];
 
-                    auto tex = wf::texture_t{buffer.get_texture()};
-                    tex.filter_mode = WLR_SCALE_FILTER_BILINEAR;
+                    auto tex = wf::texture_t::from_aux(buffer);
+                    tex->set_filter_mode(WLR_SCALE_FILTER_BILINEAR);
                     if (subbox.has_value())
                     {
-                        tex.source_box = {
-                            1.0 * subbox->x,
-                            1.0 * subbox->y,
-                            1.0 * subbox->width,
-                            1.0 * subbox->height};
+                        tex->set_source_box(wlr_fbox{
+                                1.0 * subbox->x,
+                                1.0 * subbox->y,
+                                1.0 * subbox->width,
+                                1.0 * subbox->height});
                     }
 
                     data.pass->add_texture(tex, data.target, render_geometry, data.damage);

--- a/plugins/common/workspace-wall.cpp
+++ b/plugins/common/workspace-wall.cpp
@@ -66,7 +66,10 @@ class workspace_wall_t::workspace_wall_node_t : public scene::node_t
                         }
 
                         // Also damage the 'screen' after transforming damage
-                        push_damage(our_damage);
+                        if (!our_damage.empty())
+                        {
+                            push_damage(our_damage);
+                        }
                     };
 
                     self->workspaces[i][j]->gen_render_instances(instances[i][j],

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -124,7 +124,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
             {
                 wf::geometry_t title_geometry = item->get_geometry() + origin;
                 update_title(title_geometry.width, title_geometry.height, data.target.scale);
-                if (title_texture.tex.get_texture().texture != NULL)
+                if (title_texture.tex.get_texture() != NULL)
                 {
                     data.pass->add_texture(title_texture.tex.get_texture(), data.target,
                         title_geometry, data.damage);

--- a/plugins/grid/wayfire/plugins/crossfade.hpp
+++ b/plugins/grid/wayfire/plugins/crossfade.hpp
@@ -150,7 +150,8 @@ class crossfade_render_instance_t : public scene::render_instance_t
             ra = std::pow((self->overlay_alpha - 0.5) * 2, N) / 2.0 + 0.5;
         }
 
-        wf::texture_t tex = wf::texture_t{self->original_buffer.get_texture()};
+        auto tex = wf::texture_t::from_buffer(
+            self->original_buffer.get_buffer(), self->original_buffer.get_texture());
         data.pass->add_texture(tex, data.target, self->displayed_geometry, data.damage, 1.0 - ra);
     }
 };

--- a/plugins/scale/scale-title-filter.cpp
+++ b/plugins/scale/scale-title-filter.cpp
@@ -330,7 +330,7 @@ class scale_title_filter : public wf::per_output_plugin_instance_t
         }
 
         auto tex = filter_overlay.get_texture();
-        if (!tex.texture)
+        if (!tex)
         {
             return;
         }
@@ -342,12 +342,12 @@ class scale_title_filter : public wf::per_output_plugin_instance_t
             (int)(overlay_size.height / output_scale)
         };
 
-        tex.source_box = wlr_fbox{
+        tex->set_source_box(wlr_fbox{
             filter_overlay.get_size().width / 2.0 - overlay_size.width / 2.0,
             filter_overlay.get_size().height / 2.0 - overlay_size.height / 2.0,
             overlay_size.width * 1.0,
             overlay_size.height * 1.0,
-        };
+        });
 
         auto damage = output->render->get_scheduled_damage() & geometry;
         output->render->get_current_pass()->add_texture(tex, out_fb, geometry, damage);

--- a/plugins/scale/scale-title-overlay.cpp
+++ b/plugins/scale/scale-title-overlay.cpp
@@ -198,7 +198,7 @@ class title_overlay_node_t : public node_t
          * animated and maybe redraw less frequently
          */
         auto& tex = get_overlay_texture(find_topmost_parent(view));
-        if ((tex.overlay.get_texture().texture == nullptr) ||
+        if ((tex.overlay.get_texture() == nullptr) ||
             (output_scale != tex.par.output_scale) ||
             (tex.overlay.get_size().width > box.width * output_scale) ||
             (tex.overflow &&
@@ -240,7 +240,7 @@ class title_overlay_node_t : public node_t
         auto parent = find_topmost_parent(view);
         auto& title = get_overlay_texture(parent);
 
-        if (title.overlay.get_texture().texture != nullptr)
+        if (title.overlay.get_texture() != nullptr)
         {
             text_height = (unsigned int)std::ceil(
                 title.overlay.get_size().height / title.par.output_scale);
@@ -323,7 +323,7 @@ class title_overlay_render_instance_t : public render_instance_t
         auto tr     = self->view->get_transformed_node()
             ->get_transformer<wf::scene::view_2d_transformer_t>("scale");
 
-        if (!title.overlay.get_texture().texture)
+        if (!title.overlay.get_texture())
         {
             /* this should not happen */
             return;

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -10,6 +10,12 @@
 #include <wayfire/render-manager.hpp>
 #include <wayfire/plugins/common/util.hpp>
 
+#if WF_HAS_VULKANFX
+    #include <wayfire/vulkan.hpp>
+    #include "shaders/wobbly.vert.h"
+    #include "shaders/wobbly.frag.h"
+#endif
+
 extern "C"
 {
 #include "wobbly.h"
@@ -600,6 +606,10 @@ class wobbly_transformer_node_t : public wf::scene::transformer_base_node_t
 
     OpenGL::program_t *wobbly_program;
 
+#if WF_HAS_VULKANFX
+    std::array<std::shared_ptr<wf::vk::gpu_buffer_t>, 4> vulkan_vertex_buffer;
+#endif
+
   private:
     wayfire_toplevel_view view;
 
@@ -884,24 +894,166 @@ class wobbly_render_instance_t :
         damage |= self->get_bounding_box();
     }
 
+#if WF_HAS_VULKANFX
+    class vulkan_state_t : public wf::custom_data_t
+    {
+      public:
+        std::shared_ptr<wf::vk::graphics_pipeline_t> pipeline;
+    };
+
+    struct vulkan_push_constants_t
+    {
+        glm::mat4 mvp;
+        glm::vec2 uv_scale;
+        glm::vec2 uv_offset;
+    };
+
+    vulkan_state_t& ensure_vk(wf::vulkan_render_state_t& state)
+    {
+        if (auto data = state.get_data<vulkan_state_t>())
+        {
+            return *data;
+        }
+
+        auto vs = state.get_context()->load_shader_module(wobbly_vert_data, sizeof(wobbly_vert_data));
+        auto fs = state.get_context()->load_shader_module(wobbly_frag_data, sizeof(wobbly_frag_data));
+
+        wf::vk::pipeline_params_t params{};
+        params.shaders = {
+            {.stage = VK_SHADER_STAGE_VERTEX_BIT, .shader = vs},
+            {.stage = VK_SHADER_STAGE_FRAGMENT_BIT, .shader = fs},
+        };
+
+        params.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
+        params.vertex_input_description = {{
+            .binding   = 0,
+            .stride    = sizeof(float) * 4,
+            .inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
+        }};
+        params.vertex_attribute_description = {
+            {
+                .location = 0,
+                .binding  = 0,
+                .format   = VK_FORMAT_R32G32_SFLOAT,
+                .offset   = 0,
+            },
+            {
+                .location = 1,
+                .binding  = 0,
+                .format   = VK_FORMAT_R32G32_SFLOAT,
+                .offset   = sizeof(float) * 2,
+            },
+        };
+
+        // One descriptor set for the texture.
+        params.descriptor_set_layouts = {wf::vk::pipeline_params_t::texture_descriptor_set_t{}};
+        params.push_constants = {
+            VkPushConstantRange{
+                .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+                .offset     = 0,
+                .size = sizeof(vulkan_push_constants_t),
+            },
+        };
+
+        auto data = std::make_unique<vulkan_state_t>();
+        data->pipeline = std::make_shared<wf::vk::graphics_pipeline_t>(state.get_context(), params);
+        auto ptr = data.get();
+        state.store_data<vulkan_state_t>(std::move(data));
+        return *ptr;
+    }
+
+    std::shared_ptr<wf::vk::gpu_buffer_t> find_buffer(
+        std::shared_ptr<wf::vk::context_t> ctx, VkDeviceSize total_size)
+    {
+        auto& buffers = self->vulkan_vertex_buffer;
+        for (size_t i = 0; i < buffers.size(); i++)
+        {
+            auto& buffer = buffers[i];
+            // Try to reuse the vertex buffer if possible, to avoid reallocations.
+            if (buffer && (buffer->get_size() >= total_size) && (buffer.use_count() == 1))
+            {
+                return buffers[i];
+            }
+        }
+
+        buffers[0] = ctx->create_buffer(total_size,
+            VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+        return buffers[0];
+    }
+
+#endif
+
     void render(const wf::scene::render_instruction_t& data) override
     {
         std::vector<float> vert, uv;
         auto subbox = self->get_children_bounding_box();
         wobbly_graphics::prepare_geometry(self->model.get(), subbox, vert, uv);
+        const int count_triangles = self->model->x_cells * self->model->y_cells * 2;
 
-        auto tex = wf::gles_texture_t{get_texture(data.target.scale)};
         data.pass->custom_gles_subpass(data.target, [&]
         {
+            auto tex = wf::gles_texture_t{this->get_texture(data.target.scale)};
+            wf::gles::bind_render_buffer(data.target);
             for (auto box : data.damage)
             {
                 wf::gles::render_target_logic_scissor(data.target, wlr_box_from_pixman_box(box));
                 wobbly_graphics::render_triangles(self->wobbly_program, tex,
                     wf::gles::render_target_orthographic_projection(data.target),
-                    vert.data(), uv.data(),
-                    self->model->x_cells * self->model->y_cells * 2);
+                    vert.data(), uv.data(), count_triangles);
             }
         });
+
+#if WF_HAS_VULKANFX
+        data.pass->custom_vulkan_subpass([&] (wf::vulkan_render_state_t& state,
+                                              wf::vk::command_buffer_t& cmd_buf)
+        {
+            auto& our_state = ensure_vk(state);
+
+            std::vector<float> unified_buffer;
+            for (size_t i = 0; i < vert.size() / 2; i++)
+            {
+                unified_buffer.push_back(vert[2 * i]);
+                unified_buffer.push_back(vert[2 * i + 1]);
+                unified_buffer.push_back(uv[2 * i]);
+                unified_buffer.push_back(uv[2 * i + 1]);
+            }
+
+            VkDeviceSize total_size = unified_buffer.size() * sizeof(float);
+
+            auto buffer = find_buffer(state.get_context(), total_size);
+            buffer->write(unified_buffer.data(), total_size);
+
+            auto texture  = get_texture(data.target.scale);
+            auto tex_dset = state.get_descriptor_pool()->get_descriptor_set(cmd_buf, texture);
+            wf::vk::texture_sampling_params_t sampling{texture};
+
+            wf::vk::pipeline_specialization_t specialization{};
+            specialization.add_specialization_for_texture(texture);
+
+            auto [layout, _] = cmd_buf.bind_pipeline(our_state.pipeline, data.target, specialization);
+            cmd_buf.set_full_viewport(data.target);
+            cmd_buf.bind_texture(texture);
+
+            vkCmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, layout,
+                0, 1, &tex_dset, 0, nullptr);
+
+            vulkan_push_constants_t push_constants{};
+            push_constants.mvp = wf::vk::render_target_transform(data.target);
+            push_constants.uv_scale  = sampling.get_uv_scale();
+            push_constants.uv_offset = sampling.get_uv_offset();
+            vkCmdPushConstants(cmd_buf, layout, VK_SHADER_STAGE_VERTEX_BIT,
+                0, sizeof(vulkan_push_constants_t), &push_constants);
+
+            cmd_buf.bind_buffer(buffer);
+            VkDeviceSize offset = 0;
+            vkCmdBindVertexBuffers(cmd_buf, 0, 1, &buffer->get_buffer(), &offset);
+
+            cmd_buf.for_each_scissor_rect(data.target, (data.damage & data.target.geometry), [&]
+            {
+                vkCmdDraw(cmd_buf, count_triangles * 3, 1, 0, 0);
+            });
+        });
+#endif
     }
 };
 
@@ -923,14 +1075,6 @@ class wayfire_wobbly : public wf::plugin_interface_t
   public:
     void init() override
     {
-        if (!wf::get_core().is_gles2())
-        {
-            const char *render_type =
-                wf::get_core().is_vulkan() ? "vulkan" : (wf::get_core().is_pixman() ? "pixman" : "unknown");
-            LOGE("wobbly: requires GLES2 support, but current renderer is ", render_type);
-            return;
-        }
-
         wf::get_core().connect(&wobbly_changed);
         wf::gles::run_in_context_if_gles([&]
         {

--- a/shaders/color-transform.frag
+++ b/shaders/color-transform.frag
@@ -1,0 +1,64 @@
+// Adapted from wlroots, MIT license
+// Copyright (c) 2023 The wlroots contributors
+
+layout (constant_id = 0) const int TEXTURE_TRANSFORM = 0;
+
+// Matches enum wlr_color_transfer_function
+#define TEXTURE_TRANSFORM_IDENTITY (1 << 2)
+#define TEXTURE_TRANSFORM_SRGB (1 << 0)
+#define TEXTURE_TRANSFORM_ST2084_PQ  (1 << 1)
+#define TEXTURE_TRANSFORM_GAMMA22 (1 << 3)
+#define TEXTURE_TRANSFORM_BT1886 (1 << 4)
+
+float srgb_channel_to_linear(float x) {
+	return mix(x / 12.92,
+		pow((x + 0.055) / 1.055, 2.4),
+		x > 0.04045);
+}
+
+vec3 srgb_color_to_linear(vec3 color) {
+	return vec3(
+		srgb_channel_to_linear(color.r),
+		srgb_channel_to_linear(color.g),
+		srgb_channel_to_linear(color.b)
+	);
+}
+
+vec3 pq_color_to_linear(vec3 color) {
+	float inv_m1 = 1 / 0.1593017578125;
+	float inv_m2 = 1 / 78.84375;
+	float c1 = 0.8359375;
+	float c2 = 18.8515625;
+	float c3 = 18.6875;
+	vec3 num = max(pow(color, vec3(inv_m2)) - c1, 0);
+	vec3 denom = c2 - c3 * pow(color, vec3(inv_m2));
+	return pow(num / denom, vec3(inv_m1));
+}
+
+vec3 bt1886_color_to_linear(vec3 color) {
+	float Lmin = 0.01;
+	float Lmax = 100.0;
+	float lb = pow(Lmin, 1.0 / 2.4);
+	float lw = pow(Lmax, 1.0 / 2.4);
+	float a  = pow(lw - lb, 2.4);
+	float b  = lb / (lw - lb);
+	vec3 L = a * pow(color + vec3(b), vec3(2.4));
+	return (L - Lmin) / (Lmax - Lmin);
+}
+
+vec3 transform_color(vec3 rgb) {
+    if (TEXTURE_TRANSFORM != TEXTURE_TRANSFORM_IDENTITY) {
+        rgb = max(rgb, vec3(0));
+    }
+    if (TEXTURE_TRANSFORM == TEXTURE_TRANSFORM_SRGB) {
+        rgb = srgb_color_to_linear(rgb);
+    } else if (TEXTURE_TRANSFORM == TEXTURE_TRANSFORM_ST2084_PQ) {
+        rgb = pq_color_to_linear(rgb);
+    } else if (TEXTURE_TRANSFORM == TEXTURE_TRANSFORM_GAMMA22) {
+        rgb = pow(rgb, vec3(2.2));
+    } else if (TEXTURE_TRANSFORM == TEXTURE_TRANSFORM_BT1886) {
+        rgb = bt1886_color_to_linear(rgb);
+    }
+
+    return rgb;
+}

--- a/shaders/core-basic.frag
+++ b/shaders/core-basic.frag
@@ -1,0 +1,14 @@
+#version 450
+#extension GL_ARB_shading_language_include : require
+
+layout(location = 0) out vec4 out_color;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(location = 0) in vec2 uv;
+
+#include "color-transform.frag"
+
+void main() {
+    vec4 r = texture(tex, uv);
+    out_color = vec4(transform_color(r.rgb), r.a);
+}

--- a/shaders/core-basic.vert
+++ b/shaders/core-basic.vert
@@ -1,0 +1,25 @@
+#version 450
+#extension GL_ARB_shading_language_include : require
+
+layout(push_constant, column_major) uniform UBO {
+	mat4 mvp;
+    vec2 uv_scale;
+    vec2 uv_offset;
+} data;
+
+#include "texture-transform.vert"
+
+layout(location = 0) out vec2 uv;
+
+vec2 positions[4] = vec2[](
+    vec2(0.0, 0.0), // top left
+    vec2(0.0, 1.0), // top right
+    vec2(1.0, 1.0), // bottom right
+    vec2(1.0, 0.0)  // bottom left
+);
+
+void main() {
+    vec2 pos = positions[gl_VertexIndex];
+	uv = transform_texture_uv(pos, data.uv_scale, data.uv_offset);
+	gl_Position = data.mvp * vec4(pos, 0.0, 1.0);
+}

--- a/shaders/meson.build
+++ b/shaders/meson.build
@@ -1,0 +1,41 @@
+# Thanks to wlroots' implementation
+shaders = [
+  'core-basic.vert',
+  'core-basic.frag',
+  'wobbly.vert',
+  'wobbly.frag',
+]
+
+vert_common = [ 'texture-transform.vert' ]
+frag_common = [ 'color-transform.frag' ]
+
+glslang = find_program('glslang', 'glslangValidator', native: true, required: true)
+glslang_version_info = run_command(glslang, '--version', check: true).stdout()
+glslang_version = glslang_version_info.split('\n')[0].split(':')[-1]
+
+vulkan_shaders = []
+foreach shader : shaders
+	name = shader.underscorify() + '_data'
+	args = [glslang, '-V', '@INPUT@', '-o', '@OUTPUT@', '--vn', name]
+	if glslang_version.version_compare('>=11.0.0')
+		args += '--quiet'
+	endif
+
+  deps = []
+  if shader.contains('frag')
+    deps += frag_common
+  endif
+
+  if shader.contains('vert')
+    deps += vert_common
+  endif
+
+	header = custom_target(
+		shader + '_spv',
+		output: shader + '.h',
+		input: shader,
+		command: args,
+    depend_files: deps)
+
+	vulkan_shaders += [header]
+endforeach

--- a/shaders/texture-transform.vert
+++ b/shaders/texture-transform.vert
@@ -1,0 +1,26 @@
+// Texture rotation, matches wl_output_transform
+layout (constant_id = 1) const int TEXTURE_ROTATION = 0;
+
+/**
+ * Apply texture rotation to the given UV coordinates, as well as scale them with a base and offset, which
+ * allows limiting texturing to a subset of the texture.
+ */
+vec2 transform_texture_uv(vec2 uv, vec2 scale, vec2 off) {
+    if (TEXTURE_ROTATION == 1) { // WL_OUTPUT_TRANSFORM_90
+        return vec2(1.0 - uv.y, uv.x) * scale + off;
+    } else if (TEXTURE_ROTATION == 2) { // WL_OUTPUT_TRANSFORM_180
+        return vec2(1.0 - uv.x, 1.0 - uv.y) * scale + off;
+    } else if (TEXTURE_ROTATION == 3) { // WL_OUTPUT_TRANSFORM_270
+        return vec2(uv.y, 1.0 - uv.x) * scale + off;
+    } else if (TEXTURE_ROTATION == 4) { // WL_OUTPUT_TRANSFORM_FLIPPED
+        return vec2(1.0 - uv.x, uv.y) * scale + off;
+    } else if (TEXTURE_ROTATION == 5) { // WL_OUTPUT_TRANSFORM_FLIPPED_90
+        return vec2(1.0 - uv.y, 1.0 - uv.x) * scale + off;
+    } else if (TEXTURE_ROTATION == 6) { // WL_OUTPUT_TRANSFORM_FLIPPED_180
+        return vec2(uv.x, 1.0 - uv.y) * scale + off;
+    } else if (TEXTURE_ROTATION == 7) { // WL_OUTPUT_TRANSFORM_FLIPPED_270
+        return vec2(uv.y, uv.x) * scale + off;
+    } else { // WL_OUTPUT_TRANSFORM_NORMAL
+        return uv * scale + off;
+    }
+}

--- a/shaders/wobbly.frag
+++ b/shaders/wobbly.frag
@@ -1,0 +1,14 @@
+#version 450
+#extension GL_ARB_shading_language_include : require
+
+layout(location = 0) out vec4 out_color;
+layout(set = 0, binding = 0) uniform sampler2D tex;
+
+layout(location = 0) in vec2 uv;
+
+#include "color-transform.frag"
+
+void main() {
+    vec4 r = texture(tex, uv);
+    out_color = vec4(transform_color(r.rgb), r.a);
+}

--- a/shaders/wobbly.vert
+++ b/shaders/wobbly.vert
@@ -1,0 +1,19 @@
+#version 450
+#extension GL_ARB_shading_language_include : require
+#include "texture-transform.vert"
+
+layout(push_constant, column_major) uniform UBO {
+	mat4 mvp;
+    vec2 tex_scale;
+    vec2 tex_offset;
+} data;
+
+layout(location = 0) out vec2 uv;
+
+layout(location = 0) in vec2 pos;
+layout(location = 1) in vec2 uv_in;
+
+void main() {
+	gl_Position = data.mvp * vec4(pos, 0.0, 1.0);
+	uv = transform_texture_uv(uv_in, data.tex_scale, data.tex_offset);
+}

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -127,6 +127,9 @@ geometry_t fbox_to_geometry(const wlr_fbox& fbox);
 bool operator ==(const wf::geometry_t& a, const wf::geometry_t& b);
 bool operator !=(const wf::geometry_t& a, const wf::geometry_t& b);
 
+bool operator ==(const wlr_fbox& a, const wlr_fbox& b);
+bool operator !=(const wlr_fbox& a, const wlr_fbox& b);
+
 wf::point_t operator +(const wf::point_t& a, const wf::geometry_t& b);
 wf::geometry_t operator +(const wf::geometry_t & a, const wf::point_t& b);
 wf::geometry_t operator -(const wf::geometry_t & a, const wf::point_t& b);

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -48,6 +48,8 @@ extern "C"
 #undef static
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_viewporter.h>
+#include <wlr/types/wlr_color_management_v1.h>
+#include <wlr/types/wlr_color_representation_v1.h>
 
 #include <wlr/types/wlr_damage_ring.h>
 #include <wlr/types/wlr_presentation_time.h>

--- a/src/api/wayfire/opengl.hpp
+++ b/src/api/wayfire/opengl.hpp
@@ -134,7 +134,7 @@ struct gles_texture_t
     gles_texture_t(GLuint tex);
     /** Initialize a texture with the attributes of the wlr texture */
     explicit gles_texture_t(wlr_texture*, std::optional<wlr_fbox> viewport = {});
-    explicit gles_texture_t(wf::texture_t tex);
+    explicit gles_texture_t(const std::shared_ptr<wf::texture_t>& tex);
 
     static gles_texture_t from_aux(auxilliary_buffer_t& buffer, std::optional<wlr_fbox> viewport = {});
 };

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -107,7 +107,7 @@ using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 /**
  * The version is defined as macro as well, to allow conditional compilation.
  */
-#define WAYFIRE_API_ABI_VERSION_MACRO 2026'03'27
+#define WAYFIRE_API_ABI_VERSION_MACRO 2026'04'10
 
 /**
  * The version of Wayfire's API/ABI

--- a/src/api/wayfire/render.hpp
+++ b/src/api/wayfire/render.hpp
@@ -1,5 +1,12 @@
 #pragma once
 
+#ifdef WF_USE_CONFIG_H
+    #include <config.h>
+#else
+    #include <wayfire/config.h>
+#endif
+
+#include "wayfire/signal-provider.hpp"
 #include <memory>
 #include <vector>
 #include <wayfire/config/types.hpp>
@@ -11,19 +18,104 @@
 namespace wf
 {
 class output_t;
+struct auxilliary_buffer_t;
+namespace vk
+{
+class command_buffer_t;
+}
 
 /**
- * A simple, non-owning wrapper for a wlr_texture + source box.
+ * A struct which describes the color space of a given texture.
  */
-struct texture_t
+struct color_transform_t
 {
+    wlr_color_transfer_function transfer_function = WLR_COLOR_TRANSFER_FUNCTION_SRGB;
+    wlr_color_named_primaries primaries = WLR_COLOR_NAMED_PRIMARIES_SRGB;
+    wlr_color_encoding color_encoding   = WLR_COLOR_ENCODING_NONE;
+    wlr_color_range color_range = WLR_COLOR_RANGE_NONE;
+
+    bool operator ==(const color_transform_t& other) const;
+    bool operator !=(const color_transform_t& other) const;
+};
+
+/**
+ * A wrapper around wlr_texture which ensures that the texture is kept alive as long as the wrapper object
+ * is alive.
+ */
+class texture_t : public wf::signal::provider_t
+{
+  public:
+    /**
+     * Emitted on destruction of the texture_t object, i.e when the texture is about to be destroyed.
+     */
+    struct destroy_signal
+    {
+        texture_t *self;
+    };
+
+    // Getters and setters for source_box
+    std::optional<wlr_fbox> get_source_box() const;
+    void set_source_box(const std::optional<wlr_fbox>& box);
+
+    // Getters and setters for transform
+    wl_output_transform get_transform() const;
+    void set_transform(wl_output_transform t);
+
+    // Getters and setters for filter_mode
+    std::optional<wlr_scale_filter_mode> get_filter_mode() const;
+    void set_filter_mode(const std::optional<wlr_scale_filter_mode>& mode);
+
+    // Getters and setters for color_transform
+    color_transform_t get_color_transform() const;
+    void set_color_transform(const color_transform_t& ct);
+
+    /**
+     * Manage an existing wlr_texture created from a wlr_buffer.
+     * We keep the texture alive by keeping the associated buffer alive.
+     */
+    static std::shared_ptr<texture_t> from_buffer(wlr_buffer *buffer, wlr_texture *texture);
+
+    /**
+     * Manage an existing wlr_texture created without a wlr_buffer.
+     * In this case, the caller must have ownership of the texture.
+     * The ownership is then passed to the returned texture_t object.
+     */
+    static std::shared_ptr<texture_t> from_texture(wlr_texture *texture);
+
+    /**
+     * Create a texture from an auxilliary buffer.
+     * The auxilliary buffer must have a valid buffer and texture allocated.
+     */
+    static std::shared_ptr<texture_t> from_aux(auxilliary_buffer_t& buffer);
+
+    /**
+     * Get the width of the texture in pixels.
+     */
+    int32_t get_width() const;
+
+    /**
+     * Get the height of the texture in pixels.
+     */
+    int32_t get_height() const;
+
+    ~texture_t();
+
+    /**
+     * Get the underlying wlr_texture pointer.
+     */
+    wlr_texture *get_wlr_texture() const;
+
+  private:
+    texture_t();
+
     wlr_texture *texture = NULL;
+    wlr_buffer *buffer   = NULL; // If NULL, we own @texture.
+
     std::optional<wlr_fbox> source_box = {};
     wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
     std::optional<wlr_scale_filter_mode> filter_mode = {};
+    color_transform_t color_transform;
 };
-
-struct auxilliary_buffer_t;
 
 /**
  * A simple wrapper for buffers which are used as render targets.
@@ -185,6 +277,12 @@ struct render_target_t : public render_buffer_t
     explicit render_target_t(const render_buffer_t& buffer);
     explicit render_target_t(const auxilliary_buffer_t& buffer);
 
+    render_target_t(const render_target_t& other);
+    render_target_t(render_target_t&& other);
+    render_target_t& operator =(const render_target_t& other);
+    render_target_t& operator =(render_target_t&& other);
+    ~render_target_t();
+
     // Describes the logical coordinates of the render area, in whatever
     // coordinate system the render target needs.
     wf::geometry_t geometry = {0, 0, 0, 0};
@@ -256,6 +354,29 @@ struct render_target_t : public render_buffer_t
      * geometry_box_from_framebuffer_box.
      */
     wf::region_t geometry_region_from_framebuffer_region(const wf::region_t& region) const;
+
+    /**
+     * The inverse of the color transform that will be applied to the render target in the next compositing
+     * step. For example, this is the inverse transform of the color transform applied by the monitor for
+     * render targets directly on the output, or linear encoding for auxilliary buffers used for passing
+     * through pixel data (for example transformers).
+     *
+     * When not set, it acts as the wlroots default (gamma 2.2). Note that EXT_LINEAR and SRGB color transfers
+     * usually result in faster performance in Vulkan, so they should be preferred where possible.
+     */
+    wlr_color_transform *get_color_transform() const
+    {
+        return inverse_eotf;
+    }
+
+    /**
+     * Set a new color transform for the render target.
+     */
+    void set_color_transform(wlr_color_transform *transform);
+
+  private:
+    wlr_color_transform *inverse_eotf = nullptr;
+    void copy_from(const render_target_t& other);
 };
 
 namespace scene
@@ -311,7 +432,7 @@ struct render_pass_params_t
     /**
      * Additional options for the wlroots buffer pass.
      */
-    wlr_buffer_pass_options *pass_opts = nullptr;
+    wlr_buffer_pass_options pass_opts{};
 
     /**
      * Flags for this render pass, see @render_pass_flags.
@@ -319,13 +440,15 @@ struct render_pass_params_t
     uint32_t flags = 0;
 };
 
+class vulkan_render_state_t;
+
 /**
  * A render pass is used to generate and execute a set of drawing commands to the same render target.
  */
 class render_pass_t
 {
     render_pass_params_t params;
-    wlr_render_pass *pass = NULL;
+    wlr_render_pass *_pass = NULL;
 
   public:
     render_pass_t(const render_pass_params_t& params);
@@ -391,7 +514,7 @@ class render_pass_t
     /**
      * Add a texture rendering operation to the pass.
      */
-    void add_texture(const wf::texture_t& texture,
+    void add_texture(const std::shared_ptr<wf::texture_t>& texture,
         const wf::render_target_t& adjusted_target,
         const wf::geometry_t& geometry,
         const wf::region_t& damage,
@@ -400,7 +523,7 @@ class render_pass_t
     /**
      * Add a texture rendering operation to the pass using wlr_fbox for geometry.
      */
-    void add_texture(const wf::texture_t& texture,
+    void add_texture(const std::shared_ptr<wf::texture_t>& texture,
         const wf::render_target_t& adjusted_target,
         const wlr_fbox& geometry,
         const wf::region_t& damage,
@@ -479,12 +602,37 @@ class render_pass_t
         return false;
     }
 
+#if WF_HAS_VULKANFX
+    template<class F>
+    bool custom_vulkan_subpass(F&& fn)
+    {
+        if (auto state = prepare_vulkan_subpass())
+        {
+            fn(*state, *active_command_buffer);
+            end_vulkan_subpass();
+            return true;
+        }
+
+        return false;
+    }
+
+#endif
+
   private:
+
+#if WF_HAS_VULKANFX
+    vk::command_buffer_t *active_command_buffer = nullptr;
+    vulkan_render_state_t *prepare_vulkan_subpass();
+    void end_vulkan_subpass();
+#endif
+
     bool prepare_gles_subpass();
     bool prepare_gles_subpass(const wf::render_target_t& target);
     void finish_gles_subpass();
-};
 
+    bool needs_restart = false;
+    wlr_render_pass *_get_pass();
+};
 
 /**
  * Signal that a render pass starts.

--- a/src/api/wayfire/unstable/wlr-surface-node.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-node.hpp
@@ -22,6 +22,7 @@ struct surface_state_t
     wf::dimensions_t size = {0, 0};
     std::optional<wlr_fbox> src_viewport;
     wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL;
+    wf::color_transform_t color_transform;
 
     // Sequence number of the last commit read from a wlr_surface state
     std::optional<uint32_t> seq{};
@@ -66,7 +67,7 @@ class wlr_surface_node_t : public node_t, public zero_copy_texturable_node_t
     void gen_render_instances(std::vector<render_instance_uptr>& instances, damage_callback damage,
         wf::output_t *output) override;
     wf::geometry_t get_bounding_box() override;
-    std::optional<wf::texture_t> to_texture() const override;
+    std::shared_ptr<wf::texture_t> to_texture() const override;
 
     wlr_surface *get_surface() const;
     void apply_state(surface_state_t&& state);

--- a/src/api/wayfire/view-transform.hpp
+++ b/src/api/wayfire/view-transform.hpp
@@ -22,9 +22,9 @@ class zero_copy_texturable_node_t
      * Get a texture from the node without copying.
      * Note that this operation might fail for non-trivial transformers.
      */
-    virtual std::optional<wf::texture_t> to_texture() const
+    virtual std::shared_ptr<wf::texture_t> to_texture() const
     {
-        return {};
+        return nullptr;
     }
 };
 
@@ -61,7 +61,7 @@ class transformer_base_node_t : public scene::floating_inner_node_t
     // children's current content.
     wf::region_t cached_damage;
 
-    wf::texture_t get_updated_contents(const wf::geometry_t& bbox, float scale,
+    std::shared_ptr<wf::texture_t> get_updated_contents(const wf::geometry_t& bbox, float scale,
         std::vector<scene::render_instance_uptr>& children);
 
     void release_buffers();
@@ -88,18 +88,21 @@ template<class NodeType>
 class transformer_render_instance_t : public render_instance_t
 {
   protected:
-    std::optional<wf::texture_t> zero_copy_texture()
+    std::shared_ptr<wf::texture_t> zero_copy_texture()
     {
         if (self->get_children().size() == 1)
         {
             auto child = self->get_children().front().get();
             if (auto zcopy = dynamic_cast<zero_copy_texturable_node_t*>(child))
             {
-                return zcopy->to_texture();
+                if (auto tex = zcopy->to_texture())
+                {
+                    return tex;
+                }
             }
         }
 
-        return {};
+        return nullptr;
     }
 
     // A pointer to the transformer node this render instance belongs to.
@@ -120,7 +123,7 @@ class transformer_render_instance_t : public render_instance_t
      *   indicates how much bigger the temporary buffer should be than its logical
      *   size.
      */
-    wf::texture_t get_texture(float scale)
+    std::shared_ptr<wf::texture_t> get_texture(float scale)
     {
         // Optimization: if we have a single child (usually the surface root node)
         // and we can directly convert it to texture, we don't need a full render
@@ -128,7 +131,7 @@ class transformer_render_instance_t : public render_instance_t
         if (auto tex = zero_copy_texture())
         {
             self->release_buffers();
-            return *tex;
+            return tex;
         }
 
         return self->get_updated_contents(self->get_children_bounding_box(), scale, children);

--- a/src/api/wayfire/vulkan.hpp
+++ b/src/api/wayfire/vulkan.hpp
@@ -1,0 +1,496 @@
+#pragma once
+
+#ifdef WF_USE_CONFIG_H
+    #include <config.h>
+#else
+    #include <wayfire/config.h>
+#endif
+
+#if WF_HAS_VULKANFX
+    #include <memory>
+    #include <map>
+    #include <string>
+    #include <string_view>
+    #include <variant>
+    #include <vector>
+    #include <wayfire/nonstd/wlroots-full.hpp>
+    #include <wayfire/render.hpp>
+    #include <vulkan/vulkan.h>
+    #include <wayfire/object.hpp>
+    #include <wayfire/util.hpp>
+    #include <glm/glm.hpp>
+
+namespace wf
+{
+namespace vk
+{
+class context_t;
+class gpu_buffer_t;
+class graphics_pipeline_t;
+class image_descriptor_set_pool_t;
+/**
+ * A class which encapsulates the information for specialization of a graphics pipeline for a specific render
+ * pass. Specializations are used in order to reuse the same shader in different configurations, for example
+ * to sample from textures with different color spaces (linear, sRGB, etc. @get_specialization_fo_texture),
+ * or a custom user-specified specialization constant.
+ *
+ * On the GLSL side, this works by definiting the specialization constants and then using them to turn
+ * parts of the code on or off.
+ *
+ * The pipeline specialization also involves using immutable samplers (bilinear, nearest or ycbcr) for each
+ * texture sampling descriptor set indicated in the pipeline layout parameters.
+ */
+class pipeline_specialization_t
+{
+  public:
+    template<class T>
+    void add_specialization(uint32_t constant_id, uint32_t offset, const T& data)
+    {
+        _add_specialization(constant_id, offset, &data, sizeof(T));
+    }
+
+    /**
+     * Adds the default specialization constants for sampling from a texture with different color encodings.
+     * Interacts with @pipeline_params_t::descriptor_set_layouts to ensure that the correct descriptor set
+     * layout (with the correct samplers) are used for the texture sampling.
+     *
+     * The added specializations are:
+     * - A uint32_t matching the value of wf::texture_t::get_color_transform()::transfer_function
+     * - A uint32_t matching the value of wf::texture_t::get_transform()
+     *
+     * @param texture The texture for which to add the specialization.
+     * @param constant_id The ID (default: 0) of the specialization constant to use for the color transform.
+     *                    The next ID (default: 1) is used for the texture rotation. These IDs should
+     *                    match the one used in the shader.
+     * @param offset The offset in bytes into the specialization data where the constant value will be
+     * written. This allows packing multiple specializations into the same specialization data buffer.
+     */
+    void add_specialization_for_texture(const std::shared_ptr<wf::texture_t>& texture,
+        const uint32_t constant_id = 0, const uint32_t offset = 0);
+
+    /**
+     * Get the specialization map entries.
+     */
+    const std::vector<VkSpecializationMapEntry>& get_entries() const
+    {
+        return entries;
+    }
+
+    /**
+     * Get the raw specialization data.
+     */
+    const std::vector<std::byte>& get_data() const
+    {
+        return specialization_data;
+    }
+
+  private:
+    void _add_specialization(uint32_t constant_id, uint32_t offset, const void *data, size_t size);
+    std::vector<VkSpecializationMapEntry> entries;
+    std::vector<std::byte> specialization_data;
+    std::vector<std::shared_ptr<wf::texture_t>> specialized_textures;
+    friend class graphics_pipeline_t;
+};
+
+/**
+ * A wrapper around a wlr_render_pass from the vulkan backend.
+ */
+class command_buffer_t : public wf::signal::provider_t
+{
+  private:
+    std::shared_ptr<context_t> context;
+    std::vector<std::shared_ptr<graphics_pipeline_t>> bound_pipelines;
+    std::vector<std::shared_ptr<wf::texture_t>> bound_textures;
+
+    friend class image_descriptor_set_pool_t;
+    friend class gpu_buffer_t;
+    friend class graphics_pipeline_t;
+    std::vector<std::shared_ptr<gpu_buffer_t>> bound_buffers;
+
+    VkCommandBuffer cmd;
+    VkRenderPass current_pass = VK_NULL_HANDLE;
+    wlr_render_pass *wlr_pass = nullptr;
+    command_buffer_t(std::shared_ptr<context_t> context, wf::render_pass_t& pass);
+
+  public:
+    /**
+     * Create a wrapper around the command buffer used currently in the given pass.
+     * Note that the memory for the command buffer is managed by core.
+     */
+    static command_buffer_t& buffer_for_pass(wf::render_pass_t& pass);
+
+    /**
+     * A wrapper around the command buffer used currently in the given pass.
+     */
+    ~command_buffer_t();
+
+    /**
+     * Emitted when the command buffer is reset, i.e. when it can be safely reused again.
+     */
+    struct reset_signal
+    {
+        command_buffer_t *self;
+    };
+
+    /**
+     * Bind the pipeline to the command buffer.
+     * The pipeline will be kept alive until the command buffer is finished executing.
+     *
+     * @return The vulkan pipeline layout and pipeline used for the current render pass and specialization.
+     */
+    std::pair<VkPipelineLayout, VkPipeline> bind_pipeline(std::shared_ptr<graphics_pipeline_t> pipeline,
+        const wf::render_target_t& target,
+        const pipeline_specialization_t& specialization = pipeline_specialization_t{});
+
+    /**
+     * Set the viewport to cover the entire render target.
+     */
+    void set_full_viewport(const wf::render_target_t& target);
+
+    /**
+     * Iterate over all rectangles needed to cover the given damage region, set each of them as the scissor
+     * and call the callback for each of them.
+     *
+     * Typical usage:
+     * for_each_scissor_rect(target, damage, [&] { vkCmdDraw(...); });
+     */
+    void for_each_scissor_rect(const wf::render_target_t& target, const wf::region_t& damage,
+        const std::function<void()> & callback);
+
+    /**
+     * Bind a gpu_buffer_t to this command buffer, keeping it alive until the command buffer is reset.
+     * This is useful for vertex buffers, uniform buffers, etc. that need to stay allocated while the GPU
+     * is executing the commands.
+     */
+    void bind_buffer(std::shared_ptr<gpu_buffer_t> buffer);
+
+    /**
+     * Bind a texture to this command buffer, keeping it alive until the command buffer is reset.
+     */
+    void bind_texture(const std::shared_ptr<wf::texture_t>& texture);
+
+    operator VkCommandBuffer() const
+    {
+        return cmd;
+    }
+
+    command_buffer_t(const command_buffer_t&) = delete;
+    command_buffer_t(command_buffer_t&&) = delete;
+    command_buffer_t& operator =(const command_buffer_t&) = delete;
+    command_buffer_t& operator =(command_buffer_t&&) = delete;
+};
+
+/**
+ * Manages a pool of descriptor sets for image sampling.
+ */
+/**
+ * A GPU buffer allocated via a context_t.
+ * The buffer is host-visible and host-coherent, so it can be mapped for CPU access.
+ * Suitable for uniform buffers, vertex buffers, or any other buffer usage.
+ *
+ * Use context_t::create_buffer() to allocate, and command_buffer_t::bind_buffer() to keep it alive
+ * for the duration of a command buffer's execution.
+ */
+class gpu_buffer_t : public std::enable_shared_from_this<gpu_buffer_t>
+{
+  public:
+    ~gpu_buffer_t();
+
+    gpu_buffer_t(const gpu_buffer_t&) = delete;
+    gpu_buffer_t(gpu_buffer_t&&) = delete;
+    gpu_buffer_t& operator =(const gpu_buffer_t&) = delete;
+    gpu_buffer_t& operator =(gpu_buffer_t&&) = delete;
+
+    /**
+     * Get the underlying VkBuffer handle.
+     */
+    const VkBuffer& get_buffer() const
+    {
+        return buffer;
+    }
+
+    /**
+     * Get the size of the buffer in bytes.
+     */
+    const VkDeviceSize& get_size() const
+    {
+        return size;
+    }
+
+    /**
+     * Map the buffer memory and copy data into it.
+     * @param data Pointer to the source data.
+     * @param data_size Size of the data to copy in bytes. Must be <= get_size().
+     * @param offset Offset into the buffer to start writing at.
+     * @return true if the data was successfully written.
+     */
+    bool write(const void *data, VkDeviceSize data_size, VkDeviceSize offset = 0);
+
+    /**
+     * Map the buffer memory for direct access.
+     * The caller must call unmap() when done.
+     * @return Pointer to the mapped memory, or nullptr on failure.
+     */
+    void *map(VkDeviceSize offset = 0, VkDeviceSize map_size = VK_WHOLE_SIZE);
+
+    /**
+     * Unmap previously mapped buffer memory.
+     */
+    void unmap();
+
+    operator VkBuffer() const
+    {
+        return buffer;
+    }
+
+  private:
+    friend class context_t;
+    gpu_buffer_t(std::shared_ptr<context_t> ctx, VkBuffer buffer, VkDeviceMemory memory, VkDeviceSize size);
+
+    std::shared_ptr<context_t> context;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    VkDeviceSize size     = 0;
+};
+
+/**
+ * The texture sampling parameters indicate how to sample from a texture.
+ *
+ * We may need to apply a transformation (rotation) of the buffer and/or sample from a particular subregion
+ * of the image.
+ */
+struct texture_sampling_params_t
+{
+    /**
+     * Initialize the sampling parameters for the given texture.
+     */
+    texture_sampling_params_t(const std::shared_ptr<wf::texture_t>& texture);
+
+    /**
+     * Get the UV scale to apply when sampling the texture.
+     * This is used to sample from a subregion of the texture, starting from uv_offset to
+     * uv_offset + uv_scale.
+     */
+    const glm::vec2& get_uv_scale() const
+    {
+        return uv_scale;
+    }
+
+    /**
+     * Get the UV offset to apply when sampling the texture.
+     * This is used to sample from a subregion of the texture, starting from uv_offset to
+     * uv_offset + uv_scale.
+     */
+    const glm::vec2& get_uv_offset() const
+    {
+        return uv_offset;
+    }
+
+  private:
+    glm::vec2 uv_scale{1, 1};
+    glm::vec2 uv_offset{0, 0};
+};
+
+class image_descriptor_set_pool_t : public std::enable_shared_from_this<image_descriptor_set_pool_t>
+{
+    std::shared_ptr<context_t> context;
+
+  public:
+    image_descriptor_set_pool_t(std::shared_ptr<context_t> ctx);
+    ~image_descriptor_set_pool_t();
+
+    /**
+     * Get or allocate descriptor set for the given command buffer and texture.
+     * The first binding in the set is used as a combined image sampler pointing to the texture.
+     *
+     * The descriptor set will match the layout returned by context_t::get_image_descriptor_set_layout().
+     */
+    VkDescriptorSet get_descriptor_set(
+        command_buffer_t& cmd_buf, const std::shared_ptr<wf::texture_t>& texture);
+};
+
+class context_t : public std::enable_shared_from_this<context_t>
+{
+  public:
+    /**
+     * Create a new vulkan context from the given wlr_renderer.
+     * The renderer needs to be a vulkan renderer.
+     */
+    context_t(wlr_renderer *renderer);
+    ~context_t();
+    context_t(const context_t&) = delete;
+    context_t(context_t&&) = delete;
+    context_t& operator =(const context_t&) = delete;
+    context_t& operator =(context_t&&) = delete;
+
+    VkShaderModule load_shader_module(std::string_view path);
+    VkShaderModule load_shader_module(const uint32_t *data, size_t size);
+
+    /**
+     * Create a GPU buffer with the given size and usage flags.
+     * The buffer is allocated with host-visible and host-coherent memory, making it suitable for
+     * CPU writes. Common usage flags include VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT and
+     * VK_BUFFER_USAGE_VERTEX_BUFFER_BIT.
+     *
+     * @param size Size of the buffer in bytes.
+     * @param usage Vulkan buffer usage flags.
+     * @return A shared pointer to the created buffer, or nullptr on failure.
+     */
+    std::shared_ptr<gpu_buffer_t> create_buffer(VkDeviceSize size, VkBufferUsageFlags usage);
+
+    VkDevice get_device() const
+    {
+        return device;
+    }
+
+    VkQueue get_queue() const
+    {
+        return queue;
+    }
+
+    VkPhysicalDevice get_physical_device() const
+    {
+        return physical_device;
+    }
+
+    /**
+     * Get the wlr_renderer associated with this context.
+     */
+    wlr_renderer *get_renderer() const
+    {
+        return renderer;
+    }
+
+  private:
+    // Vulkan core objects
+    wlr_renderer *renderer = nullptr;
+    VkDevice device;
+    VkPhysicalDevice physical_device;
+    VkQueue queue;
+};
+
+struct pipeline_shader_t
+{
+    VkShaderStageFlagBits stage;
+    // Can be either file names (std::string) or preloaded VkShaderModules.
+    // Note that the pipeline will take ownership of any VkShaderModule passed here.
+    std::variant<std::string, VkShaderModule> shader;
+};
+
+struct blending_params_t
+{
+    // If not set, blending is disabled.
+    std::optional<VkBlendOp> blend_op = VK_BLEND_OP_ADD;
+    VkBlendFactor src_factor = VK_BLEND_FACTOR_ONE;
+    VkBlendFactor dst_factor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
+
+    // If not set, same as color blending is used.
+    std::optional<VkBlendOp> alpha_blend_op = {};
+    std::optional<VkBlendFactor> alpha_src_factor = {};
+    std::optional<VkBlendFactor> alpha_dst_factor = {};
+};
+
+struct pipeline_params_t
+{
+    struct texture_descriptor_set_t {};
+
+    // List of shaders for the pipeline.
+    std::vector<pipeline_shader_t> shaders;
+
+    // Descriptor set layouts used in the pipeline.
+    // Each texture_descriptor_set_t will be replaced with an appropriate descriptor set when specializing
+    // the pipeline with pipeline_specialization_t::add_specialization_for_texture():
+    // the i-th texture_descriptor_set_t in the descriptor layout list will be replaced with a descriptor set
+    // layout for the i-th texture specialization.
+    std::vector<std::variant<VkDescriptorSetLayout, texture_descriptor_set_t>> descriptor_set_layouts;
+
+    // Vertex input description
+    VkPrimitiveTopology topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN;
+    std::vector<VkVertexInputAttributeDescription> vertex_attribute_description;
+    std::vector<VkVertexInputBindingDescription> vertex_input_description;
+
+    // Push constants for the shader
+    std::vector<VkPushConstantRange> push_constants;
+
+    // Blending parameters
+    blending_params_t blending{};
+};
+
+/**
+ * A helper class to create and manage a graphics pipeline.
+ * This involves the creation of render passes as well as pipelines as needed for various output buffer
+ * formats.
+ */
+class graphics_pipeline_t
+{
+  public:
+    graphics_pipeline_t(std::shared_ptr<context_t> ctx, const pipeline_params_t& params);
+    ~graphics_pipeline_t();
+
+    graphics_pipeline_t(const graphics_pipeline_t&) = delete;
+    graphics_pipeline_t(graphics_pipeline_t&&) = delete;
+    graphics_pipeline_t& operator =(const graphics_pipeline_t&) = delete;
+    graphics_pipeline_t& operator =(graphics_pipeline_t&&) = delete;
+
+    /**
+     * Get or create a pipeline for the given render pass and specialization.
+     * If no specialization is provided, a pipeline with no specialization constants is used.
+     * Pipelines are cached by (render pass, specialization data) pairs.
+     */
+    std::pair<VkPipelineLayout, VkPipeline> pipeline_for(const command_buffer_t& pass,
+        const pipeline_specialization_t& specialization = pipeline_specialization_t{});
+
+  private:
+    std::shared_ptr<context_t> context;
+    pipeline_params_t params;
+    std::vector<VkShaderModule> loaded_shader_modules;
+
+    // Cache key: (render pass, specialization data bytes, specialization texture ds)
+    using pipeline_key_t = std::tuple<VkRenderPass, std::vector<std::byte>,
+        std::vector<VkDescriptorSetLayout>>;
+    std::map<pipeline_key_t, std::pair<VkPipelineLayout, VkPipeline>> pipelines;
+};
+
+/**
+ * Helper method to calculate a 4x4 matrix which maps the unit square [0,1]x[0,1] to the given box.
+ */
+glm::mat4 geometry_mat(const wf::geometry_t& box);
+
+/**
+ * Helper method to calculate a transformation from logical render target coordinates to final NDC space.
+ */
+glm::mat4 render_target_transform(const wf::render_target_t& target);
+}
+
+/**
+ * Global vulkan state managed in core.
+ */
+class vulkan_render_state_t : public wf::object_base_t
+{
+  public:
+    /**
+     * Gets the vulkan state allocated and managed by core.
+     * Note that plugins are free to create and manage their own vulkan contexts, but this is provided as a
+     * convenience for plugins so that we can reuse command buffers between multiple plugins.
+     */
+    static vulkan_render_state_t& get();
+
+    std::shared_ptr<wf::vk::context_t> get_context() const
+    {
+        return context;
+    }
+
+    std::shared_ptr<wf::vk::image_descriptor_set_pool_t> get_descriptor_pool() const
+    {
+        return descriptor_pool;
+    }
+
+    vulkan_render_state_t(wlr_renderer *renderer);
+
+  private:
+    std::shared_ptr<wf::vk::context_t> context;
+    std::shared_ptr<wf::vk::image_descriptor_set_pool_t> descriptor_pool;
+};
+}
+
+#endif

--- a/src/core/core-impl.hpp
+++ b/src/core/core-impl.hpp
@@ -8,6 +8,7 @@
 #include "wayfire/scene.hpp"
 #include "wayfire/util.hpp"
 #include <wayfire/nonstd/wlroots-full.hpp>
+#include <wayfire/vulkan.hpp>
 
 namespace wf
 {
@@ -20,6 +21,10 @@ class compositor_core_impl_t : public compositor_core_t
     // If NULL, we are not running in GLES mode.
     wlr_egl *egl = NULL;
     wlr_compositor *compositor;
+
+#if WF_HAS_VULKANFX
+    std::unique_ptr<wf::vulkan_render_state_t> vulkan_state;
+#endif
 
     std::unique_ptr<wf::input_manager_t> input;
     std::unique_ptr<input_method_relay> im_relay;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -254,6 +254,14 @@ void wf::compositor_core_impl_t::init()
         OpenGL::init();
     }
 
+#if WF_HAS_VULKANFX
+    if (is_vulkan())
+    {
+        this->vulkan_state = std::make_unique<wf::vulkan_render_state_t>(renderer);
+    }
+
+#endif
+
     increase_nofile_limit();
 
     this->state = compositor_state_t::START_BACKEND;
@@ -369,7 +377,12 @@ void wf::compositor_core_impl_t::fini()
     input.reset();
     output_layout.reset();
     tx_manager.reset();
+
     OpenGL::fini();
+#if WF_HAS_VULKANFX
+    vulkan_state.reset();
+#endif
+
     disconnect_signals();
     wl_display_destroy(static_core->display);
 }

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -448,7 +448,8 @@ wf::gles_texture_t::gles_texture_t(GLuint tex)
     this->tex_id = tex;
 }
 
-wf::gles_texture_t::gles_texture_t(wf::texture_t tex) : wf::gles_texture_t(tex.texture, tex.source_box)
+wf::gles_texture_t::gles_texture_t(const std::shared_ptr<wf::texture_t>& tex) :
+    wf::gles_texture_t(tex->get_wlr_texture(), tex->get_source_box())
 {}
 
 wf::gles_texture_t::gles_texture_t(wlr_texture *texture, std::optional<wlr_fbox> viewport)

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -358,7 +358,7 @@ struct output_layout_output_t
     bool is_nested_compositor  = false;
     bool inhibited = false;
     std::map<int, std::vector<uint32_t>> formats_for_depth;
-    int current_bit_depth = RENDER_BIT_DEPTH_DEFAULT;
+    int current_bit_depth = 0;
 
     std::unique_ptr<wf::output_impl_t> output;
     wl_listener_wrapper on_destroy, on_commit, on_request_state;

--- a/src/core/vulkan.cpp
+++ b/src/core/vulkan.cpp
@@ -1,0 +1,582 @@
+#include "core/core-impl.hpp"
+#include "wayfire/opengl.hpp"
+#include <wayfire/vulkan.hpp>
+#include <fstream>
+#include <wayfire/util/log.hpp>
+#include <drm_fourcc.h>
+#include <cstring>
+#include <glm/gtc/matrix_transform.hpp>
+
+extern "C"
+{
+#include <wlr/interfaces/wlr_buffer.h>
+}
+
+namespace wf
+{
+namespace vk
+{
+static uint32_t find_memory_type(VkPhysicalDevice physical_device, uint32_t type_filter,
+    VkMemoryPropertyFlags properties)
+{
+    VkPhysicalDeviceMemoryProperties mem_properties;
+    vkGetPhysicalDeviceMemoryProperties(physical_device, &mem_properties);
+
+    for (uint32_t i = 0; i < mem_properties.memoryTypeCount; i++)
+    {
+        if ((type_filter & (1 << i)) &&
+            ((mem_properties.memoryTypes[i].propertyFlags & properties) == properties))
+        {
+            return i;
+        }
+    }
+
+    return UINT32_MAX;
+}
+
+// --- gpu_buffer_t implementation ---
+gpu_buffer_t::gpu_buffer_t(std::shared_ptr<context_t> ctx, VkBuffer buffer, VkDeviceMemory memory,
+    VkDeviceSize size) :
+    context(std::move(ctx)), buffer(buffer), memory(memory), size(size)
+{}
+
+gpu_buffer_t::~gpu_buffer_t()
+{
+    if (buffer != VK_NULL_HANDLE)
+    {
+        vkDestroyBuffer(context->get_device(), buffer, nullptr);
+    }
+
+    if (memory != VK_NULL_HANDLE)
+    {
+        vkFreeMemory(context->get_device(), memory, nullptr);
+    }
+}
+
+bool gpu_buffer_t::write(const void *data, VkDeviceSize data_size, VkDeviceSize offset)
+{
+    if ((offset + data_size) > size)
+    {
+        LOGE("gpu_buffer_t::write: data_size + offset exceeds buffer size");
+        return false;
+    }
+
+    void *mapped = map(offset, data_size);
+    if (!mapped)
+    {
+        return false;
+    }
+
+    memcpy(mapped, data, data_size);
+    unmap();
+    return true;
+}
+
+void*gpu_buffer_t::map(VkDeviceSize offset, VkDeviceSize map_size)
+{
+    void *mapped = nullptr;
+    if (vkMapMemory(context->get_device(), memory, offset, map_size, 0, &mapped) != VK_SUCCESS)
+    {
+        LOGE("Failed to map gpu_buffer_t memory");
+        return nullptr;
+    }
+
+    return mapped;
+}
+
+void gpu_buffer_t::unmap()
+{
+    vkUnmapMemory(context->get_device(), memory);
+}
+
+texture_sampling_params_t::texture_sampling_params_t(const std::shared_ptr<wf::texture_t>& texture)
+{
+    if (texture->get_source_box())
+    {
+        uv_offset.x = texture->get_source_box()->x / static_cast<float>(texture->get_width());
+        uv_offset.y = texture->get_source_box()->y / static_cast<float>(texture->get_height());
+        uv_scale.x  = texture->get_source_box()->width / static_cast<float>(texture->get_width());
+        uv_scale.y  = texture->get_source_box()->height / static_cast<float>(texture->get_height());
+    }
+}
+
+image_descriptor_set_pool_t::image_descriptor_set_pool_t(std::shared_ptr<context_t> ctx)
+{
+    this->context = std::move(ctx);
+}
+
+image_descriptor_set_pool_t::~image_descriptor_set_pool_t() = default;
+
+VkDescriptorSet image_descriptor_set_pool_t::get_descriptor_set(
+    command_buffer_t& cmd_buf, const std::shared_ptr<wf::texture_t>& texture)
+{
+    return wlr_vk_render_pass_get_texture_ds(cmd_buf.wlr_pass, texture->get_wlr_texture(),
+        texture->get_filter_mode().value_or(WLR_SCALE_FILTER_BILINEAR),
+        texture->get_color_transform().transfer_function);
+}
+
+command_buffer_t::command_buffer_t(std::shared_ptr<context_t> ctx, wf::render_pass_t& pass) :
+    context(ctx)
+{
+    this->cmd = wlr_vk_render_pass_get_command_buffer(pass.get_wlr_pass());
+    this->current_pass = wlr_vk_render_pass_get_render_pass(pass.get_wlr_pass());
+    this->wlr_pass     = pass.get_wlr_pass();
+}
+
+command_buffer_t::~command_buffer_t()
+{
+    bound_pipelines.clear();
+    bound_buffers.clear();
+    reset_signal data;
+    emit(&data);
+}
+
+static void handle_release_resources(void *user_data)
+{
+    auto *cmd_buf = static_cast<command_buffer_t*>(user_data);
+    // LOGI("Render pass is releasing resources, deleting command buffer");
+    delete cmd_buf;
+}
+
+command_buffer_t& command_buffer_t::buffer_for_pass(wf::render_pass_t& pass)
+{
+    auto ctx = vulkan_render_state_t::get().get_context();
+
+    // Will be freed by handle_release_resources callback when the render pass is really completed.
+    auto *cmd_buf = new command_buffer_t(ctx, pass);
+    wlr_vk_render_pass_set_resources_callback(pass.get_wlr_pass(), handle_release_resources, cmd_buf);
+    return *cmd_buf;
+}
+
+void command_buffer_t::bind_buffer(std::shared_ptr<gpu_buffer_t> buffer)
+{
+    bound_buffers.push_back(std::move(buffer));
+}
+
+void command_buffer_t::bind_texture(const std::shared_ptr<wf::texture_t>& texture)
+{
+    bound_textures.push_back(texture);
+}
+
+std::pair<VkPipelineLayout, VkPipeline> command_buffer_t::bind_pipeline(
+    std::shared_ptr<graphics_pipeline_t> pipeline,
+    const wf::render_target_t& target, const pipeline_specialization_t& specialization)
+{
+    bound_pipelines.push_back(pipeline);
+
+    auto [pipeline_layout, vk_pipeline] = pipeline->pipeline_for(*this, specialization);
+    vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, vk_pipeline);
+    return {pipeline_layout, vk_pipeline};
+}
+
+void command_buffer_t::set_full_viewport(const wf::render_target_t& target)
+{
+    VkViewport viewport{
+        .x     = 0.0f,
+        .y     = 0.0f,
+        .width = static_cast<float>(target.get_size().width),
+        .height   = static_cast<float>(target.get_size().height),
+        .minDepth = 0.0f,
+        .maxDepth = 1.0f,
+    };
+
+    vkCmdSetViewport(*this, 0, 1, &viewport);
+}
+
+void command_buffer_t::for_each_scissor_rect(const wf::render_target_t& target, const wf::region_t& damage,
+    const std::function<void()> & callback)
+{
+    auto buffer_damage = target.framebuffer_region_from_geometry_region(damage);
+    for (const auto& box : buffer_damage)
+    {
+        VkRect2D scissor{
+            .offset = {box.x1, box.y1},
+            .extent = {static_cast<uint32_t>(box.x2 - box.x1), static_cast<uint32_t>(box.y2 - box.y1)},
+        };
+
+        vkCmdSetScissor(*this, 0, 1, &scissor);
+        callback();
+    }
+
+    wlr_vk_render_pass_mark_updated(wlr_pass, buffer_damage.to_pixman());
+}
+
+context_t::context_t(wlr_renderer *renderer) : renderer(renderer)
+{
+    this->device = wlr_vk_renderer_get_device(renderer);
+    this->physical_device = wlr_vk_renderer_get_physical_device(renderer);
+    uint32_t queue_family = wlr_vk_renderer_get_queue_family(renderer);
+
+    // Get the graphics queue
+    vkGetDeviceQueue(device, queue_family, 0, &queue);
+}
+
+context_t::~context_t()
+{}
+
+VkShaderModule context_t::load_shader_module(std::string_view path)
+{
+    std::ifstream file(std::string(path), std::ios::ate | std::ios::binary);
+    if (!file.is_open())
+    {
+        LOGE("Failed to open shader file: ", path);
+        return VK_NULL_HANDLE;
+    }
+
+    size_t file_size = (size_t)file.tellg();
+    std::vector<uint8_t> buffer(file_size);
+    file.seekg(0);
+    file.read(reinterpret_cast<char*>(buffer.data()), file_size);
+    file.close();
+
+    while (buffer.size() % 4 != 0)
+    {
+        buffer.push_back(0);
+    }
+
+    return load_shader_module(reinterpret_cast<const uint32_t*>(buffer.data()), buffer.size() / 4);
+}
+
+VkShaderModule context_t::load_shader_module(const uint32_t *data, size_t size)
+{
+    if (!data || (size == 0))
+    {
+        LOGE("Invalid shader data or size");
+        return VK_NULL_HANDLE;
+    }
+
+    VkShaderModuleCreateInfo create_info{};
+    create_info.sType    = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    create_info.codeSize = size;
+    create_info.pCode    = data;
+
+    VkShaderModule shader_module;
+    if (vkCreateShaderModule(device, &create_info, nullptr, &shader_module) != VK_SUCCESS)
+    {
+        LOGE("Failed to create shader module");
+        return VK_NULL_HANDLE;
+    }
+
+    return shader_module;
+}
+
+std::shared_ptr<gpu_buffer_t> context_t::create_buffer(VkDeviceSize size, VkBufferUsageFlags usage)
+{
+    VkBufferCreateInfo buffer_info{};
+    buffer_info.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buffer_info.size  = size;
+    buffer_info.usage = usage;
+    buffer_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    VkBuffer buffer;
+    if (vkCreateBuffer(device, &buffer_info, nullptr, &buffer) != VK_SUCCESS)
+    {
+        LOGE("Failed to create GPU buffer");
+        return nullptr;
+    }
+
+    VkMemoryRequirements mem_requirements;
+    vkGetBufferMemoryRequirements(device, buffer, &mem_requirements);
+
+    uint32_t memory_type = find_memory_type(physical_device,
+        mem_requirements.memoryTypeBits,
+        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    if (memory_type == UINT32_MAX)
+    {
+        LOGE("Failed to find suitable memory type for GPU buffer");
+        vkDestroyBuffer(device, buffer, nullptr);
+        return nullptr;
+    }
+
+    VkMemoryAllocateInfo alloc_info{};
+    alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    alloc_info.allocationSize  = mem_requirements.size;
+    alloc_info.memoryTypeIndex = memory_type;
+
+    VkDeviceMemory memory;
+    if (vkAllocateMemory(device, &alloc_info, nullptr, &memory) != VK_SUCCESS)
+    {
+        LOGE("Failed to allocate memory for GPU buffer");
+        vkDestroyBuffer(device, buffer, nullptr);
+        return nullptr;
+    }
+
+    vkBindBufferMemory(device, buffer, memory, 0);
+
+    // Use the private constructor via shared_ptr with a custom make (can't use make_shared with private ctor)
+    return std::shared_ptr<gpu_buffer_t>(
+        new gpu_buffer_t(shared_from_this(), buffer, memory, size));
+}
+
+void pipeline_specialization_t::add_specialization_for_texture(const std::shared_ptr<wf::texture_t>& texture,
+    const uint32_t constant_id, const uint32_t offset)
+{
+    add_specialization(constant_id, offset, (uint32_t)texture->get_color_transform().transfer_function);
+    // We need to flip 180 degrees because for Vulkan, 0,0 is top left
+    auto total_transform =
+        wlr_output_transform_compose(texture->get_transform(), WL_OUTPUT_TRANSFORM_FLIPPED_180);
+    add_specialization(constant_id + 1, offset + sizeof(uint32_t), total_transform);
+    specialized_textures.push_back(texture);
+}
+
+void pipeline_specialization_t::_add_specialization(
+    uint32_t constant_id, uint32_t offset, const void *data, size_t size)
+{
+    // Ensure the data buffer is large enough to hold the new entry
+    if (specialization_data.size() < offset + size)
+    {
+        specialization_data.resize(offset + size);
+    }
+
+    // Copy the data into the buffer at the given offset
+    std::memcpy(specialization_data.data() + offset, data, size);
+
+    // Record the specialization map entry
+    VkSpecializationMapEntry entry{};
+    entry.constantID = constant_id;
+    entry.offset     = offset;
+    entry.size = size;
+    entries.push_back(entry);
+}
+
+graphics_pipeline_t::graphics_pipeline_t(std::shared_ptr<context_t> ctx, const pipeline_params_t& params) :
+    context(ctx)
+{
+    // Store pipeline params for later use
+    this->params = params;
+
+    // Load all shader modules in advance and store them
+    for (const auto& shader : params.shaders)
+    {
+        if (std::holds_alternative<std::string>(shader.shader))
+        {
+            VkShaderModule module = context->load_shader_module(std::get<std::string>(shader.shader));
+            loaded_shader_modules.push_back(module);
+        } else
+        {
+            loaded_shader_modules.push_back(std::get<VkShaderModule>(shader.shader));
+        }
+    }
+}
+
+graphics_pipeline_t::~graphics_pipeline_t()
+{
+    // Destroy all pipelines and render passes
+    for (auto& [pass, pf] : pipelines)
+    {
+        vkDestroyPipelineLayout(context->get_device(), pf.first, nullptr);
+        vkDestroyPipeline(context->get_device(), pf.second, nullptr);
+    }
+
+    // Destroy loaded shader modules
+    for (auto module : loaded_shader_modules)
+    {
+        if (module != VK_NULL_HANDLE)
+        {
+            vkDestroyShaderModule(context->get_device(), module, nullptr);
+        }
+    }
+}
+
+std::pair<VkPipelineLayout, VkPipeline> graphics_pipeline_t::pipeline_for(const command_buffer_t& cmd_buf,
+    const pipeline_specialization_t& specialization)
+{
+    std::vector<VkDescriptorSetLayout> specialization_filters;
+    for (const auto& texture : specialization.specialized_textures)
+    {
+        auto dsl = wlr_vk_render_pass_get_texture_ds_layout(cmd_buf.wlr_pass, texture->get_wlr_texture(),
+            texture->get_filter_mode().value_or(WLR_SCALE_FILTER_BILINEAR),
+            texture->get_color_transform().transfer_function);
+        specialization_filters.push_back(dsl);
+    }
+
+    pipeline_key_t key{cmd_buf.current_pass, specialization.get_data(), specialization_filters};
+    auto it = pipelines.find(key);
+    if (it != pipelines.end())
+    {
+        return it->second;
+    }
+
+    // Create pipeline layout from descriptor set layouts and push constants
+    VkPipelineLayout layout = VK_NULL_HANDLE;
+    std::vector<VkDescriptorSetLayout> specialized_layouts;
+    size_t specialized_idx = 0;
+    for (const auto& layout_variant : params.descriptor_set_layouts)
+    {
+        if (std::holds_alternative<VkDescriptorSetLayout>(layout_variant))
+        {
+            specialized_layouts.push_back(std::get<VkDescriptorSetLayout>(layout_variant));
+        } else if (specialized_idx < specialization_filters.size())
+        {
+            specialized_layouts.push_back(specialization_filters[specialized_idx++]);
+        } else
+        {
+            LOGE("Not enough specialization filters provided for pipeline specialization");
+            return {VK_NULL_HANDLE, VK_NULL_HANDLE};
+        }
+    }
+
+    VkPipelineLayoutCreateInfo layout_info{};
+    layout_info.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    layout_info.setLayoutCount = specialized_layouts.size();
+    layout_info.pSetLayouts    = specialized_layouts.data();
+    layout_info.pushConstantRangeCount = params.push_constants.size();
+    layout_info.pPushConstantRanges    = params.push_constants.data();
+    if (vkCreatePipelineLayout(context->get_device(), &layout_info, nullptr, &layout) != VK_SUCCESS)
+    {
+        LOGE("Failed to create pipeline layout");
+        return {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    }
+
+    // Build VkSpecializationInfo if we have specialization constants
+    VkSpecializationInfo spec_info{};
+    const bool has_specialization = !specialization.get_entries().empty();
+    if (has_specialization)
+    {
+        spec_info.mapEntryCount = specialization.get_entries().size();
+        spec_info.pMapEntries   = specialization.get_entries().data();
+        spec_info.dataSize = specialization.get_data().size();
+        spec_info.pData    = specialization.get_data().data();
+    }
+
+    // --- Pipeline creation ---
+    std::vector<VkPipelineShaderStageCreateInfo> shader_stages;
+    for (size_t i = 0; i < params.shaders.size(); ++i)
+    {
+        const auto& shader = params.shaders[i];
+        VkPipelineShaderStageCreateInfo stage_info{};
+        stage_info.sType  = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+        stage_info.stage  = shader.stage;
+        stage_info.module = loaded_shader_modules[i];
+        stage_info.pName  = "main";
+        stage_info.pSpecializationInfo = has_specialization ? &spec_info : nullptr;
+        shader_stages.push_back(stage_info);
+    }
+
+    VkPipelineVertexInputStateCreateInfo vertex_input_info{};
+    vertex_input_info.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vertex_input_info.vertexBindingDescriptionCount = params.vertex_input_description.size();
+    vertex_input_info.pVertexBindingDescriptions    = params.vertex_input_description.data();
+    vertex_input_info.vertexAttributeDescriptionCount = params.vertex_attribute_description.size();
+    vertex_input_info.pVertexAttributeDescriptions    = params.vertex_attribute_description.data();
+
+    VkPipelineInputAssemblyStateCreateInfo input_assembly{};
+    input_assembly.sType    = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    input_assembly.topology = params.topology;
+    input_assembly.primitiveRestartEnable = VK_FALSE;
+
+    VkViewport viewport{};
+    viewport.x     = 0.0f;
+    viewport.y     = 0.0f;
+    viewport.width = 1.0f;
+    viewport.height   = 1.0f;
+    viewport.minDepth = 0.0f;
+    viewport.maxDepth = 1.0f;
+
+    VkRect2D scissor{};
+    scissor.offset = {0, 0};
+    scissor.extent = {1, 1};
+
+    VkPipelineViewportStateCreateInfo viewport_state{};
+    viewport_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    viewport_state.viewportCount = 1;
+    viewport_state.pViewports    = nullptr; // Dynamic
+    viewport_state.scissorCount  = 1;
+    viewport_state.pScissors     = nullptr; // Dynamic
+
+    VkPipelineRasterizationStateCreateInfo rasterizer{};
+    rasterizer.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rasterizer.depthClampEnable = VK_FALSE;
+    rasterizer.rasterizerDiscardEnable = VK_FALSE;
+    rasterizer.polygonMode = VK_POLYGON_MODE_FILL;
+    rasterizer.lineWidth   = 1.0f;
+    rasterizer.cullMode    = VK_CULL_MODE_NONE;
+    rasterizer.frontFace   = VK_FRONT_FACE_COUNTER_CLOCKWISE;
+    rasterizer.depthBiasEnable = VK_FALSE;
+
+    VkPipelineMultisampleStateCreateInfo multisampling{};
+    multisampling.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    multisampling.sampleShadingEnable  = VK_FALSE;
+    multisampling.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineColorBlendAttachmentState color_blend_attachment{};
+    color_blend_attachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+        VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    color_blend_attachment.blendEnable = params.blending.blend_op.has_value() ? VK_TRUE : VK_FALSE;
+    color_blend_attachment.srcColorBlendFactor = params.blending.src_factor;
+    color_blend_attachment.dstColorBlendFactor = params.blending.dst_factor;
+    color_blend_attachment.colorBlendOp = params.blending.blend_op.value_or(VK_BLEND_OP_ADD);
+    color_blend_attachment.srcAlphaBlendFactor =
+        params.blending.alpha_src_factor.value_or(params.blending.src_factor);
+    color_blend_attachment.dstAlphaBlendFactor =
+        params.blending.alpha_dst_factor.value_or(params.blending.dst_factor);
+    color_blend_attachment.alphaBlendOp = params.blending.alpha_blend_op.value_or(
+        params.blending.blend_op.value_or(VK_BLEND_OP_ADD));
+
+    VkPipelineColorBlendStateCreateInfo color_blending{};
+    color_blending.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    color_blending.logicOpEnable   = VK_FALSE;
+    color_blending.attachmentCount = 1;
+    color_blending.pAttachments    = &color_blend_attachment;
+
+    VkDynamicState dynamic_states[] = {VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR};
+    VkPipelineDynamicStateCreateInfo dynamic_state_info{};
+    dynamic_state_info.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dynamic_state_info.dynamicStateCount = 2;
+    dynamic_state_info.pDynamicStates    = dynamic_states;
+
+    VkGraphicsPipelineCreateInfo pipeline_info{};
+    pipeline_info.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipeline_info.stageCount = shader_stages.size();
+    pipeline_info.pStages    = shader_stages.data();
+    pipeline_info.pVertexInputState   = &vertex_input_info;
+    pipeline_info.pInputAssemblyState = &input_assembly;
+    pipeline_info.pViewportState = &viewport_state;
+    pipeline_info.pRasterizationState = &rasterizer;
+    pipeline_info.pMultisampleState   = &multisampling;
+    pipeline_info.pColorBlendState    = &color_blending;
+    pipeline_info.layout     = layout;
+    pipeline_info.renderPass = cmd_buf.current_pass;
+    pipeline_info.subpass    = 0;
+    pipeline_info.pDynamicState = &dynamic_state_info;
+
+    VkPipeline pipeline;
+    if (vkCreateGraphicsPipelines(
+        context->get_device(), VK_NULL_HANDLE, 1, &pipeline_info, nullptr, &pipeline) != VK_SUCCESS)
+    {
+        LOGE("Failed to create graphics pipeline for pass: ", cmd_buf.current_pass);
+        vkDestroyPipelineLayout(context->get_device(), layout, nullptr);
+        return {VK_NULL_HANDLE, VK_NULL_HANDLE};
+    }
+
+    // Store the pipeline keyed by (render pass, specialization data)
+    pipelines[key] = {layout, pipeline};
+    return {layout, pipeline};
+}
+
+glm::mat4 render_target_transform(const wf::render_target_t& target)
+
+{
+    auto ortho = glm::ortho(
+        1.0f * target.geometry.x,
+        1.0f * target.geometry.x + 1.0f * target.geometry.width,
+        1.0f * target.geometry.y,
+        1.0f * target.geometry.y + 1.0f * target.geometry.height);
+
+    ortho[1][1] *= -1; // Invert Y axis to match Vulkan's coordinate system
+    return ortho * gles::render_target_gl_to_framebuffer(target);
+}
+} // namespace vk
+
+vulkan_render_state_t::vulkan_render_state_t(wlr_renderer *renderer)
+{
+    this->context = std::make_shared<wf::vk::context_t>(renderer);
+    this->descriptor_pool = std::make_shared<wf::vk::image_descriptor_set_pool_t>(context);
+}
+
+vulkan_render_state_t& vulkan_render_state_t::get()
+{
+    auto& core_impl = wf::get_core_impl();
+    return *core_impl.vulkan_state;
+}
+} // namespace wf

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -80,6 +80,16 @@ bool operator !=(const wf::geometry_t& a, const wf::geometry_t& b)
     return !(a == b);
 }
 
+bool operator ==(const wlr_fbox& a, const wlr_fbox& b)
+{
+    return a.x == b.x && a.y == b.y && a.width == b.width && a.height == b.height;
+}
+
+bool operator !=(const wlr_fbox& a, const wlr_fbox& b)
+{
+    return !(a == b);
+}
+
 wf::point_t wf::operator +(const wf::point_t& a, const wf::point_t& b)
 {
     return {a.x + b.x, a.y + b.y};

--- a/src/meson.build
+++ b/src/meson.build
@@ -69,6 +69,12 @@ wayfire_dependencies = [wayland_server, wlroots, xkbcommon, libinput,
                        wfconfig, libinotify, backtrace, wfutils, xcb,
                        wftouch, json_flags, udev]
 
+if use_vulkan
+  wayfire_dependencies += vulkan
+  wayfire_sources += vulkan_shaders
+  wayfire_sources += 'core/vulkan.cpp'
+endif
+
 if conf_data.get('BUILD_WITH_IMAGEIO')
     wayfire_dependencies += [jpeg, png]
 endif
@@ -157,7 +163,7 @@ if wlroots_features['gles2_renderer']
   public_api_requirements += glesv2
 endif
 
-if wlroots_features['vulkan_renderer']
+if use_vulkan
   public_api_requirements += vulkan
 endif
 

--- a/src/output/render-manager.cpp
+++ b/src/output/render-manager.cpp
@@ -812,7 +812,14 @@ class wf::render_manager::impl
 
     wlr_color_transform *get_color_transform()
     {
-        return icc_color_transform;
+        if (icc_color_transform)
+        {
+            return icc_color_transform;
+        }
+
+        static wlr_color_transform *default_transform =
+            wlr_color_transform_init_linear_to_inverse_eotf(WLR_COLOR_TRANSFER_FUNCTION_SRGB);
+        return default_transform;
     }
 
     impl(output_t *o) : output(o), env_allow_scanout(check_scanout_enabled())
@@ -1013,8 +1020,8 @@ class wf::render_manager::impl
         params.flags    = RPASS_CLEAR_BACKGROUND | RPASS_EMIT_SIGNALS;
 
         pass_opts.timer = NULL; // TODO: do we care about this? could be useful for dynamic frame scheduling
-        pass_opts.color_transform = icc_color_transform;
-        params.pass_opts   = &pass_opts;
+        pass_opts.color_transform = get_color_transform();
+        params.pass_opts   = std::move(pass_opts);
         this->current_pass = std::make_unique<render_pass_t>(params);
 
         auto total_damage = current_pass->run_partial();
@@ -1125,8 +1132,10 @@ class wf::render_manager::impl
 
     void render_sw_cursors(swapchain_damage_manager_t::frame_object_t *next_frame)
     {
+        wlr_buffer_pass_options options{};
+        options.color_transform = get_color_transform();
         auto sw_cursor_pass =
-            wlr_renderer_begin_buffer_pass(output->handle->renderer, next_frame->buffer, nullptr);
+            wlr_renderer_begin_buffer_pass(output->handle->renderer, next_frame->buffer, &options);
         if (!sw_cursor_pass)
         {
             LOGE("Failed to render software cursors!");

--- a/src/output/workspace-stream.cpp
+++ b/src/output/workspace-stream.cpp
@@ -39,7 +39,11 @@ class workspace_stream_node_t::workspace_stream_instance_t : public scene::
         auto translate_and_push_damage = [this, push_damage] (wf::region_t damage)
         {
             damage += -get_offset();
-            push_damage(damage);
+            damage &= this->self->get_bounding_box();
+            if (!damage.empty())
+            {
+                push_damage(damage);
+            }
         };
 
         for (auto& output_node : wf::collect_output_nodes(wf::get_core().scene(), self->output))

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -6,6 +6,119 @@
 #include <wayfire/scene-render.hpp>
 #include <drm_fourcc.h>
 
+bool wf::color_transform_t::operator ==(const color_transform_t& other) const
+{
+    return transfer_function == other.transfer_function &&
+           primaries == other.primaries &&
+           color_encoding == other.color_encoding &&
+           color_range == other.color_range;
+}
+
+bool wf::color_transform_t::operator !=(const color_transform_t& other) const
+{
+    return !(*this == other);
+}
+
+wf::texture_t::texture_t() = default;
+
+wf::texture_t::~texture_t()
+{
+    if (buffer)
+    {
+        wlr_buffer_unlock(buffer);
+    } else if (texture)
+    {
+        wlr_texture_destroy(texture);
+    }
+}
+
+std::optional<wlr_fbox> wf::texture_t::get_source_box() const
+{
+    return source_box;
+}
+
+void wf::texture_t::set_source_box(const std::optional<wlr_fbox>& box)
+{
+    source_box = box;
+}
+
+wl_output_transform wf::texture_t::get_transform() const
+{
+    return transform;
+}
+
+void wf::texture_t::set_transform(wl_output_transform t)
+{
+    transform = t;
+}
+
+std::optional<wlr_scale_filter_mode> wf::texture_t::get_filter_mode() const
+{
+    return filter_mode;
+}
+
+void wf::texture_t::set_filter_mode(const std::optional<wlr_scale_filter_mode>& mode)
+{
+    filter_mode = mode;
+}
+
+wf::color_transform_t wf::texture_t::get_color_transform() const
+{
+    return color_transform;
+}
+
+void wf::texture_t::set_color_transform(const wf::color_transform_t& ct)
+{
+    color_transform = ct;
+}
+
+std::shared_ptr<wf::texture_t> wf::texture_t::from_buffer(wlr_buffer *buffer, wlr_texture *texture)
+{
+    auto tex = std::shared_ptr<texture_t>(new texture_t());
+    tex->buffer  = buffer;
+    tex->texture = texture;
+    if (buffer)
+    {
+        wlr_buffer_lock(buffer);
+    }
+
+    return tex;
+}
+
+std::shared_ptr<wf::texture_t> wf::texture_t::from_texture(wlr_texture *texture)
+{
+    auto tex = std::shared_ptr<texture_t>(new texture_t());
+    tex->buffer  = nullptr;
+    tex->texture = texture;
+    return tex;
+}
+
+std::shared_ptr<wf::texture_t> wf::texture_t::from_aux(auxilliary_buffer_t& buffer)
+{
+    auto tex = from_buffer(buffer.get_buffer(), buffer.get_texture());
+
+    // We keep aux buffers in linear color space.
+    auto transform = tex->get_color_transform();
+    transform.transfer_function = WLR_COLOR_TRANSFER_FUNCTION_EXT_LINEAR;
+    tex->set_color_transform(transform);
+    return tex;
+}
+
+wlr_texture*wf::texture_t::get_wlr_texture() const
+{
+    return texture;
+}
+
+int32_t wf::texture_t::get_width() const
+{
+    return texture->width;
+}
+
+int32_t wf::texture_t::get_height() const
+{
+    return texture->height;
+}
+
 wf::render_buffer_t::render_buffer_t(wlr_buffer *buffer, wf::dimensions_t size)
 {
     this->buffer = buffer;
@@ -272,9 +385,83 @@ void wf::render_buffer_t::blit(const wf::render_buffer_t& source, wlr_fbox src_b
 
 wf::render_target_t::render_target_t(const render_buffer_t& buffer) : render_buffer_t(buffer)
 {}
+
 wf::render_target_t::render_target_t(const auxilliary_buffer_t& buffer) : render_buffer_t(
         buffer.get_buffer(), buffer.get_size())
-{}
+{
+    // By default, we keep aux buffers in SRGB color space, as SRGB is efficiently implemented in Vulkan.
+    set_color_transform(
+        wlr_color_transform_init_linear_to_inverse_eotf(WLR_COLOR_TRANSFER_FUNCTION_EXT_LINEAR));
+}
+
+void wf::render_target_t::copy_from(const render_target_t& other)
+{
+    geometry     = other.geometry;
+    wl_transform = other.wl_transform;
+    scale     = other.scale;
+    subbuffer = other.subbuffer;
+    inverse_eotf = other.inverse_eotf;
+}
+
+wf::render_target_t::render_target_t(const render_target_t& other) : render_buffer_t(other)
+{
+    copy_from(other);
+    if (inverse_eotf)
+    {
+        wlr_color_transform_ref(inverse_eotf);
+    }
+}
+
+wf::render_target_t::render_target_t(render_target_t&& other) : render_buffer_t(other)
+{
+    copy_from(other);
+    other.inverse_eotf = nullptr;
+}
+
+wf::render_target_t& wf::render_target_t::operator =(const render_target_t& other)
+{
+    if (this != &other)
+    {
+        if (inverse_eotf)
+        {
+            wlr_color_transform_unref(inverse_eotf);
+        }
+
+        render_buffer_t::operator =(other);
+        copy_from(other);
+        if (inverse_eotf)
+        {
+            wlr_color_transform_ref(inverse_eotf);
+        }
+    }
+
+    return *this;
+}
+
+wf::render_target_t& wf::render_target_t::operator =(render_target_t&& other)
+{
+    if (this != &other)
+    {
+        if (inverse_eotf)
+        {
+            wlr_color_transform_unref(inverse_eotf);
+        }
+
+        render_buffer_t::operator =(other);
+        copy_from(other);
+        other.inverse_eotf = nullptr;
+    }
+
+    return *this;
+}
+
+wf::render_target_t::~render_target_t()
+{
+    if (inverse_eotf)
+    {
+        wlr_color_transform_unref(inverse_eotf);
+    }
+}
 
 wf::render_target_t wf::render_target_t::translated(wf::point_t offset) const
 {
@@ -379,6 +566,7 @@ wf::render_pass_t::render_pass_t(const render_pass_params_t& p)
 {
     this->params = p;
     this->params.renderer = p.renderer ?: wf::get_core().renderer;
+    this->params.pass_opts.color_transform = p.pass_opts.color_transform ?: p.target.get_color_transform();
     wf::dassert(p.target.get_buffer(), "Cannot run a render pass without a valid target!");
 }
 
@@ -413,16 +601,8 @@ wf::region_t wf::render_pass_t::run_partial()
         }
     }
 
-    this->pass = wlr_renderer_begin_buffer_pass(
-        params.renderer ?: wf::get_core().renderer,
-        params.target.get_buffer(),
-        params.pass_opts);
-
-    if (!pass)
-    {
-        LOGE("Error: failed to start wlr render pass!");
-        return accumulated_damage;
-    }
+    // When we need the wlr pass, start rendering.
+    this->needs_restart = true;
 
     // Clear visible background areas
     if (params.flags & RPASS_CLEAR_BACKGROUND)
@@ -462,7 +642,7 @@ wlr_renderer*wf::render_pass_t::get_wlr_renderer() const
 
 wlr_render_pass*wf::render_pass_t::get_wlr_pass()
 {
-    return pass;
+    return _get_pass();
 }
 
 void wf::render_pass_t::clear(const wf::region_t& region, const wf::color_t& color)
@@ -481,11 +661,12 @@ void wf::render_pass_t::clear(const wf::region_t& region, const wf::color_t& col
         .a = static_cast<float>(color.a),
     };
 
-    wlr_render_pass_add_rect(pass, &opts);
+    wlr_render_pass_add_rect(_get_pass(), &opts);
 }
 
-void wf::render_pass_t::add_texture(const wf::texture_t& texture, const wf::render_target_t& adjusted_target,
-    const wlr_fbox& geometry, const wf::region_t& damage, float alpha)
+void wf::render_pass_t::add_texture(const std::shared_ptr<wf::texture_t>& texture,
+    const wf::render_target_t& adjusted_target, const wlr_fbox& geometry,
+    const wf::region_t& damage, float alpha)
 {
     if (wlr_renderer_is_gles2(this->get_wlr_renderer()))
     {
@@ -499,7 +680,7 @@ void wf::render_pass_t::add_texture(const wf::texture_t& texture, const wf::rend
     wf::region_t fb_damage = adjusted_target.framebuffer_region_from_geometry_region(damage);
 
     wlr_render_texture_options opts{};
-    opts.texture = texture.texture;
+    opts.texture = texture->get_wlr_texture();
     opts.alpha   = &alpha;
     opts.blend_mode = WLR_RENDER_BLEND_MODE_PREMULTIPLIED;
 
@@ -508,12 +689,21 @@ void wf::render_pass_t::add_texture(const wf::texture_t& texture, const wf::rend
     // but only for integer scale.
     const auto preferred_filter = ((adjusted_target.scale - floor(adjusted_target.scale)) < 0.001) ?
         WLR_SCALE_FILTER_NEAREST : WLR_SCALE_FILTER_BILINEAR;
-    opts.filter_mode = texture.filter_mode.value_or(preferred_filter);
-    opts.transform   = wlr_output_transform_compose(wlr_output_transform_invert(texture.transform),
+    opts.filter_mode = texture->get_filter_mode().value_or(preferred_filter);
+    opts.transform   = wlr_output_transform_compose(wlr_output_transform_invert(texture->get_transform()),
         adjusted_target.wl_transform);
     opts.clip    = fb_damage.to_pixman();
-    opts.src_box = texture.source_box.value_or(wlr_fbox{0, 0, 0, 0});
+    opts.src_box = texture->get_source_box().value_or(wlr_fbox{0, 0, 0, 0});
     opts.dst_box = fbox_to_geometry(adjusted_target.framebuffer_box_from_geometry_box(geometry));
+
+    auto ct = texture->get_color_transform();
+    wlr_color_primaries primaries{};
+    opts.color_encoding = ct.color_encoding;
+    opts.color_range    = ct.color_range;
+    wlr_color_primaries_from_named(&primaries, ct.primaries);
+    opts.primaries = &primaries;
+    opts.transfer_function = ct.transfer_function;
+
     wlr_render_pass_add_texture(get_wlr_pass(), &opts);
 }
 
@@ -538,11 +728,12 @@ void wf::render_pass_t::add_rect(const wf::color_t& color, const wf::render_targ
     opts.box  = fbox_to_geometry(adjusted_target.framebuffer_box_from_geometry_box(geometry));
     wf::dassert(opts.box.width >= 0);
     wf::dassert(opts.box.height >= 0);
-    wlr_render_pass_add_rect(pass, &opts);
+    wlr_render_pass_add_rect(_get_pass(), &opts);
 }
 
-void wf::render_pass_t::add_texture(const wf::texture_t& texture, const wf::render_target_t& adjusted_target,
-    const wf::geometry_t& geometry, const wf::region_t& damage, float alpha)
+void wf::render_pass_t::add_texture(const std::shared_ptr<wf::texture_t>& texture,
+    const wf::render_target_t& adjusted_target, const wf::geometry_t& geometry, const wf::region_t& damage,
+    float alpha)
 {
     add_texture(texture, adjusted_target, geometry_to_fbox(geometry), damage, alpha);
 }
@@ -555,14 +746,21 @@ void wf::render_pass_t::add_rect(const wf::color_t& color, const wf::render_targ
 
 bool wf::render_pass_t::submit()
 {
-    bool status = wlr_render_pass_submit(pass);
-    this->pass = NULL;
+    if (!this->_pass)
+    {
+        // No pass currently running.
+        needs_restart = false;
+        return true;
+    }
+
+    bool status = wlr_render_pass_submit(_pass);
+    this->_pass = NULL;
     return status;
 }
 
 wf::render_pass_t::~render_pass_t()
 {
-    if (this->pass)
+    if (this->_pass)
     {
         LOGW("Dropping unsubmitted render pass!");
     }
@@ -580,9 +778,10 @@ wf::render_pass_t& wf::render_pass_t::operator =(render_pass_t&& other)
         return *this;
     }
 
-    this->pass   = other.pass;
-    other.pass   = NULL;
+    this->_pass  = other._pass;
+    other._pass  = NULL;
     this->params = other.params;
+    this->needs_restart = other.needs_restart;
     return *this;
 }
 
@@ -608,4 +807,63 @@ void wf::render_pass_t::finish_gles_subpass()
     // Bind the framebuffer again so that the wlr pass can continue as usual.
     wf::gles::bind_render_buffer(params.target);
     GL_CALL(glDisable(GL_SCISSOR_TEST));
+}
+
+#if WF_HAS_VULKANFX
+wf::vulkan_render_state_t*wf::render_pass_t::prepare_vulkan_subpass()
+{
+    if (!wlr_renderer_is_vk(this->get_wlr_renderer()))
+    {
+        return nullptr;
+    }
+
+    if (!active_command_buffer)
+    {
+        active_command_buffer = &vk::command_buffer_t::buffer_for_pass(*this);
+    }
+
+    return wf::get_core_impl().vulkan_state.get();
+}
+
+void wf::render_pass_t::end_vulkan_subpass()
+{
+    wlr_vk_render_pass_reset_pipeline(this->get_wlr_pass());
+}
+
+#endif
+
+wlr_render_pass*wf::render_pass_t::_get_pass()
+{
+    if (this->_pass)
+    {
+        return this->_pass;
+    }
+
+    if (!this->needs_restart)
+    {
+        LOGE("Cannot get wlr_render_pass before starting the render pass!");
+        return nullptr;
+    }
+
+    this->_pass = wlr_renderer_begin_buffer_pass(
+        params.renderer ?: wf::get_core().renderer,
+        params.target.get_buffer(),
+        & params.pass_opts);
+
+    return _pass;
+}
+
+void wf::render_target_t::set_color_transform(wlr_color_transform *transform)
+{
+    if (transform)
+    {
+        wlr_color_transform_ref(transform);
+    }
+
+    if (inverse_eotf)
+    {
+        wlr_color_transform_unref(inverse_eotf);
+    }
+
+    inverse_eotf = transform;
 }

--- a/src/view/layer-shell/layer-shell-node.cpp
+++ b/src/view/layer-shell/layer-shell-node.cpp
@@ -94,12 +94,12 @@ wf::region_t wf::layer_shell_node_t::get_opaque_region() const
     return {};
 }
 
-std::optional<wf::texture_t> wf::layer_shell_node_t::to_texture() const
+std::shared_ptr<wf::texture_t> wf::layer_shell_node_t::to_texture() const
 {
     auto view = _view.lock();
     if (!view || !view->is_mapped() || (get_children().size() != 1))
     {
-        return {};
+        return nullptr;
     }
 
     if (auto texturable = dynamic_cast<zero_copy_texturable_node_t*>(get_children().front().get()))
@@ -107,7 +107,7 @@ std::optional<wf::texture_t> wf::layer_shell_node_t::to_texture() const
         return texturable->to_texture();
     }
 
-    return {};
+    return nullptr;
 }
 
 void wf::layer_shell_node_t::gen_render_instances(std::vector<scene::render_instance_uptr> & instances,

--- a/src/view/layer-shell/layer-shell-node.hpp
+++ b/src/view/layer-shell/layer-shell-node.hpp
@@ -23,7 +23,7 @@ class layer_shell_node_t : public wf::scene::translation_node_t,
     void gen_render_instances(std::vector<scene::render_instance_uptr>& instances,
         scene::damage_callback push_damage, wf::output_t *output) override;
 
-    std::optional<wf::texture_t> to_texture() const override;
+    std::shared_ptr<wf::texture_t> to_texture() const override;
     wf::region_t get_opaque_region() const override;
 
   protected:

--- a/src/view/toplevel-node.cpp
+++ b/src/view/toplevel-node.cpp
@@ -125,12 +125,12 @@ void wf::toplevel_view_node_t::gen_render_instances(
     instances.push_back(std::make_unique<toplevel_view_render_instance_t>(this, push_damage, output));
 }
 
-std::optional<wf::texture_t> wf::toplevel_view_node_t::to_texture() const
+std::shared_ptr<wf::texture_t> wf::toplevel_view_node_t::to_texture() const
 {
     auto view = _view.lock();
     if (!view || !view->is_mapped() || (get_children().size() != 1))
     {
-        return {};
+        return nullptr;
     }
 
     if (auto texturable = dynamic_cast<zero_copy_texturable_node_t*>(get_children().front().get()))
@@ -138,7 +138,7 @@ std::optional<wf::texture_t> wf::toplevel_view_node_t::to_texture() const
         return texturable->to_texture();
     }
 
-    return {};
+    return nullptr;
 }
 
 wf::region_t wf::toplevel_view_node_t::get_opaque_region() const

--- a/src/view/toplevel-node.hpp
+++ b/src/view/toplevel-node.hpp
@@ -24,7 +24,7 @@ class toplevel_view_node_t : public wf::scene::translation_node_t,
     void gen_render_instances(std::vector<scene::render_instance_uptr>& instances,
         scene::damage_callback push_damage, wf::output_t *output) override;
 
-    std::optional<wf::texture_t> to_texture() const override;
+    std::shared_ptr<wf::texture_t> to_texture() const override;
     wf::region_t get_opaque_region() const override;
 
   protected:

--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -48,6 +48,60 @@ wf::geometry_t get_bbox_for_node(scene::node_ptr node, wf::geometry_t box)
     return get_bbox_for_node(node.get(), box);
 }
 
+#if WF_HAS_VULKANFX
+namespace vk
+{
+class core_vulkan_state_t : public wf::custom_data_t
+{
+  public:
+    std::shared_ptr<wf::vk::graphics_pipeline_t> pipeline;
+};
+
+struct core_vulkan_push_data_t
+{
+    glm::mat4 transform;
+    glm::vec2 uv_scale;
+    glm::vec2 uv_offset;
+};
+
+core_vulkan_state_t& core_ensure_vk(wf::vulkan_render_state_t& state)
+{
+    if (auto data = state.get_data<core_vulkan_state_t>())
+    {
+        return *data;
+    }
+
+    auto vs = state.get_context()->load_shader_module(
+        core_basic_vert_data, sizeof(core_basic_vert_data));
+    auto fs = state.get_context()->load_shader_module(
+        core_basic_frag_data, sizeof(core_basic_frag_data));
+
+    wf::vk::pipeline_params_t params{};
+    params.shaders = {
+        {.stage = VK_SHADER_STAGE_VERTEX_BIT, .shader = vs},
+        {.stage = VK_SHADER_STAGE_FRAGMENT_BIT, .shader = fs},
+    };
+
+    // One descriptor set for the uv texture.
+    params.descriptor_set_layouts = {wf::vk::pipeline_params_t::texture_descriptor_set_t{}};
+    params.push_constants = {
+        VkPushConstantRange{
+            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+            .offset     = 0,
+            .size = sizeof(core_vulkan_push_data_t),
+        },
+    };
+
+    auto data = std::make_unique<core_vulkan_state_t>();
+    data->pipeline = std::make_shared<wf::vk::graphics_pipeline_t>(state.get_context(), params);
+    auto ptr = data.get();
+    state.store_data<core_vulkan_state_t>(std::move(data));
+    return *ptr;
+}
+}
+
+#endif
+
 namespace scene
 {
 void transform_manager_node_t::_add_transformer(
@@ -230,21 +284,59 @@ class view_2d_render_instance_t :
         auto translate = glm::translate(glm::mat4(1.0),
             glm::vec3{self->get_translation_x() + midpoint.x,
                 self->get_translation_y() + midpoint.y, 0.0});
-        auto ortho = wf::gles::render_target_orthographic_projection(data.target);
-        auto full_matrix = ortho * translate * rotate * scale * center_at;
+
+        auto flat_transform = translate * rotate * scale * center_at;
 
         data.pass->custom_gles_subpass([&]
         {
             auto tex = wf::gles_texture_t{this->get_texture(data.target.scale)};
             wf::gles::bind_render_buffer(data.target);
+            auto ortho = wf::gles::render_target_orthographic_projection(data.target);
+
             for (auto& box : data.damage)
             {
                 wf::gles::render_target_logic_scissor(data.target, wlr_box_from_pixman_box(box));
                 // OpenGL::clear({1, 0, 0, 1});
-                OpenGL::render_transformed_texture(tex, bbox, full_matrix,
+                OpenGL::render_transformed_texture(tex, bbox, ortho * flat_transform,
                     glm::vec4{1.0, 1.0, 1.0, self->get_alpha()});
             }
         });
+
+#if WF_HAS_VULKANFX
+        data.pass->custom_vulkan_subpass([&] (wf::vulkan_render_state_t& state, vk::command_buffer_t& cmd_buf)
+        {
+            auto& vk_state = vk::core_ensure_vk(state);
+            auto texture   = get_texture(data.target.scale);
+            auto tex_dset  = state.get_descriptor_pool()->get_descriptor_set(cmd_buf, texture);
+            wf::vk::texture_sampling_params_t sampling{texture};
+            wf::vk::pipeline_specialization_t specialization{};
+            specialization.add_specialization_for_texture(texture);
+
+            // The shader renders a hardcoded quad from (0,0) to (1,1) so scale to match view size first.
+            glm::mat4 scale     = glm::scale(glm::mat4(1.0), {1.0 * bbox.width, -1.0 * bbox.height, 1.0f});
+            glm::mat4 translate = glm::translate(glm::mat4(1.0), {bbox.x, bbox.y + bbox.height, 0});
+            auto transform = vk::render_target_transform(data.target) * flat_transform * translate * scale;
+
+            auto [layout, _] = cmd_buf.bind_pipeline(vk_state.pipeline, data.target, specialization);
+            cmd_buf.set_full_viewport(data.target);
+            cmd_buf.bind_texture(texture);
+
+            vkCmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, layout,
+                0, 1, &tex_dset, 0, nullptr);
+
+            vk::core_vulkan_push_data_t push_constants{};
+            push_constants.transform = transform;
+            push_constants.uv_scale  = sampling.get_uv_scale();
+            push_constants.uv_offset = sampling.get_uv_offset();
+            vkCmdPushConstants(cmd_buf, layout, VK_SHADER_STAGE_VERTEX_BIT,
+                0, sizeof(vk::core_vulkan_push_data_t), &push_constants);
+
+            cmd_buf.for_each_scissor_rect(data.target, (data.damage & data.target.geometry), [&]
+            {
+                vkCmdDraw(cmd_buf, 4, 1, 0, 0);
+            });
+        });
+#endif
     }
 };
 
@@ -432,57 +524,6 @@ class view_3d_render_instance_t :
         transform_linear_damage(self.get(), damage);
     }
 
-#if WF_HAS_VULKANFX
-    class vulkan_state_t : public wf::custom_data_t
-    {
-      public:
-        std::shared_ptr<wf::vk::graphics_pipeline_t> pipeline;
-    };
-
-    struct vulkan_push_data_t
-    {
-        glm::mat4 transform;
-        glm::vec2 uv_scale;
-        glm::vec2 uv_offset;
-    };
-
-    vulkan_state_t& ensure_vk(wf::vulkan_render_state_t& state)
-    {
-        if (auto data = state.get_data<vulkan_state_t>())
-        {
-            return *data;
-        }
-
-        auto vs = state.get_context()->load_shader_module(
-            core_basic_vert_data, sizeof(core_basic_vert_data));
-        auto fs = state.get_context()->load_shader_module(
-            core_basic_frag_data, sizeof(core_basic_frag_data));
-
-        wf::vk::pipeline_params_t params{};
-        params.shaders = {
-            {.stage = VK_SHADER_STAGE_VERTEX_BIT, .shader = vs},
-            {.stage = VK_SHADER_STAGE_FRAGMENT_BIT, .shader = fs},
-        };
-
-        // One descriptor set for the uv texture.
-        params.descriptor_set_layouts = {wf::vk::pipeline_params_t::texture_descriptor_set_t{}};
-        params.push_constants = {
-            VkPushConstantRange{
-                .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
-                .offset     = 0,
-                .size = sizeof(vulkan_push_data_t),
-            },
-        };
-
-        auto data = std::make_unique<vulkan_state_t>();
-        data->pipeline = std::make_shared<wf::vk::graphics_pipeline_t>(state.get_context(), params);
-        auto ptr = data.get();
-        state.store_data<vulkan_state_t>(std::move(data));
-        return *ptr;
-    }
-
-#endif
-
     void render(const wf::scene::render_instruction_t& data) override
     {
         auto bbox = self->get_children_bounding_box();
@@ -514,7 +555,7 @@ class view_3d_render_instance_t :
 #if WF_HAS_VULKANFX
         data.pass->custom_vulkan_subpass([&] (wf::vulkan_render_state_t& state, vk::command_buffer_t& cmd_buf)
         {
-            auto& vk_state = ensure_vk(state);
+            auto& vk_state = vk::core_ensure_vk(state);
             auto texture   = get_texture(data.target.scale);
             auto tex_dset  = state.get_descriptor_pool()->get_descriptor_set(cmd_buf, texture);
             wf::vk::texture_sampling_params_t sampling{texture};
@@ -533,12 +574,12 @@ class view_3d_render_instance_t :
             vkCmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, layout,
                 0, 1, &tex_dset, 0, nullptr);
 
-            vulkan_push_data_t push_constants{};
+            vk::core_vulkan_push_data_t push_constants{};
             push_constants.transform = transform;
             push_constants.uv_scale  = sampling.get_uv_scale();
             push_constants.uv_offset = sampling.get_uv_offset();
             vkCmdPushConstants(cmd_buf, layout, VK_SHADER_STAGE_VERTEX_BIT,
-                0, sizeof(vulkan_push_data_t), &push_constants);
+                0, sizeof(vk::core_vulkan_push_data_t), &push_constants);
 
             cmd_buf.for_each_scissor_rect(data.target, (data.damage & data.target.geometry), [&]
             {

--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -16,6 +16,12 @@
 #include <algorithm>
 #include <cmath>
 
+#if WF_HAS_VULKANFX
+    #include <wayfire/vulkan.hpp>
+    #include "shaders/core-basic.vert.h"
+    #include "shaders/core-basic.frag.h"
+#endif
+
 #include <glm/gtc/matrix_transform.hpp>
 
 static const double PI = std::acos(-1);
@@ -205,7 +211,7 @@ class view_2d_render_instance_t :
         {
             // No rotation, we can use render-agnostic functions.
             auto tex = this->get_texture(data.target.scale);
-            tex.filter_mode = WLR_SCALE_FILTER_BILINEAR;
+            tex->set_filter_mode(WLR_SCALE_FILTER_BILINEAR);
             auto bbox = self->get_bounding_box();
             data.pass->add_texture(tex, data.target, bbox, data.damage, self->get_alpha());
             return;
@@ -266,7 +272,13 @@ glm::mat4 view_3d_transformer_t::default_view_matrix()
 
 glm::mat4 view_3d_transformer_t::default_proj_matrix()
 {
-    return glm::perspective(fov, 1.0f, .1f, 100.f);
+    if (wf::get_core().is_vulkan())
+    {
+        return glm::perspectiveZO(fov, 1.0f, .1f, 100.f);
+    } else
+    {
+        return glm::perspective(fov, 1.0f, .1f, 100.f);
+    }
 }
 
 view_3d_transformer_t::view_3d_transformer_t(wayfire_view view) :
@@ -420,6 +432,57 @@ class view_3d_render_instance_t :
         transform_linear_damage(self.get(), damage);
     }
 
+#if WF_HAS_VULKANFX
+    class vulkan_state_t : public wf::custom_data_t
+    {
+      public:
+        std::shared_ptr<wf::vk::graphics_pipeline_t> pipeline;
+    };
+
+    struct vulkan_push_data_t
+    {
+        glm::mat4 transform;
+        glm::vec2 uv_scale;
+        glm::vec2 uv_offset;
+    };
+
+    vulkan_state_t& ensure_vk(wf::vulkan_render_state_t& state)
+    {
+        if (auto data = state.get_data<vulkan_state_t>())
+        {
+            return *data;
+        }
+
+        auto vs = state.get_context()->load_shader_module(
+            core_basic_vert_data, sizeof(core_basic_vert_data));
+        auto fs = state.get_context()->load_shader_module(
+            core_basic_frag_data, sizeof(core_basic_frag_data));
+
+        wf::vk::pipeline_params_t params{};
+        params.shaders = {
+            {.stage = VK_SHADER_STAGE_VERTEX_BIT, .shader = vs},
+            {.stage = VK_SHADER_STAGE_FRAGMENT_BIT, .shader = fs},
+        };
+
+        // One descriptor set for the uv texture.
+        params.descriptor_set_layouts = {wf::vk::pipeline_params_t::texture_descriptor_set_t{}};
+        params.push_constants = {
+            VkPushConstantRange{
+                .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+                .offset     = 0,
+                .size = sizeof(vulkan_push_data_t),
+            },
+        };
+
+        auto data = std::make_unique<vulkan_state_t>();
+        data->pipeline = std::make_shared<wf::vk::graphics_pipeline_t>(state.get_context(), params);
+        auto ptr = data.get();
+        state.store_data<vulkan_state_t>(std::move(data));
+        return *ptr;
+    }
+
+#endif
+
     void render(const wf::scene::render_instruction_t& data) override
     {
         auto bbox = self->get_children_bounding_box();
@@ -435,6 +498,7 @@ class view_3d_render_instance_t :
 
         transform =
             wf::gles::render_target_gl_to_framebuffer(data.target) * scale * translate * transform;
+
         data.pass->custom_gles_subpass([&]
         {
             auto tex = wf::gles_texture_t{get_texture(data.target.scale)};
@@ -446,6 +510,42 @@ class view_3d_render_instance_t :
                     transform, self->color);
             }
         });
+
+#if WF_HAS_VULKANFX
+        data.pass->custom_vulkan_subpass([&] (wf::vulkan_render_state_t& state, vk::command_buffer_t& cmd_buf)
+        {
+            auto& vk_state = ensure_vk(state);
+            auto texture   = get_texture(data.target.scale);
+            auto tex_dset  = state.get_descriptor_pool()->get_descriptor_set(cmd_buf, texture);
+            wf::vk::texture_sampling_params_t sampling{texture};
+            wf::vk::pipeline_specialization_t specialization{};
+            specialization.add_specialization_for_texture(texture);
+
+            glm::mat4 scale = glm::scale(glm::mat4(1.0),
+                {quad.geometry.x2 - quad.geometry.x1, quad.geometry.y1 - quad.geometry.y2, 1.0f});
+            glm::mat4 translate = glm::translate(glm::mat4(1.0), {quad.geometry.x1, quad.geometry.y2, 0});
+            transform = transform * translate * scale;
+
+            auto [layout, _] = cmd_buf.bind_pipeline(vk_state.pipeline, data.target, specialization);
+            cmd_buf.set_full_viewport(data.target);
+            cmd_buf.bind_texture(texture);
+
+            vkCmdBindDescriptorSets(cmd_buf, VK_PIPELINE_BIND_POINT_GRAPHICS, layout,
+                0, 1, &tex_dset, 0, nullptr);
+
+            vulkan_push_data_t push_constants{};
+            push_constants.transform = transform;
+            push_constants.uv_scale  = sampling.get_uv_scale();
+            push_constants.uv_offset = sampling.get_uv_offset();
+            vkCmdPushConstants(cmd_buf, layout, VK_SHADER_STAGE_VERTEX_BIT,
+                0, sizeof(vulkan_push_data_t), &push_constants);
+
+            cmd_buf.for_each_scissor_rect(data.target, (data.damage & data.target.geometry), [&]
+            {
+                vkCmdDraw(cmd_buf, 4, 1, 0, 0);
+            });
+        });
+#endif
     }
 };
 
@@ -477,8 +577,8 @@ uint32_t transformer_base_node_t::optimize_update(uint32_t flags)
     return optimize_nested_render_instances(shared_from_this(), flags);
 }
 
-wf::texture_t transformer_base_node_t::get_updated_contents(const wf::geometry_t& bbox, float scale,
-    std::vector<scene::render_instance_uptr>& children)
+std::shared_ptr<wf::texture_t> transformer_base_node_t::get_updated_contents(const wf::geometry_t& bbox,
+    float scale, std::vector<scene::render_instance_uptr>& children)
 {
     if (inner_content.allocate(wf::dimensions(bbox), scale) != buffer_reallocation_result_t::SAME)
     {
@@ -492,13 +592,13 @@ wf::texture_t transformer_base_node_t::get_updated_contents(const wf::geometry_t
     render_pass_params_t params;
     params.instances = &children;
     params.target    = target;
-    params.damage    = cached_damage;
+    params.damage    = cached_damage & bbox;
     params.background_color = {0.0f, 0.0f, 0.0f, 0.0f};
     params.flags = RPASS_CLEAR_BACKGROUND;
     wf::render_pass_t::run(params);
-
     cached_damage.clear();
-    return wf::texture_t{inner_content.get_texture(), {}};
+
+    return wf::texture_t::from_aux(inner_content);
 }
 
 void transformer_base_node_t::release_buffers()

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -36,11 +36,13 @@ wf::scene::surface_state_t& wf::scene::surface_state_t::operator =(surface_state
     size = other.size;
     src_viewport = other.src_viewport;
     transform    = other.transform;
+    color_transform = other.color_transform;
 
     other.current_buffer = NULL;
     other.texture = NULL;
     other.accumulated_damage.clear();
     other.src_viewport.reset();
+    other.color_transform = wf::color_transform_t{};
     other.seq.reset();
     return *this;
 }
@@ -69,6 +71,35 @@ void wf::scene::surface_state_t::merge_state(wlr_surface *surface)
         this->current_buffer = NULL;
         this->texture = NULL;
         this->size    = {0, 0};
+    }
+
+    this->color_transform = wf::color_transform_t{};
+    this->color_transform.transfer_function = WLR_COLOR_TRANSFER_FUNCTION_GAMMA22;
+    const wlr_image_description_v1_data *img_desc =
+        wlr_surface_get_image_description_v1_data(surface);
+    if (img_desc != NULL)
+    {
+        this->color_transform.transfer_function = wlr_color_manager_v1_transfer_function_to_wlr(
+            (wp_color_manager_v1_transfer_function)img_desc->tf_named);
+        this->color_transform.primaries = wlr_color_manager_v1_primaries_to_wlr(
+            (wp_color_manager_v1_primaries)img_desc->primaries_named);
+    }
+
+    const wlr_color_representation_v1_surface_state *color_repr =
+        wlr_color_representation_v1_get_surface_state(surface);
+    if (color_repr != NULL)
+    {
+        if (color_repr->coefficients != 0)
+        {
+            this->color_transform.color_encoding = wlr_color_representation_v1_color_encoding_to_wlr(
+                (wp_color_representation_surface_v1_coefficients)color_repr->coefficients);
+        }
+
+        if (color_repr->range != 0)
+        {
+            this->color_transform.color_range = wlr_color_representation_v1_color_range_to_wlr(
+                (wp_color_representation_surface_v1_range)color_repr->range);
+        }
     }
 
     if (surface->current.viewport.has_src)
@@ -325,7 +356,7 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
             return;
         }
 
-        data.pass->add_texture(*self->to_texture(), data.target, self->get_bounding_box(), data.damage);
+        data.pass->add_texture(self->to_texture(), data.target, self->get_bounding_box(), data.damage);
     }
 
     void presentation_feedback(wf::output_t *output) override
@@ -427,14 +458,18 @@ wlr_surface*wf::scene::wlr_surface_node_t::get_surface() const
     return this->surface;
 }
 
-std::optional<wf::texture_t> wf::scene::wlr_surface_node_t::to_texture() const
+std::shared_ptr<wf::texture_t> wf::scene::wlr_surface_node_t::to_texture() const
 {
     if (this->current_state.current_buffer)
     {
-        return wf::texture_t{current_state.texture, current_state.src_viewport, current_state.transform};
+        auto tex = wf::texture_t::from_buffer(current_state.current_buffer, current_state.texture);
+        tex->set_source_box(current_state.src_viewport);
+        tex->set_transform(current_state.transform);
+        tex->set_color_transform(current_state.color_transform);
+        return tex;
     }
 
-    return {};
+    return nullptr;
 }
 
 // Idea of handling output enter/leave events: when the event comes, we store the number of enters/leaves

--- a/src/view/wlr-surface-touch-interaction.cpp
+++ b/src/view/wlr-surface-touch-interaction.cpp
@@ -56,7 +56,7 @@ class wlr_surface_touch_interaction_t final : public wf::touch_interaction_t
                     node->local_coords.x, node->local_coords.y);
             } else
             {
-                wlr_seat_touch_point_clear_focus(seat->seat, time_ms, finger_id);
+                wlr_seat_touch_notify_clear_focus(seat->seat, time_ms, finger_id);
             }
 
             return;


### PR DESCRIPTION
As people following the Matrix channel likely already know, I have been working on custom Vulkan effects for Wayfire. Currently, this requires installing a wlroots 0.20 fork with minimal changes (it can be installed alongside any other wlroots release without conflicts): https://gitlab.freedesktop.org/ammen99/wlroots/-/tree/vulkan-effects?ref_type=heads

To enable vulkan effects, make sure that you:

1. Install the wlroots fork described above
2. Pass `-Dvulkan_effects=true` when building Wayfire

Currently supported are wobbly and view-3d, which means that plugins like wrot and switcher also are supposed to work, alongside wobbly. The entire vulkan effects support is currently guarded behind `#if WF_HAS_VULKANFX` and is meant as experimental, i.e big breaking changes might be required in the future - though hopefully, this won't be the case ...

Marking this as draft because this currently requires wlroots 0.20, so it will be mergeable after that. Feedback really welcome in case anyone wants to review and/or test this new functionality.