### PR TITLE
plugins: fix cairo text transparency

### DIFF
--- a/plugins/common/wayfire/plugins/common/cairo-util.hpp
+++ b/plugins/common/wayfire/plugins/common/cairo-util.hpp
@@ -256,7 +256,7 @@ struct cairo_text_t
         x += xpad;
         y += ypad;
 
-        cairo_set_operator(cr, CAIRO_OPERATOR_SOURCE);
+        cairo_set_operator(cr, par.bg_rect ? CAIRO_OPERATOR_OVER : CAIRO_OPERATOR_SOURCE);
         cairo_move_to(cr, x - (float)extents.x / PANGO_SCALE, y);
         cairo_set_source_rgba(cr, par.text_color.r, par.text_color.g,
             par.text_color.b, par.text_color.a);


### PR DESCRIPTION
fixes: https://github.com/WayfireWM/wayfire/issues/2911

Use [CAIRO_OPERATOR_OVER](https://cairographics.org/operators/) when rendering text with a background

<img width="880" height="742" alt="2026-03-19_16:41:45" src="https://github.com/user-attachments/assets/4cef2ba5-bb36-4cba-ad7c-54e1d78960c4" />
