### PR TITLE
make sure old input-method-popup is destroyed or they can accumulate quite a lot.

### DIFF
--- a/plugins/protocols/input-method-v1.cpp
+++ b/plugins/protocols/input-method-v1.cpp
@@ -441,6 +441,11 @@ class wayfire_input_method_v1_panel_surface
 
             on_surface_destroy.disconnect();
             on_surface_commit.disconnect();
+
+            if (resource)
+            {
+                wl_resource_destroy(resource);
+            }
         });
         on_surface_destroy.connect(&surface->events.destroy);
     }


### PR DESCRIPTION
Some days ago I asked in Matrix that my IPC call to `list_views` didn't work unless I straced wayfire. That was because the list was very long: hundreds of "input-method-popup" views!

This patch makes sure that there is only one "input-method-popup". I'm not very familiar with the code so I asked codex (a coding AI agent) to help. It works for me for days.

One possible side-effect is that when I restart fcitx5 (the input method), wayfire no longer crashes. (It used to crash after wayfire had been running for e.g. days; it seemed to be random memory corruption but asan didn't catch it.)