### PR TITLE
fix: guard against negative output scale values

### DIFF
--- a/metadata/output.xml
+++ b/metadata/output.xml
@@ -10,6 +10,7 @@
     </option>
     <option name="scale" type="double">
       <default>1.0</default>
+      <min>0.1</min>
     </option>
     <option name="transform" type="string">
       <default>normal</default>


### PR DESCRIPTION
Guard against invalid output scale values to prevent Wayfire crashes.

------------------

I somehow fatfingered a `-` in front of my scaling factor which results in this segfault:

```
wayfire: ../src/core/output-layout.cpp:1937: wf::output_t* wf::output_layout_t::impl::get_output_coords_at(const wf::pointf_t&, wf::pointf_t&): Assertion `handle || is_shutting_down()' failed.
EE 2026-04-13 16:36:29.481 - [src/main.cpp:144] Fatal error: Fatal error(SIGABRT)
EE 2026-04-13 16:36:29.528 - #1  signal_handler(int) ../src/main.cpp:146
EE 2026-04-13 16:36:29.540 - #2  __restore_rt ??:?
EE 2026-04-13 16:36:29.551 - #3  __pthread_kill_implementation ??:?
EE 2026-04-13 16:36:29.563 - #4  __GI_raise :?
EE 2026-04-13 16:36:29.575 - #5  __GI_abort :?
EE 2026-04-13 16:36:29.589 - #6  __GI___assert_perror_fail :?
EE 2026-04-13 16:36:29.685 - #7  wf::output_layout_t::impl::get_output_coords_at(wf::pointf_t const&, wf::pointf_t&) ../src/core/output-layout.cpp:1938
EE 2026-04-13 16:36:29.783 - #8  wf::output_layout_t::get_output_coords_at(wf::pointf_t, wf::pointf_t&) ../src/core/output-layout.cpp:1991
EE 2026-04-13 16:36:29.964 - #9  wf::compositor_core_impl_t::post_init() ../src/core/core.cpp:309 (discriminator 7)
EE 2026-04-13 16:36:30.014 - #10 main ../src/main.cpp:514
EE 2026-04-13 16:36:30.026 - #11 __libc_start_call_main ??:?
EE 2026-04-13 16:36:30.036 - #12 __libc_start_main_alias_2 :?
EE 2026-04-13 16:36:30.289 - #13 ?? ??:0
```