### PR TITLE
Unit testing for core

### DIFF
--- a/src/core/output-layout-priv.hpp
+++ b/src/core/output-layout-priv.hpp
@@ -1,4 +1,7 @@
 #include <wayfire/output-layout.hpp>
+#include <string_view>
+
+#include <xf86drmMode.h>
 
 namespace wf
 {
@@ -7,5 +10,14 @@ namespace layout_detail
 void priv_output_layout_fini(wf::output_layout_t *layout);
 std::string_view get_output_source_name(output_image_source_t source);
 std::string wl_transform_to_string(wl_output_transform transform);
+wl_output_transform get_transform_from_string(std::string_view transform);
+bool parse_modeline(const char *modeline, drmModeModeInfo& mode);
+
+wf::geometry_t calculate_output_geometry(const output_state_t& state);
+std::vector<wf::geometry_t> calculate_fixed_geometries(const output_configuration_t& config);
+bool has_overlapping_outputs(const output_configuration_t& config);
+bool all_outputs_disabled(const output_configuration_t& config);
+bool are_rectangles_touching(const wf::geometry_t& a, const wf::geometry_t& b);
+bool has_disjoint_outputs(const output_configuration_t& config);
 }
 }

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -99,9 +99,9 @@ static std::map<std::string, wl_output_transform> output_transforms = {
     {"270_flipped", WL_OUTPUT_TRANSFORM_FLIPPED_270},
 };
 
-static wl_output_transform get_transform_from_string(std::string transform)
+wl_output_transform wf::layout_detail::get_transform_from_string(std::string_view transform)
 {
-    auto it = output_transforms.find(transform);
+    auto it = output_transforms.find(std::string{transform});
     if (it != output_transforms.end())
     {
         return it->second;
@@ -145,6 +145,119 @@ std::string_view wf::layout_detail::get_output_source_name(output_image_source_t
     }
 
     return "unknown";
+}
+
+wf::geometry_t wf::layout_detail::calculate_output_geometry(const output_state_t& state)
+{
+    wf::geometry_t geometry = {
+        state.position.get_x(),
+        state.position.get_y(),
+        (int32_t)(state.mode.width / state.scale),
+        (int32_t)(state.mode.height / state.scale),
+    };
+
+    if (state.transform & 1)
+    {
+        std::swap(geometry.width, geometry.height);
+    }
+
+    return geometry;
+}
+
+std::vector<wf::geometry_t> wf::layout_detail::calculate_fixed_geometries(
+    const output_configuration_t& config)
+{
+    std::vector<wf::geometry_t> geometries;
+    for (auto& entry : config)
+    {
+        if (!(entry.second.source & OUTPUT_IMAGE_SOURCE_SELF) ||
+            entry.second.position.is_automatic_position())
+        {
+            continue;
+        }
+
+        geometries.push_back(calculate_output_geometry(entry.second));
+    }
+
+    return geometries;
+}
+
+bool wf::layout_detail::has_overlapping_outputs(const output_configuration_t& config)
+{
+    auto geometries = calculate_fixed_geometries(config);
+    for (size_t i = 0; i < geometries.size(); i++)
+    {
+        for (size_t j = i + 1; j < geometries.size(); j++)
+        {
+            if (geometries[i] & geometries[j])
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool wf::layout_detail::all_outputs_disabled(const output_configuration_t& config)
+{
+    int count_enabled = 0;
+    for (auto& entry : config)
+    {
+        if (entry.second.source & OUTPUT_IMAGE_SOURCE_SELF)
+        {
+            ++count_enabled;
+        }
+    }
+
+    return count_enabled == 0;
+}
+
+bool wf::layout_detail::are_rectangles_touching(const wf::geometry_t& a, const wf::geometry_t& b)
+{
+    return !(a.x + a.width < b.x || a.y + a.height < b.y ||
+        b.x + b.width < a.x || b.y + b.height < a.y);
+}
+
+bool wf::layout_detail::has_disjoint_outputs(const output_configuration_t& config)
+{
+    auto geometries = calculate_fixed_geometries(config);
+    if (geometries.empty())
+    {
+        return false;
+    }
+
+    std::vector<std::vector<int>> graph(geometries.size());
+    for (size_t i = 0; i < geometries.size(); i++)
+    {
+        for (size_t j = i + 1; j < geometries.size(); j++)
+        {
+            if (are_rectangles_touching(geometries[i], geometries[j]))
+            {
+                graph[i].push_back(j);
+                graph[j].push_back(i);
+            }
+        }
+    }
+
+    std::vector<int> visited(geometries.size(), 0);
+    std::function<void(int)> dfs;
+    dfs = [&] (int u)
+    {
+        if (visited[u] == 1)
+        {
+            return;
+        }
+
+        visited[u] = 1;
+        for (int v : graph[u])
+        {
+            dfs(v);
+        }
+    };
+
+    dfs(0);
+    return *std::min_element(visited.begin(), visited.end()) == 0;
 }
 
 wlr_output_mode *find_matching_mode(wlr_output *output,
@@ -193,7 +306,7 @@ wlr_output_mode *find_matching_mode(wlr_output *output,
 }
 
 // from rootston
-static bool parse_modeline(const char *modeline, drmModeModeInfo & mode)
+bool wf::layout_detail::parse_modeline(const char *modeline, drmModeModeInfo & mode)
 {
     char hsync[16];
     char vsync[16];
@@ -641,7 +754,7 @@ struct output_layout_output_t
         }
 
         state.scale     = scale_opt;
-        state.transform = get_transform_from_string(transform_opt);
+        state.transform = layout_detail::get_transform_from_string(std::string{transform_opt});
         state.vrr   = vrr_opt;
         state.hdr   = hdr_opt;
         state.depth = depth_opt;
@@ -735,7 +848,7 @@ struct output_layout_output_t
 
         added_custom_modes.insert(modeline);
         drmModeModeInfo *mode = new drmModeModeInfo;
-        if (!parse_modeline(modeline.c_str(), *mode))
+        if (!layout_detail::parse_modeline(modeline.c_str(), *mode))
         {
             LOGE("invalid modeline ", modeline, " in config file");
 
@@ -1522,129 +1635,39 @@ class output_layout_t::impl
      * Calculate the output layout geometry for the state.
      * The state represents a non-automatically positioned enabled output.
      */
-    wf::geometry_t calculate_geometry_from_state(
-        const output_state_t& state) const
+    wf::geometry_t calculate_geometry_from_state(const output_state_t& state) const
     {
-        wf::geometry_t geometry = {
-            state.position.get_x(),
-            state.position.get_y(),
-            (int32_t)(state.mode.width / state.scale),
-            (int32_t)(state.mode.height / state.scale),
-        };
-
-        if (state.transform & 1)
-        {
-            std::swap(geometry.width, geometry.height);
-        }
-
-        return geometry;
+        return layout_detail::calculate_output_geometry(state);
     }
 
     /** @return A list of geometries of fixed position outputs. */
-    std::vector<wf::geometry_t> calculate_fixed_geometries(
-        const output_configuration_t& config)
+    std::vector<wf::geometry_t> calculate_fixed_geometries(const output_configuration_t& config)
     {
-        std::vector<wf::geometry_t> geometries;
-        for (auto& entry : config)
-        {
-            if (!(entry.second.source & OUTPUT_IMAGE_SOURCE_SELF) ||
-                entry.second.position.is_automatic_position())
-            {
-                continue;
-            }
-
-            geometries.push_back(calculate_geometry_from_state(entry.second));
-        }
-
-        return geometries;
+        return layout_detail::calculate_fixed_geometries(config);
     }
 
     /** @return true if there are overlapping outputs */
     bool test_overlapping_outputs(const output_configuration_t& config)
     {
-        auto geometries = calculate_fixed_geometries(config);
-        for (size_t i = 0; i < geometries.size(); i++)
-        {
-            for (size_t j = i + 1; j < geometries.size(); j++)
-            {
-                if (geometries[i] & geometries[j])
-                {
-                    return true;
-                }
-            }
-        }
-
-        return false;
+        return layout_detail::has_overlapping_outputs(config);
     }
 
     /** @return true if all outputs are disabled. */
     bool test_all_disabled_outputs(const output_configuration_t& config)
     {
-        int count_enabled = 0;
-        for (auto& entry : config)
-        {
-            if (entry.second.source & OUTPUT_IMAGE_SOURCE_SELF)
-            {
-                ++count_enabled;
-            }
-        }
-
-        return count_enabled == 0;
+        return layout_detail::all_outputs_disabled(config);
     }
 
     /* @return true if rectangles have a common interior or border point. */
     bool rectangles_touching(const wf::geometry_t& a, const wf::geometry_t& b)
     {
-        return !(a.x + a.width < b.x || a.y + a.height < b.y ||
-            b.x + b.width < a.x || b.y + b.height < a.y);
+        return layout_detail::are_rectangles_touching(a, b);
     }
 
     /** @return true if fixed position outputs do not form a continuous space */
     bool test_disjoint_outputs(const output_configuration_t& config)
     {
-        auto geometries = calculate_fixed_geometries(config);
-        if (geometries.empty())
-        {
-            /* Not disjoint */
-            return false;
-        }
-
-        /* Create graph with a vertex for each rectangle.
-         * Configuration is disjoint iff the graph has more than one component */
-        std::vector<std::vector<int>> graph(geometries.size());
-        for (size_t i = 0; i < geometries.size(); i++)
-        {
-            for (size_t j = i + 1; j < geometries.size(); j++)
-            {
-                if (rectangles_touching(geometries[i], geometries[j]))
-                {
-                    graph[i].push_back(j);
-                    graph[j].push_back(i);
-                }
-            }
-        }
-
-        /* Do a depth-first-search */
-        std::vector<int> visited(geometries.size(), 0);
-        std::function<void(int)> dfs;
-        dfs = [&] (int u)
-        {
-            if (visited[u] == 1)
-            {
-                return;
-            }
-
-            visited[u] = 1;
-            for (int v : graph[u])
-            {
-                dfs(v);
-            }
-        };
-
-        dfs(0);
-
-        // If we have a zero somewhere it means the vertex was not reached
-        return *std::min_element(visited.begin(), visited.end()) == 0;
+        return layout_detail::has_disjoint_outputs(config);
     }
 
     /** Check whether the given configuration can be applied */

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -227,7 +227,7 @@ void wayfire_xdg_popup::map()
     emit_view_map();
     wf::get_core().connect(&on_keyboard_focus_changed);
 
-    if (popup->seat)
+    if (popup->seat && get_keyboard_focus_surface())
     {
         wf::get_core().seat->focus_view(self());
     }
@@ -416,6 +416,11 @@ wf::geometry_t wayfire_xdg_popup::get_geometry()
 
 wlr_surface*wayfire_xdg_popup::get_keyboard_focus_surface()
 {
+    if (!parent_allows_keyboard_focus())
+    {
+        return nullptr;
+    }
+
     static wf::option_wrapper_t<bool> focus_main_view{"workarounds/focus_main_surface_instead_of_popup"};
     if (focus_main_view)
     {
@@ -429,6 +434,12 @@ wlr_surface*wayfire_xdg_popup::get_keyboard_focus_surface()
     }
 
     return priv->wsurface;
+}
+
+bool wayfire_xdg_popup::parent_allows_keyboard_focus() const
+{
+    auto parent = popup_parent.lock();
+    return parent && (parent->get_keyboard_focus_surface() != nullptr);
 }
 
 /**

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -76,6 +76,7 @@ class wayfire_xdg_popup : public wf::view_interface_t
     void handle_app_id_changed(std::string new_app_id);
     void handle_title_changed(std::string new_title);
     void update_size();
+    bool parent_allows_keyboard_focus() const;
 
     bool should_close_on_focus_change(wf::keyboard_focus_changed_signal *ev);
 };

--- a/test/geometry/meson.build
+++ b/test/geometry/meson.build
@@ -11,3 +11,10 @@ region_test = executable(
     dependencies: libwayfire,
     install: false)
 test('Region test', region_test)
+
+output_layout_helpers_test = executable(
+    'output_layout_helpers_test',
+    'output-layout-helpers-test.cpp',
+    dependencies: libwayfire,
+    install: false)
+test('Output layout helpers test', output_layout_helpers_test)

--- a/test/geometry/meson.build
+++ b/test/geometry/meson.build
@@ -4,3 +4,10 @@ geometry_test = executable(
     dependencies: libwayfire,
     install: false)
 test('Geometry test', geometry_test)
+
+region_test = executable(
+    'region_test',
+    'region_test.cpp',
+    dependencies: libwayfire,
+    install: false)
+test('Region test', region_test)

--- a/test/geometry/output-layout-helpers-test.cpp
+++ b/test/geometry/output-layout-helpers-test.cpp
@@ -1,0 +1,125 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/config/types.hpp>
+
+#include "../../src/core/output-layout-priv.hpp"
+
+namespace
+{
+wlr_output_mode make_mode(int width, int height, int refresh)
+{
+    wlr_output_mode mode{};
+    mode.width   = width;
+    mode.height  = height;
+    mode.refresh = refresh;
+    return mode;
+}
+
+wf::output_state_t make_state(wf::output_image_source_t source,
+    wf::output_config::position_t position, wlr_output_mode mode,
+    double scale = 1.0,
+    wl_output_transform transform = WL_OUTPUT_TRANSFORM_NORMAL)
+{
+    wf::output_state_t state;
+    state.source   = source;
+    state.position = position;
+    state.mode     = mode;
+    state.scale    = scale;
+    state.transform = transform;
+    return state;
+}
+
+wf::output_configuration_t config_from_states(const std::vector<wf::output_state_t>& states)
+{
+    wf::output_configuration_t config;
+    uintptr_t id = 1;
+    for (auto& state : states)
+    {
+        config.emplace(reinterpret_cast<wlr_output*>(id++), state);
+    }
+
+    return config;
+}
+}
+
+TEST_CASE("output layout transform helpers round-trip known values")
+{
+    CHECK(wf::layout_detail::get_transform_from_string("normal") == WL_OUTPUT_TRANSFORM_NORMAL);
+    CHECK(wf::layout_detail::get_transform_from_string("90_flipped") == WL_OUTPUT_TRANSFORM_FLIPPED_90);
+    CHECK(wf::layout_detail::get_transform_from_string("invalid") == WL_OUTPUT_TRANSFORM_NORMAL);
+
+    CHECK(wf::layout_detail::wl_transform_to_string(WL_OUTPUT_TRANSFORM_270) == "270");
+    CHECK(wf::layout_detail::wl_transform_to_string(WL_OUTPUT_TRANSFORM_FLIPPED_180) == "180_flipped");
+}
+
+TEST_CASE("output layout modeline parser accepts valid forms and rejects invalid ones")
+{
+    drmModeModeInfo mode;
+    REQUIRE(wf::layout_detail::parse_modeline(
+        "148.50 1920 2008 2052 2200 1080 1084 1089 1125 +hsync +vsync", mode));
+
+    CHECK(mode.hdisplay == 1920);
+    CHECK(mode.vdisplay == 1080);
+    CHECK((mode.flags & DRM_MODE_FLAG_PHSYNC) != 0);
+    CHECK((mode.flags & DRM_MODE_FLAG_PVSYNC) != 0);
+    CHECK(std::string{mode.name} == "1920x1080@60");
+
+    REQUIRE(wf::layout_detail::parse_modeline(
+        "74.25 1280 1390 1430 1650 720 725 730 750 -hsync -vsync interlace", mode));
+    CHECK((mode.flags & DRM_MODE_FLAG_NHSYNC) != 0);
+    CHECK((mode.flags & DRM_MODE_FLAG_NVSYNC) != 0);
+    CHECK((mode.flags & DRM_MODE_FLAG_INTERLACE) != 0);
+
+    CHECK_FALSE(wf::layout_detail::parse_modeline(
+        "148.50 1920 2008 2052 2200 1080 1084 1089 1125 maybe +vsync", mode));
+    CHECK_FALSE(wf::layout_detail::parse_modeline("too short", mode));
+}
+
+TEST_CASE("output layout geometry helpers ignore dynamic and disabled outputs")
+{
+    auto fixed = make_state(wf::OUTPUT_IMAGE_SOURCE_SELF,
+        wf::output_config::position_t{100, 200}, make_mode(1920, 1080, 60000), 2.0,
+        WL_OUTPUT_TRANSFORM_90);
+    auto automatic = make_state(wf::OUTPUT_IMAGE_SOURCE_SELF,
+        wf::output_config::position_t{}, make_mode(1280, 720, 60000));
+    auto disabled = make_state(wf::OUTPUT_IMAGE_SOURCE_NONE,
+        wf::output_config::position_t{0, 0}, make_mode(1280, 720, 60000));
+
+    auto geometry = wf::layout_detail::calculate_output_geometry(fixed);
+    CHECK(geometry == wf::geometry_t{100, 200, 540, 960});
+
+    auto config     = config_from_states(std::vector<wf::output_state_t>{fixed, automatic, disabled});
+    auto geometries = wf::layout_detail::calculate_fixed_geometries(config);
+    REQUIRE(geometries.size() == 1);
+    CHECK(geometries[0] == geometry);
+    CHECK_FALSE(wf::layout_detail::all_outputs_disabled(config));
+    CHECK(wf::layout_detail::all_outputs_disabled(config_from_states(
+        std::vector<wf::output_state_t>{disabled})));
+}
+
+TEST_CASE("output layout detects overlap touching and disjoint groups")
+{
+    auto left = make_state(wf::OUTPUT_IMAGE_SOURCE_SELF,
+        wf::output_config::position_t{0, 0}, make_mode(100, 100, 60000));
+    auto touching = make_state(wf::OUTPUT_IMAGE_SOURCE_SELF,
+        wf::output_config::position_t{100, 0}, make_mode(100, 100, 60000));
+    auto overlapping = make_state(wf::OUTPUT_IMAGE_SOURCE_SELF,
+        wf::output_config::position_t{80, 0}, make_mode(100, 100, 60000));
+    auto separate = make_state(wf::OUTPUT_IMAGE_SOURCE_SELF,
+        wf::output_config::position_t{250, 0}, make_mode(100, 100, 60000));
+
+    CHECK(wf::layout_detail::are_rectangles_touching({0, 0, 100, 100}, {100, 0, 100, 100}));
+    CHECK_FALSE(wf::layout_detail::are_rectangles_touching({0, 0, 100, 100}, {101, 0, 100, 100}));
+
+    CHECK_FALSE(wf::layout_detail::has_overlapping_outputs(config_from_states(std::vector<wf::output_state_t>{
+        left, touching})));
+    CHECK(wf::layout_detail::has_overlapping_outputs(config_from_states(std::vector<wf::output_state_t>{left,
+        overlapping})));
+
+    CHECK_FALSE(wf::layout_detail::has_disjoint_outputs(config_from_states(std::vector<wf::output_state_t>{
+        left, touching})));
+    CHECK(wf::layout_detail::has_disjoint_outputs(config_from_states(std::vector<wf::output_state_t>{left,
+        separate})));
+    CHECK_FALSE(wf::layout_detail::has_disjoint_outputs(config_from_states({})));
+}

--- a/test/geometry/region_test.cpp
+++ b/test/geometry/region_test.cpp
@@ -1,0 +1,96 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/region.hpp>
+
+#include <algorithm>
+#include <tuple>
+#include <vector>
+
+namespace
+{
+std::vector<wlr_box> as_boxes(const wf::region_t& region)
+{
+    std::vector<wlr_box> boxes;
+    for (auto it = region.begin(); it != region.end(); ++it)
+    {
+        boxes.push_back(wlr_box_from_pixman_box(*it));
+    }
+
+    std::sort(boxes.begin(), boxes.end(), [] (const auto& a, const auto& b)
+    {
+        return std::tie(a.x, a.y, a.width, a.height) <
+        std::tie(b.x, b.y, b.width, b.height);
+    });
+
+    return boxes;
+}
+}
+
+TEST_CASE("region supports copy move and clear semantics")
+{
+    wf::region_t original{{0, 0, 10, 10}};
+    wf::region_t copy = original;
+    copy += wf::point_t{5, 0};
+
+    REQUIRE(original.contains_point({1, 1}));
+    REQUIRE_FALSE(original.contains_point({11, 1}));
+    REQUIRE(copy.contains_point({6, 1}));
+    REQUIRE_FALSE(copy.contains_point({1, 1}));
+
+    wf::region_t moved = std::move(copy);
+    auto moved_boxes   = as_boxes(moved);
+    REQUIRE(moved_boxes.size() == 1);
+    REQUIRE(moved_boxes[0] == wf::geometry_t{5, 0, 10, 10});
+    REQUIRE(copy.empty());
+
+    moved.clear();
+    REQUIRE(moved.empty());
+}
+
+TEST_CASE("region set operations preserve expected coverage")
+{
+    wf::region_t region{{0, 0, 10, 10}};
+
+    auto intersection = region & wlr_box{5, 5, 10, 10};
+    REQUIRE(as_boxes(intersection) == std::vector<wlr_box>{{5, 5, 5, 5}});
+
+    auto united = region | wlr_box{10, 0, 5, 10};
+    REQUIRE(as_boxes(united) == std::vector<wlr_box>{{0, 0, 15, 10}});
+
+    auto subtracted = region ^ wlr_box{2, 2, 6, 6};
+    REQUIRE(subtracted.contains_point({1, 1}));
+    REQUIRE(subtracted.contains_point({9, 9}));
+    REQUIRE_FALSE(subtracted.contains_point({5, 5}));
+    auto extents = subtracted.get_extents();
+    REQUIRE(extents.x1 == 0);
+    REQUIRE(extents.y1 == 0);
+    REQUIRE(extents.x2 == 10);
+    REQUIRE(extents.y2 == 10);
+}
+
+TEST_CASE("region translation scaling and float containment work together")
+{
+    wf::region_t region{{1, 2, 3, 4}};
+    auto shifted = region + wf::point_t{2, 3};
+    auto scaled  = shifted * 2.0f;
+
+    REQUIRE(as_boxes(shifted) == std::vector<wlr_box>{{3, 5, 3, 4}});
+    REQUIRE(as_boxes(scaled) == std::vector<wlr_box>{{6, 10, 6, 8}});
+    REQUIRE(scaled.contains_pointf({6.5, 10.5}));
+    REQUIRE_FALSE(scaled.contains_pointf({12.5, 18.5}));
+}
+
+TEST_CASE("region edge expansion handles no-op growth and shrink")
+{
+    wf::region_t region{{0, 0, 10, 10}};
+
+    region.expand_edges(0);
+    REQUIRE(as_boxes(region) == std::vector<wlr_box>{{0, 0, 10, 10}});
+
+    region.expand_edges(2);
+    REQUIRE(as_boxes(region) == std::vector<wlr_box>{{-2, -2, 14, 14}});
+
+    region.expand_edges(-3);
+    REQUIRE(as_boxes(region) == std::vector<wlr_box>{{1, 1, 8, 8}});
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,3 +1,4 @@
 subdir('geometry')
 subdir('txn')
 subdir('misc')
+subdir('protocol')

--- a/test/misc/meson.build
+++ b/test/misc/meson.build
@@ -11,3 +11,10 @@ safe_list = executable(
     dependencies: [doctest, wfconfig],
     install: false)
 test('Safe list test', safe_list)
+
+object_signal = executable(
+    'object-signal-test',
+    'object-signal-test.cpp',
+    dependencies: libwayfire,
+    install: false)
+test('Object and signal test', object_signal)

--- a/test/misc/object-signal-test.cpp
+++ b/test/misc/object-signal-test.cpp
@@ -1,0 +1,137 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/object.hpp>
+#include <wayfire/signal-provider.hpp>
+
+#include <memory>
+#include <string>
+
+namespace
+{
+class test_object_t : public wf::object_base_t
+{};
+
+struct test_data_t : public wf::custom_data_t
+{
+    int value = 0;
+};
+
+struct test_signal
+{
+    int value;
+};
+
+class test_provider_t : public wf::signal::provider_t
+{};
+}
+
+TEST_CASE("object base stores and releases custom data")
+{
+    test_object_t object;
+
+    auto stored = std::make_unique<test_data_t>();
+    stored->value = 42;
+    object.store_data(std::move(stored), "custom");
+
+    REQUIRE(object.has_data("custom"));
+    REQUIRE(object.get_data<test_data_t>("custom"));
+    REQUIRE(object.get_data<test_data_t>("custom")->value == 42);
+
+    auto released = object.release_data<test_data_t>("custom");
+    REQUIRE(released);
+    REQUIRE(released->value == 42);
+    REQUIRE_FALSE(object.has_data("custom"));
+
+    auto safe = object.get_data_safe<test_data_t>();
+    safe->value = 17;
+
+    auto safe_again = object.get_data_safe<test_data_t>();
+    REQUIRE(safe_again.get() == safe.get());
+    REQUIRE(safe_again->value == 17);
+
+    object.erase_data<test_data_t>();
+    REQUIRE_FALSE(object.has_data<test_data_t>());
+}
+
+TEST_CASE("object base typed properties behave predictably")
+{
+    test_object_t object;
+
+    REQUIRE(object.set_property("answer", 42));
+    REQUIRE(object.has_property("answer"));
+    REQUIRE(object.get_property<int>("answer") == 42);
+    REQUIRE_FALSE(object.get_property<std::string>("answer").has_value());
+
+    REQUIRE_FALSE(object.set_property("answer", std::string{"wrong type"}));
+    REQUIRE(object.get_property<int>("answer") == 42);
+
+    object.erase_property("answer");
+    REQUIRE_FALSE(object.has_property("answer"));
+    REQUIRE_FALSE(object.get_property<int>("answer").has_value());
+}
+
+TEST_CASE("signal provider supports disconnect during emission")
+{
+    test_provider_t provider;
+    wf::signal::connection_t<test_signal> self_disconnect;
+    wf::signal::connection_t<test_signal> peer_disconnect;
+
+    int self_calls = 0;
+    int peer_calls = 0;
+
+    self_disconnect = [&] (test_signal*)
+    {
+        ++self_calls;
+        self_disconnect.disconnect();
+    };
+
+    peer_disconnect = [&] (test_signal*)
+    {
+        ++peer_calls;
+        self_disconnect.disconnect();
+    };
+
+    provider.connect(&self_disconnect);
+    provider.connect(&peer_disconnect);
+
+    test_signal signal{1};
+    provider.emit(&signal);
+    provider.emit(&signal);
+
+    REQUIRE(self_calls == 1);
+    REQUIRE(peer_calls == 2);
+    REQUIRE_FALSE(self_disconnect.is_connected());
+    REQUIRE(peer_disconnect.is_connected());
+}
+
+TEST_CASE("signal connections disconnect on scope exit and provider destruction")
+{
+    int scoped_calls = 0;
+    auto provider    = std::make_unique<test_provider_t>();
+    test_signal signal{1};
+
+    {
+        wf::signal::connection_t<test_signal> scoped;
+        scoped = [&] (test_signal *ev)
+        {
+            scoped_calls += ev->value;
+        };
+
+        provider->connect(&scoped);
+        provider->emit(&signal);
+        REQUIRE(scoped_calls == 1);
+        REQUIRE(scoped.is_connected());
+    }
+
+    provider->emit(&signal);
+    REQUIRE(scoped_calls == 1);
+
+    wf::signal::connection_t<test_signal> persistent;
+    persistent = [] (test_signal*) {};
+    provider->connect(&persistent);
+    REQUIRE(persistent.is_connected());
+
+    provider.reset();
+    REQUIRE_FALSE(persistent.is_connected());
+}

--- a/test/protocol/layer-shell-test.cpp
+++ b/test/protocol/layer-shell-test.cpp
@@ -1,0 +1,99 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/core.hpp>
+#include <wayfire/seat.hpp>
+#include <wayfire/signal-definitions.hpp>
+
+#include <vector>
+
+#include "../support/headless-core-harness.hpp"
+#include "../support/wayland-layer-shell-client.hpp"
+#include "../support/wayland-xdg-client.hpp"
+
+namespace
+{
+constexpr uint32_t LAYER_OVERLAY = 3;
+constexpr uint32_t LAYER_KEYBOARD_NONE = 0;
+constexpr uint32_t LAYER_ANCHOR_BOTTOM = 2;
+constexpr uint32_t LAYER_ANCHOR_RIGHT  = 8;
+}
+
+TEST_CASE("layer-shell popup with keyboard none does not steal focus")
+{
+    wf::test::headless_core_harness_t harness;
+
+    std::vector<wayfire_view> mapped;
+    wf::signal::connection_t<wf::view_mapped_signal> on_map = [&] (wf::view_mapped_signal *ev)
+    {
+        mapped.push_back(ev->view);
+    };
+
+    wf::get_core().connect(&on_map);
+
+    wf::test::wayland_xdg_client_t focused_client{harness.socket_name()};
+    wf::test::wayland_layer_shell_client_t layer_client{harness.socket_name()};
+    REQUIRE(harness.run_until([&]
+    {
+        focused_client.dispatch_once();
+        layer_client.dispatch_once();
+        return focused_client.has_required_globals() && layer_client.has_required_globals();
+    }));
+
+    focused_client.create_toplevel("focus target", "org.wayfire.FocusTarget");
+    REQUIRE(harness.run_until([&]
+    {
+        focused_client.dispatch_once();
+        return focused_client.has_pending_configure();
+    }));
+
+    focused_client.attach_and_commit(200, 120);
+    REQUIRE(harness.run_until([&]
+    {
+        focused_client.dispatch_once();
+        return mapped.size() == 1;
+    }));
+
+    auto focused_view = mapped.front();
+    REQUIRE(focused_view);
+    REQUIRE(harness.run_until([&]
+    {
+        return wf::get_core().seat->get_active_view() == focused_view;
+    }));
+
+    layer_client.create_layer_surface("regression-layer-shell-popup",
+        LAYER_OVERLAY,
+        LAYER_KEYBOARD_NONE,
+        120, 40,
+        LAYER_ANCHOR_BOTTOM | LAYER_ANCHOR_RIGHT);
+    REQUIRE(harness.run_until([&]
+    {
+        layer_client.dispatch_once();
+        return layer_client.has_pending_layer_configure();
+    }));
+
+    layer_client.attach_layer_and_commit(120, 40);
+    REQUIRE(harness.run_until([&]
+    {
+        layer_client.dispatch_once();
+        return mapped.size() == 2;
+    }));
+
+    CHECK(wf::get_core().seat->get_active_view() == focused_view);
+
+    layer_client.create_popup(140, 32, layer_client.last_layer_configure_serial());
+    REQUIRE(harness.run_until([&]
+    {
+        layer_client.dispatch_once();
+        return layer_client.has_pending_popup_configure();
+    }));
+
+    layer_client.attach_popup_and_commit(140, 32);
+    REQUIRE(harness.run_until([&]
+    {
+        layer_client.dispatch_once();
+        return mapped.size() == 3;
+    }));
+
+    CHECK(wf::get_core().seat->get_active_view() == focused_view);
+}

--- a/test/protocol/meson.build
+++ b/test/protocol/meson.build
@@ -6,9 +6,22 @@ xdg_shell_client_header = custom_target(
     output: 'xdg-shell-client-protocol.h',
     command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'])
 
+layer_shell_client_xml = join_paths(meson.project_source_root(),
+    'proto/wlr-layer-shell-unstable-v1.xml')
+
+layer_shell_client_header = custom_target(
+    'wlr-layer-shell-client-header',
+    input: layer_shell_client_xml,
+    output: 'wlr-layer-shell-client-protocol.h',
+    command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'])
+
 test_support_sources = [
     '../support/headless-core-harness.cpp',
+    '../support/wayland-client-utils.cpp',
+    '../support/wayland-layer-shell-client-bridge.c',
+    '../support/wayland-layer-shell-client.cpp',
     '../support/wayland-xdg-client.cpp',
+    layer_shell_client_header,
     xdg_shell_client_header,
 ]
 
@@ -23,4 +36,16 @@ xdg_shell_test = executable(
     ],
     install: false)
 
+layer_shell_test = executable(
+    'layer-shell-test',
+    'layer-shell-test.cpp',
+    test_support_sources,
+    dependencies: [doctest, libwayfire, wayland_client],
+    cpp_args: [
+        '-DTEST_METADATA_DIR="' + meson.project_source_root() + '/metadata"',
+        '-DTEST_DEFAULTS_INI="' + meson.project_source_root() + '/wayfire.ini"',
+    ],
+    install: false)
+
 test('Xdg-shell test', xdg_shell_test)
+test('Layer-shell test', layer_shell_test)

--- a/test/protocol/meson.build
+++ b/test/protocol/meson.build
@@ -1,0 +1,26 @@
+xdg_shell_client_xml = join_paths(wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml')
+
+xdg_shell_client_header = custom_target(
+    'xdg-shell-client-header',
+    input: xdg_shell_client_xml,
+    output: 'xdg-shell-client-protocol.h',
+    command: [wayland_scanner, 'client-header', '@INPUT@', '@OUTPUT@'])
+
+test_support_sources = [
+    '../support/headless-core-harness.cpp',
+    '../support/wayland-xdg-client.cpp',
+    xdg_shell_client_header,
+]
+
+xdg_shell_test = executable(
+    'xdg-shell-test',
+    'xdg-shell-test.cpp',
+    test_support_sources,
+    dependencies: [doctest, libwayfire, wayland_client],
+    cpp_args: [
+        '-DTEST_METADATA_DIR="' + meson.project_source_root() + '/metadata"',
+        '-DTEST_DEFAULTS_INI="' + meson.project_source_root() + '/wayfire.ini"',
+    ],
+    install: false)
+
+test('Xdg-shell test', xdg_shell_test)

--- a/test/protocol/xdg-shell-test.cpp
+++ b/test/protocol/xdg-shell-test.cpp
@@ -1,0 +1,58 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/core.hpp>
+#include <wayfire/signal-definitions.hpp>
+
+#include <vector>
+
+#include "../support/headless-core-harness.hpp"
+#include "../support/wayland-xdg-client.hpp"
+
+TEST_CASE("xdg toplevel maps after configure ack and buffer commit")
+{
+    wf::test::headless_core_harness_t harness;
+
+    std::vector<wayfire_view> mapped;
+    std::vector<wayfire_view> unmapped;
+    wf::signal::connection_t<wf::view_mapped_signal> on_map = [&] (wf::view_mapped_signal *ev)
+    {
+        mapped.push_back(ev->view);
+    };
+    wf::signal::connection_t<wf::view_unmapped_signal> on_unmap = [&] (wf::view_unmapped_signal *ev)
+    {
+        unmapped.push_back(ev->view);
+    };
+
+    wf::get_core().connect(&on_map);
+    wf::get_core().connect(&on_unmap);
+
+    wf::test::wayland_xdg_client_t client{harness.socket_name()};
+    REQUIRE(harness.run_until([&]
+    {
+        client.dispatch_once();
+        return client.has_required_globals();
+    }));
+
+    client.create_toplevel("xdg-shell test", "org.wayfire.Test");
+
+    REQUIRE(harness.run_until([&]
+    {
+        client.dispatch_once();
+        return client.has_pending_configure();
+    }));
+    REQUIRE(client.last_configure_serial() != 0);
+    CHECK(mapped.empty());
+
+    client.attach_and_commit(200, 120);
+    REQUIRE(harness.run_until([&] () { return mapped.size() == 1; }));
+    REQUIRE(mapped.front());
+    CHECK(mapped.front()->get_title() == "xdg-shell test");
+    CHECK(mapped.front()->get_app_id() == "org.wayfire.Test");
+    CHECK(mapped.front()->get_output() == harness.output());
+    CHECK(mapped.front()->is_mapped());
+
+    client.destroy_toplevel();
+    REQUIRE(harness.run_until([&] () { return unmapped.size() == 1; }));
+    CHECK(unmapped.front() == mapped.front());
+}

--- a/test/support/headless-core-harness.cpp
+++ b/test/support/headless-core-harness.cpp
@@ -1,0 +1,265 @@
+#include "headless-core-harness.hpp"
+
+#include <config.h>
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <stdexcept>
+#include <chrono>
+#include <array>
+
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <wayfire/config-backend.hpp>
+#include <wayfire/config/file.hpp>
+#include <wayfire/core.hpp>
+#include <wayfire/debug.hpp>
+#include <wayfire/nonstd/wlroots-full.hpp>
+#include <wayfire/output-layout.hpp>
+#include <wayfire/seat.hpp>
+#include <wayfire/signal-definitions.hpp>
+#include <wayfire/util/log.hpp>
+
+#include <wayland-server-core.h>
+
+#include "../../src/core/core-impl.hpp"
+#include "../../src/main.hpp"
+
+namespace
+{
+class test_config_backend_t : public wf::config_backend_t
+{
+  public:
+    void init(wl_display*, wf::config::config_manager_t& config,
+        const std::string&) override
+    {
+        setenv("WAYFIRE_PLUGIN_XML_PATH", TEST_METADATA_DIR, 1);
+        config = wf::config::build_configuration(get_xml_dirs(), "/dev/null",
+            "/dev/null");
+
+        wf::config::load_configuration_options_from_string(config,
+            "[core]\n"
+            "plugins = \n"
+            "xwayland = false\n"
+            "\n"
+            "[autostart]\n"
+            "autostart_wf_shell = false\n"
+            "\n"
+            "[workarounds]\n"
+            "auto_reload_config = false\n"
+            "enable_input_method_v2 = false\n"
+            "use_external_output_configuration = false\n",
+            "xdg-shell-test-config");
+    }
+};
+
+static std::string add_test_socket(wl_display *display)
+{
+    const char *socket = wl_display_add_socket_auto(display);
+    if (!socket)
+    {
+        throw std::runtime_error("Failed to create Wayland socket for test harness");
+    }
+
+    return socket;
+}
+
+static bool is_usable_runtime_dir(const char *path)
+{
+    if (!path || !path[0])
+    {
+        return false;
+    }
+
+    struct stat st;
+    return (stat(path, &st) == 0) && S_ISDIR(st.st_mode) && (access(path, W_OK | X_OK) == 0);
+}
+
+static std::string ensure_test_runtime_dir()
+{
+    if (is_usable_runtime_dir(getenv("XDG_RUNTIME_DIR")))
+    {
+        return {};
+    }
+
+    auto base = std::filesystem::temp_directory_path() / "wayfire-test-runtime-XXXXXX";
+    std::array<char, PATH_MAX> runtime_dir{};
+    auto path = base.string();
+    if (path.size() >= runtime_dir.size())
+    {
+        throw std::runtime_error("Temporary runtime directory path is too long");
+    }
+
+    std::snprintf(runtime_dir.data(), runtime_dir.size(), "%s", path.c_str());
+    if (!mkdtemp(runtime_dir.data()))
+    {
+        throw std::runtime_error("Failed to create temporary runtime directory for test harness");
+    }
+
+    std::filesystem::permissions(runtime_dir.data(),
+        std::filesystem::perms::owner_all,
+        std::filesystem::perm_options::replace);
+    setenv("XDG_RUNTIME_DIR", runtime_dir.data(), 1);
+    return runtime_dir.data();
+}
+}
+
+struct wf::test::headless_core_harness_t::impl
+{
+    wf::compositor_core_impl_t *core = nullptr;
+    std::string old_wayland_display;
+    std::string old_xdg_runtime_dir;
+    std::string test_runtime_dir;
+    bool had_wayland_display = false;
+    bool had_xdg_runtime_dir = false;
+};
+
+wf::test::headless_core_harness_t::headless_core_harness_t()
+{
+    wf::log::initialize_logging(std::cout, wf::log::LOG_LEVEL_DEBUG,
+        wf::log::LOG_COLOR_MODE_OFF);
+    wlr_log_init(WLR_ERROR, nullptr);
+
+    priv = std::make_unique<impl>();
+    priv->core = &wf::compositor_core_impl_t::allocate_core();
+
+    if (const char *old = getenv("WAYLAND_DISPLAY"))
+    {
+        priv->had_wayland_display = true;
+        priv->old_wayland_display = old;
+    }
+
+    if (const char *old = getenv("XDG_RUNTIME_DIR"))
+    {
+        priv->had_xdg_runtime_dir = true;
+        priv->old_xdg_runtime_dir = old;
+    }
+
+    priv->test_runtime_dir = ensure_test_runtime_dir();
+
+    auto& core = *priv->core;
+    core.display = wl_display_create();
+    core.session = nullptr;
+    if (!core.display)
+    {
+        throw std::runtime_error("Failed to create Wayland display");
+    }
+
+    core.ev_loop = wl_display_get_event_loop(core.display);
+    core.backend = wlr_headless_backend_create(core.ev_loop);
+    if (!core.backend)
+    {
+        throw std::runtime_error("Failed to create headless backend");
+    }
+
+    core.renderer = wlr_pixman_renderer_create();
+    if (!core.renderer)
+    {
+        throw std::runtime_error("Failed to create renderer");
+    }
+
+    core.allocator = wlr_allocator_autocreate(core.backend, core.renderer);
+    if (!core.allocator)
+    {
+        throw std::runtime_error("Failed to create allocator");
+    }
+
+    core.config_backend = std::make_unique<test_config_backend_t>();
+    core.config_backend->init(core.display, *core.config, "");
+    core.init();
+
+    core.wayland_display = add_test_socket(core.display);
+    setenv("WAYLAND_DISPLAY", core.wayland_display.c_str(), 1);
+
+    if (!wlr_backend_start(core.backend))
+    {
+        throw std::runtime_error("Failed to start headless backend");
+    }
+
+    auto *output_handle = wlr_headless_add_output(core.backend, 1280, 720);
+    if (!output_handle)
+    {
+        throw std::runtime_error("Failed to create headless output");
+    }
+
+    roundtrip();
+    auto outputs = core.output_layout->get_outputs();
+    if (!outputs.empty())
+    {
+        outputs.front()->ensure_pointer(true);
+        core.seat->focus_output(outputs.front());
+    }
+
+    roundtrip();
+}
+
+wf::test::headless_core_harness_t::~headless_core_harness_t()
+{
+    if (priv && priv->core)
+    {
+        wf::compositor_core_impl_t::deallocate_core();
+    }
+
+    if (priv && priv->had_wayland_display)
+    {
+        setenv("WAYLAND_DISPLAY", priv->old_wayland_display.c_str(), 1);
+    } else
+    {
+        unsetenv("WAYLAND_DISPLAY");
+    }
+
+    if (priv && priv->had_xdg_runtime_dir)
+    {
+        setenv("XDG_RUNTIME_DIR", priv->old_xdg_runtime_dir.c_str(), 1);
+    } else
+    {
+        unsetenv("XDG_RUNTIME_DIR");
+    }
+
+    if (priv && !priv->test_runtime_dir.empty())
+    {
+        std::error_code ec;
+        std::filesystem::remove_all(priv->test_runtime_dir, ec);
+    }
+}
+
+void wf::test::headless_core_harness_t::dispatch_once(int timeout_ms)
+{
+    wl_event_loop_dispatch(priv->core->ev_loop, timeout_ms);
+    wl_display_flush_clients(priv->core->display);
+}
+
+void wf::test::headless_core_harness_t::roundtrip()
+{
+    dispatch_once(0);
+    dispatch_once(0);
+}
+
+bool wf::test::headless_core_harness_t::run_until(const std::function<bool()>& predicate,
+    int max_iterations)
+{
+    for (int i = 0; i < max_iterations; ++i)
+    {
+        if (predicate())
+        {
+            return true;
+        }
+
+        dispatch_once(10);
+    }
+
+    return predicate();
+}
+
+wf::output_t*wf::test::headless_core_harness_t::output() const
+{
+    auto outputs = priv->core->output_layout->get_outputs();
+    return outputs.empty() ? nullptr : outputs.front();
+}
+
+const std::string& wf::test::headless_core_harness_t::socket_name() const
+{
+    return priv->core->wayland_display;
+}

--- a/test/support/headless-core-harness.hpp
+++ b/test/support/headless-core-harness.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <wayfire/core.hpp>
+
+namespace wf::test
+{
+class headless_core_harness_t
+{
+  public:
+    headless_core_harness_t();
+    ~headless_core_harness_t();
+
+    headless_core_harness_t(const headless_core_harness_t&) = delete;
+    headless_core_harness_t(headless_core_harness_t&&) = delete;
+    headless_core_harness_t& operator =(const headless_core_harness_t&) = delete;
+    headless_core_harness_t& operator =(headless_core_harness_t&&) = delete;
+
+    void dispatch_once(int timeout_ms = 0);
+    void roundtrip();
+    bool run_until(const std::function<bool()>& predicate, int max_iterations = 200);
+
+    wf::output_t *output() const;
+    const std::string& socket_name() const;
+
+  private:
+    struct impl;
+    std::unique_ptr<impl> priv;
+};
+}

--- a/test/support/wayland-client-utils.cpp
+++ b/test/support/wayland-client-utils.cpp
@@ -1,0 +1,88 @@
+#include "wayland-client-utils.hpp"
+
+#include <sys/mman.h>
+#include <poll.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <algorithm>
+#include <stdexcept>
+
+#include <wayland-client-core.h>
+#include <wayland-client-protocol.h>
+
+namespace
+{
+int create_shm_file(size_t size)
+{
+    char name[] = "/wayfire-test-XXXXXX";
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd < 0)
+    {
+        return -1;
+    }
+
+    shm_unlink(name);
+    if (ftruncate(fd, size) < 0)
+    {
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+}
+
+void wf::test::wayland_dispatch_once(wl_display *display, int timeout_ms)
+{
+    wl_display_dispatch_pending(display);
+    wl_display_flush(display);
+
+    if (wl_display_prepare_read(display) != 0)
+    {
+        wl_display_dispatch_pending(display);
+        return;
+    }
+
+    pollfd pfd = {
+        .fd     = wl_display_get_fd(display),
+        .events = POLLIN,
+        .revents = 0,
+    };
+
+    if (poll(&pfd, 1, timeout_ms) > 0)
+    {
+        wl_display_read_events(display);
+        wl_display_dispatch_pending(display);
+    } else
+    {
+        wl_display_cancel_read(display);
+    }
+}
+
+wl_buffer*wf::test::create_shm_buffer(wl_shm *shm, int width, int height, uint32_t color)
+{
+    const int stride  = width * 4;
+    const size_t size = stride * height;
+    int fd = create_shm_file(size);
+    if (fd < 0)
+    {
+        throw std::runtime_error("Failed to create shared memory file for test buffer");
+    }
+
+    void *data = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED)
+    {
+        close(fd);
+        throw std::runtime_error("Failed to mmap test buffer");
+    }
+
+    std::fill_n(static_cast<uint32_t*>(data), width * height, color);
+    auto *pool   = wl_shm_create_pool(shm, fd, size);
+    auto *buffer = wl_shm_pool_create_buffer(pool, 0, width, height, stride,
+        WL_SHM_FORMAT_XRGB8888);
+    wl_shm_pool_destroy(pool);
+    munmap(data, size);
+    close(fd);
+    return buffer;
+}

--- a/test/support/wayland-client-utils.hpp
+++ b/test/support/wayland-client-utils.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <cstdint>
+
+struct wl_buffer;
+struct wl_display;
+struct wl_shm;
+
+namespace wf::test
+{
+void wayland_dispatch_once(wl_display *display, int timeout_ms = 0);
+wl_buffer *create_shm_buffer(wl_shm *shm, int width, int height, uint32_t color);
+}

--- a/test/support/wayland-layer-shell-client-bridge.c
+++ b/test/support/wayland-layer-shell-client-bridge.c
@@ -1,0 +1,65 @@
+#include "wayland-layer-shell-client-bridge.h"
+
+#include "wlr-layer-shell-client-protocol.h"
+
+struct zwlr_layer_surface_v1 *wf_test_layer_shell_get_layer_surface(
+    struct zwlr_layer_shell_v1 *layer_shell,
+    struct wl_surface *surface,
+    struct wl_output *output,
+    uint32_t layer,
+    const char *namespace_name)
+{
+    return zwlr_layer_shell_v1_get_layer_surface(layer_shell, surface, output,
+        layer, namespace_name);
+}
+
+int wf_test_layer_surface_add_listener(
+    struct zwlr_layer_surface_v1 *layer_surface,
+    const struct zwlr_layer_surface_v1_listener *listener,
+    void *data)
+{
+    return zwlr_layer_surface_v1_add_listener(layer_surface, listener, data);
+}
+
+void wf_test_layer_shell_destroy(struct zwlr_layer_shell_v1 *layer_shell)
+{
+    zwlr_layer_shell_v1_destroy(layer_shell);
+}
+
+void wf_test_layer_surface_set_size(struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t width, uint32_t height)
+{
+    zwlr_layer_surface_v1_set_size(layer_surface, width, height);
+}
+
+void wf_test_layer_surface_set_anchor(struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t anchor)
+{
+    zwlr_layer_surface_v1_set_anchor(layer_surface, anchor);
+}
+
+void wf_test_layer_surface_set_keyboard_interactivity(
+    struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t keyboard_interactivity)
+{
+    zwlr_layer_surface_v1_set_keyboard_interactivity(layer_surface,
+        keyboard_interactivity);
+}
+
+void wf_test_layer_surface_get_popup(struct zwlr_layer_surface_v1 *layer_surface,
+    struct xdg_popup *popup)
+{
+    zwlr_layer_surface_v1_get_popup(layer_surface, popup);
+}
+
+void wf_test_layer_surface_ack_configure(
+    struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t serial)
+{
+    zwlr_layer_surface_v1_ack_configure(layer_surface, serial);
+}
+
+void wf_test_layer_surface_destroy(struct zwlr_layer_surface_v1 *layer_surface)
+{
+    zwlr_layer_surface_v1_destroy(layer_surface);
+}

--- a/test/support/wayland-layer-shell-client-bridge.h
+++ b/test/support/wayland-layer-shell-client-bridge.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <stdint.h>
+
+struct wl_output;
+struct wl_surface;
+struct xdg_popup;
+struct zwlr_layer_shell_v1;
+struct zwlr_layer_surface_v1;
+struct zwlr_layer_surface_v1_listener;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct zwlr_layer_surface_v1 *wf_test_layer_shell_get_layer_surface(
+    struct zwlr_layer_shell_v1 *layer_shell,
+    struct wl_surface *surface,
+    struct wl_output *output,
+    uint32_t layer,
+    const char *namespace_name);
+
+int wf_test_layer_surface_add_listener(
+    struct zwlr_layer_surface_v1 *layer_surface,
+    const struct zwlr_layer_surface_v1_listener *listener,
+    void *data);
+
+void wf_test_layer_shell_destroy(struct zwlr_layer_shell_v1 *layer_shell);
+void wf_test_layer_surface_set_size(struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t width, uint32_t height);
+void wf_test_layer_surface_set_anchor(struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t anchor);
+void wf_test_layer_surface_set_keyboard_interactivity(
+    struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t keyboard_interactivity);
+void wf_test_layer_surface_get_popup(struct zwlr_layer_surface_v1 *layer_surface,
+    struct xdg_popup *popup);
+void wf_test_layer_surface_ack_configure(
+    struct zwlr_layer_surface_v1 *layer_surface,
+    uint32_t serial);
+void wf_test_layer_surface_destroy(struct zwlr_layer_surface_v1 *layer_surface);
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/support/wayland-layer-shell-client.cpp
+++ b/test/support/wayland-layer-shell-client.cpp
@@ -1,0 +1,344 @@
+#include "wayland-layer-shell-client.hpp"
+
+#include <stdexcept>
+#include <string>
+
+#include <wayland-client-core.h>
+#include <wayland-client-protocol.h>
+
+#define namespace namespace_
+#include "wlr-layer-shell-client-protocol.h"
+#undef namespace
+
+#include "wayland-client-utils.hpp"
+#include "wayland-layer-shell-client-bridge.h"
+#include "xdg-shell-client-protocol.h"
+
+struct wf::test::wayland_layer_shell_client_t::impl
+{
+    wl_display *display   = nullptr;
+    wl_registry *registry = nullptr;
+    wl_compositor *compositor = nullptr;
+    wl_shm *shm   = nullptr;
+    wl_seat *seat = nullptr;
+    xdg_wm_base *wm_base = nullptr;
+    zwlr_layer_shell_v1 *layer_shell = nullptr;
+
+    wl_surface *layer_surface = nullptr;
+    zwlr_layer_surface_v1 *shell_layer_surface = nullptr;
+    wl_buffer *layer_buffer = nullptr;
+
+    wl_surface *popup_surface = nullptr;
+    ::xdg_surface *popup_xdg_surface = nullptr;
+    ::xdg_popup *shell_popup = nullptr;
+    wl_buffer *popup_buffer  = nullptr;
+
+    bool layer_configured = false;
+    uint32_t layer_configure_serial = 0;
+
+    bool popup_configured = false;
+    uint32_t popup_configure_serial = 0;
+
+    static void handle_registry_global(void *data, wl_registry *registry,
+        uint32_t name, const char *interface, uint32_t version)
+    {
+        auto *self = static_cast<impl*>(data);
+        if (std::string{interface} == wl_compositor_interface.name)
+        {
+            self->compositor = static_cast<wl_compositor*>(wl_registry_bind(registry,
+                name, &wl_compositor_interface, 4));
+        } else if (std::string{interface} == wl_shm_interface.name)
+        {
+            self->shm = static_cast<wl_shm*>(wl_registry_bind(registry,
+                name, &wl_shm_interface, 1));
+        } else if (std::string{interface} == wl_seat_interface.name)
+        {
+            self->seat = static_cast<wl_seat*>(wl_registry_bind(registry,
+                name, &wl_seat_interface, 5));
+        } else if (std::string{interface} == xdg_wm_base_interface.name)
+        {
+            self->wm_base = static_cast<xdg_wm_base*>(wl_registry_bind(registry,
+                name, &xdg_wm_base_interface, std::min(version, 2u)));
+        } else if (std::string{interface} == zwlr_layer_shell_v1_interface.name)
+        {
+            self->layer_shell = static_cast<zwlr_layer_shell_v1*>(wl_registry_bind(registry,
+                name, &zwlr_layer_shell_v1_interface, std::min(version, 4u)));
+        }
+    }
+
+    static void handle_registry_remove(void*, wl_registry*, uint32_t)
+    {}
+
+    static constexpr wl_registry_listener registry_listener = {
+        .global = handle_registry_global,
+        .global_remove = handle_registry_remove,
+    };
+
+    static void handle_ping(void*, xdg_wm_base *wm_base, uint32_t serial)
+    {
+        xdg_wm_base_pong(wm_base, serial);
+    }
+
+    static constexpr xdg_wm_base_listener wm_base_listener = {
+        .ping = handle_ping,
+    };
+
+    static void handle_layer_surface_configure(void *data,
+        zwlr_layer_surface_v1 *layer_surface, uint32_t serial, uint32_t, uint32_t)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->layer_configured = true;
+        self->layer_configure_serial = serial;
+        wf_test_layer_surface_ack_configure(layer_surface, serial);
+    }
+
+    static void handle_layer_surface_closed(void*, zwlr_layer_surface_v1*)
+    {}
+
+    static constexpr zwlr_layer_surface_v1_listener layer_surface_listener = {
+        .configure = handle_layer_surface_configure,
+        .closed    = handle_layer_surface_closed,
+    };
+
+    static void handle_popup_xdg_surface_configure(void *data, ::xdg_surface *surface,
+        uint32_t serial)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->popup_configured = true;
+        self->popup_configure_serial = serial;
+        xdg_surface_ack_configure(surface, serial);
+    }
+
+    static constexpr ::xdg_surface_listener popup_xdg_surface_listener = {
+        .configure = handle_popup_xdg_surface_configure,
+    };
+
+    static void handle_popup_configure(void*, ::xdg_popup*, int32_t, int32_t,
+        int32_t, int32_t)
+    {}
+
+    static void handle_popup_done(void*, ::xdg_popup*)
+    {}
+
+    static void handle_popup_repositioned(void*, ::xdg_popup*, uint32_t)
+    {}
+
+    static constexpr ::xdg_popup_listener popup_listener = {
+        .configure    = handle_popup_configure,
+        .popup_done   = handle_popup_done,
+        .repositioned = handle_popup_repositioned,
+    };
+};
+
+wf::test::wayland_layer_shell_client_t::wayland_layer_shell_client_t(const std::string& socket_name)
+{
+    priv = std::make_unique<impl>();
+    priv->display = wl_display_connect(socket_name.c_str());
+    if (!priv->display)
+    {
+        throw std::runtime_error("Failed to connect layer-shell test client to Wayland display");
+    }
+
+    priv->registry = wl_display_get_registry(priv->display);
+    wl_registry_add_listener(priv->registry, &impl::registry_listener, priv.get());
+    wl_display_flush(priv->display);
+}
+
+wf::test::wayland_layer_shell_client_t::~wayland_layer_shell_client_t()
+{
+    destroy_popup();
+    destroy_layer_surface();
+
+    if (priv->layer_shell)
+    {
+        wf_test_layer_shell_destroy(priv->layer_shell);
+    }
+
+    if (priv->wm_base)
+    {
+        xdg_wm_base_destroy(priv->wm_base);
+    }
+
+    if (priv->seat)
+    {
+        wl_seat_destroy(priv->seat);
+    }
+
+    if (priv->registry)
+    {
+        wl_registry_destroy(priv->registry);
+    }
+
+    if (priv->shm)
+    {
+        wl_shm_destroy(priv->shm);
+    }
+
+    if (priv->compositor)
+    {
+        wl_compositor_destroy(priv->compositor);
+    }
+
+    if (priv->display)
+    {
+        wl_display_disconnect(priv->display);
+    }
+}
+
+void wf::test::wayland_layer_shell_client_t::dispatch_once(int timeout_ms)
+{
+    wayland_dispatch_once(priv->display, timeout_ms);
+}
+
+bool wf::test::wayland_layer_shell_client_t::has_required_globals() const
+{
+    return priv->compositor && priv->shm && priv->seat && priv->wm_base && priv->layer_shell;
+}
+
+void wf::test::wayland_layer_shell_client_t::create_layer_surface(
+    const std::string& namespace_name, uint32_t layer, uint32_t keyboard_interactivity,
+    int width, int height, uint32_t anchor)
+{
+    if (!has_required_globals())
+    {
+        throw std::runtime_error("Tried to create layer surface before binding required globals");
+    }
+
+    xdg_wm_base_add_listener(priv->wm_base, &impl::wm_base_listener, priv.get());
+    priv->layer_surface = wl_compositor_create_surface(priv->compositor);
+    priv->shell_layer_surface = wf_test_layer_shell_get_layer_surface(priv->layer_shell,
+        priv->layer_surface, nullptr, layer, namespace_name.c_str());
+    wf_test_layer_surface_add_listener(priv->shell_layer_surface,
+        &impl::layer_surface_listener, priv.get());
+    wf_test_layer_surface_set_size(priv->shell_layer_surface, width, height);
+    wf_test_layer_surface_set_anchor(priv->shell_layer_surface, anchor);
+    wf_test_layer_surface_set_keyboard_interactivity(priv->shell_layer_surface,
+        keyboard_interactivity);
+    wl_surface_commit(priv->layer_surface);
+    wl_display_flush(priv->display);
+}
+
+bool wf::test::wayland_layer_shell_client_t::has_pending_layer_configure() const
+{
+    return priv->layer_configured;
+}
+
+uint32_t wf::test::wayland_layer_shell_client_t::last_layer_configure_serial() const
+{
+    return priv->layer_configure_serial;
+}
+
+void wf::test::wayland_layer_shell_client_t::attach_layer_and_commit(int width, int height)
+{
+    if (priv->layer_buffer)
+    {
+        wl_buffer_destroy(priv->layer_buffer);
+    }
+
+    priv->layer_buffer = create_shm_buffer(priv->shm, width, height, 0xff6644aau);
+    wl_surface_attach(priv->layer_surface, priv->layer_buffer, 0, 0);
+    wl_surface_damage_buffer(priv->layer_surface, 0, 0, width, height);
+    wl_surface_commit(priv->layer_surface);
+    wl_display_flush(priv->display);
+}
+
+void wf::test::wayland_layer_shell_client_t::create_popup(int width, int height,
+    uint32_t grab_serial)
+{
+    auto *positioner = xdg_wm_base_create_positioner(priv->wm_base);
+    xdg_positioner_set_size(positioner, width, height);
+    xdg_positioner_set_anchor_rect(positioner, 0, 0, width, height);
+    xdg_positioner_set_anchor(positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);
+    xdg_positioner_set_gravity(positioner, XDG_POSITIONER_GRAVITY_BOTTOM_RIGHT);
+
+    priv->popup_surface     = wl_compositor_create_surface(priv->compositor);
+    priv->popup_xdg_surface = xdg_wm_base_get_xdg_surface(priv->wm_base, priv->popup_surface);
+    xdg_surface_add_listener(priv->popup_xdg_surface, &impl::popup_xdg_surface_listener,
+        priv.get());
+    priv->shell_popup = xdg_surface_get_popup(priv->popup_xdg_surface, nullptr, positioner);
+    xdg_popup_add_listener(priv->shell_popup, &impl::popup_listener, priv.get());
+    wf_test_layer_surface_get_popup(priv->shell_layer_surface, priv->shell_popup);
+    if (grab_serial)
+    {
+        xdg_popup_grab(priv->shell_popup, priv->seat, grab_serial);
+    }
+
+    xdg_positioner_destroy(positioner);
+    wl_surface_commit(priv->popup_surface);
+    wl_display_flush(priv->display);
+}
+
+bool wf::test::wayland_layer_shell_client_t::has_pending_popup_configure() const
+{
+    return priv->popup_configured;
+}
+
+void wf::test::wayland_layer_shell_client_t::attach_popup_and_commit(int width, int height)
+{
+    if (priv->popup_buffer)
+    {
+        wl_buffer_destroy(priv->popup_buffer);
+    }
+
+    priv->popup_buffer = create_shm_buffer(priv->shm, width, height, 0xff6644aau);
+    wl_surface_attach(priv->popup_surface, priv->popup_buffer, 0, 0);
+    wl_surface_damage_buffer(priv->popup_surface, 0, 0, width, height);
+    wl_surface_commit(priv->popup_surface);
+    wl_display_flush(priv->display);
+}
+
+void wf::test::wayland_layer_shell_client_t::destroy_popup()
+{
+    if (priv->popup_buffer)
+    {
+        wl_buffer_destroy(priv->popup_buffer);
+        priv->popup_buffer = nullptr;
+    }
+
+    if (priv->shell_popup)
+    {
+        xdg_popup_destroy(priv->shell_popup);
+        priv->shell_popup = nullptr;
+    }
+
+    if (priv->popup_xdg_surface)
+    {
+        xdg_surface_destroy(priv->popup_xdg_surface);
+        priv->popup_xdg_surface = nullptr;
+    }
+
+    if (priv->popup_surface)
+    {
+        wl_surface_destroy(priv->popup_surface);
+        priv->popup_surface = nullptr;
+    }
+
+    priv->popup_configured = false;
+    priv->popup_configure_serial = 0;
+    wl_display_flush(priv->display);
+}
+
+void wf::test::wayland_layer_shell_client_t::destroy_layer_surface()
+{
+    if (priv->layer_buffer)
+    {
+        wl_buffer_destroy(priv->layer_buffer);
+        priv->layer_buffer = nullptr;
+    }
+
+    if (priv->shell_layer_surface)
+    {
+        wf_test_layer_surface_destroy(priv->shell_layer_surface);
+        priv->shell_layer_surface = nullptr;
+    }
+
+    if (priv->layer_surface)
+    {
+        wl_surface_destroy(priv->layer_surface);
+        priv->layer_surface = nullptr;
+    }
+
+    priv->layer_configured = false;
+    priv->layer_configure_serial = 0;
+    wl_display_flush(priv->display);
+}

--- a/test/support/wayland-layer-shell-client.hpp
+++ b/test/support/wayland-layer-shell-client.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+struct wl_display;
+struct wl_registry;
+struct wl_compositor;
+struct wl_shm;
+struct wl_surface;
+struct wl_buffer;
+struct wl_seat;
+struct xdg_wm_base;
+struct xdg_surface;
+struct xdg_popup;
+struct zwlr_layer_shell_v1;
+struct zwlr_layer_surface_v1;
+
+namespace wf::test
+{
+class wayland_layer_shell_client_t
+{
+  public:
+    explicit wayland_layer_shell_client_t(const std::string& socket_name);
+    ~wayland_layer_shell_client_t();
+
+    wayland_layer_shell_client_t(const wayland_layer_shell_client_t&) = delete;
+    wayland_layer_shell_client_t(wayland_layer_shell_client_t&&) = delete;
+    wayland_layer_shell_client_t& operator =(const wayland_layer_shell_client_t&) = delete;
+    wayland_layer_shell_client_t& operator =(wayland_layer_shell_client_t&&) = delete;
+
+    void dispatch_once(int timeout_ms = 0);
+    bool has_required_globals() const;
+
+    void create_layer_surface(const std::string& namespace_name, uint32_t layer,
+        uint32_t keyboard_interactivity, int width, int height, uint32_t anchor);
+    bool has_pending_layer_configure() const;
+    uint32_t last_layer_configure_serial() const;
+    void attach_layer_and_commit(int width, int height);
+
+    void create_popup(int width, int height, uint32_t grab_serial = 0);
+    bool has_pending_popup_configure() const;
+    void attach_popup_and_commit(int width, int height);
+
+    void destroy_popup();
+    void destroy_layer_surface();
+
+  private:
+    struct impl;
+    std::unique_ptr<impl> priv;
+};
+}

--- a/test/support/wayland-xdg-client.cpp
+++ b/test/support/wayland-xdg-client.cpp
@@ -1,0 +1,307 @@
+#include "wayland-xdg-client.hpp"
+
+#include <sys/mman.h>
+#include <poll.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <wayland-client-core.h>
+#include <wayland-client-protocol.h>
+
+#include "xdg-shell-client-protocol.h"
+
+namespace
+{
+int create_shm_file(size_t size)
+{
+    char name[] = "/wayfire-test-XXXXXX";
+    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd < 0)
+    {
+        return -1;
+    }
+
+    shm_unlink(name);
+    if (ftruncate(fd, size) < 0)
+    {
+        close(fd);
+        return -1;
+    }
+
+    return fd;
+}
+}
+
+struct wf::test::wayland_xdg_client_t::impl
+{
+    wl_display *display   = nullptr;
+    wl_registry *registry = nullptr;
+    wl_compositor *compositor = nullptr;
+    wl_shm *shm = nullptr;
+    xdg_wm_base *wm_base = nullptr;
+
+    wl_surface *surface = nullptr;
+    ::xdg_surface *shell_surface   = nullptr;
+    ::xdg_toplevel *shell_toplevel = nullptr;
+    wl_buffer *buffer = nullptr;
+
+    bool configured = false;
+    uint32_t configure_serial = 0;
+
+    static void handle_registry_global(void *data, wl_registry *registry,
+        uint32_t name, const char *interface, uint32_t version)
+    {
+        auto *self = static_cast<impl*>(data);
+        if (std::string{interface} == wl_compositor_interface.name)
+        {
+            self->compositor = static_cast<wl_compositor*>(wl_registry_bind(registry,
+                name, &wl_compositor_interface, 4));
+        } else if (std::string{interface} == wl_shm_interface.name)
+        {
+            self->shm = static_cast<wl_shm*>(wl_registry_bind(registry,
+                name, &wl_shm_interface, 1));
+        } else if (std::string{interface} == xdg_wm_base_interface.name)
+        {
+            self->wm_base = static_cast<xdg_wm_base*>(wl_registry_bind(registry,
+                name, &xdg_wm_base_interface, std::min(version, 2u)));
+        }
+    }
+
+    static void handle_registry_remove(void*, wl_registry*, uint32_t)
+    {}
+
+    static constexpr wl_registry_listener registry_listener = {
+        .global = handle_registry_global,
+        .global_remove = handle_registry_remove,
+    };
+
+    static void handle_ping(void*, xdg_wm_base *wm_base, uint32_t serial)
+    {
+        xdg_wm_base_pong(wm_base, serial);
+    }
+
+    static constexpr xdg_wm_base_listener wm_base_listener = {
+        .ping = handle_ping,
+    };
+
+    static void handle_xdg_surface_configure(void *data, ::xdg_surface *surface,
+        uint32_t serial)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->configured = true;
+        self->configure_serial = serial;
+        xdg_surface_ack_configure(surface, serial);
+    }
+
+    static constexpr ::xdg_surface_listener xdg_surface_listener = {
+        .configure = handle_xdg_surface_configure,
+    };
+};
+
+wf::test::wayland_xdg_client_t::wayland_xdg_client_t(const std::string& socket_name)
+{
+    priv = std::make_unique<impl>();
+    priv->display = wl_display_connect(socket_name.c_str());
+    if (!priv->display)
+    {
+        throw std::runtime_error("Failed to connect test client to Wayland display");
+    }
+
+    priv->registry = wl_display_get_registry(priv->display);
+    wl_registry_add_listener(priv->registry, &impl::registry_listener, priv.get());
+    wl_display_flush(priv->display);
+}
+
+wf::test::wayland_xdg_client_t::~wayland_xdg_client_t()
+{
+    destroy_toplevel();
+    if (priv->wm_base)
+    {
+        xdg_wm_base_destroy(priv->wm_base);
+    }
+
+    if (priv->registry)
+    {
+        wl_registry_destroy(priv->registry);
+    }
+
+    if (priv->shm)
+    {
+        wl_shm_destroy(priv->shm);
+    }
+
+    if (priv->compositor)
+    {
+        wl_compositor_destroy(priv->compositor);
+    }
+
+    if (priv->display)
+    {
+        wl_display_disconnect(priv->display);
+    }
+}
+
+void wf::test::wayland_xdg_client_t::roundtrip()
+{
+    wl_display_roundtrip(priv->display);
+}
+
+void wf::test::wayland_xdg_client_t::dispatch_once(int timeout_ms)
+{
+    wl_display_dispatch_pending(priv->display);
+    wl_display_flush(priv->display);
+
+    if (wl_display_prepare_read(priv->display) != 0)
+    {
+        wl_display_dispatch_pending(priv->display);
+        return;
+    }
+
+    pollfd pfd = {
+        .fd     = wl_display_get_fd(priv->display),
+        .events = POLLIN,
+        .revents = 0,
+    };
+
+    if (poll(&pfd, 1, timeout_ms) > 0)
+    {
+        wl_display_read_events(priv->display);
+        wl_display_dispatch_pending(priv->display);
+    } else
+    {
+        wl_display_cancel_read(priv->display);
+    }
+}
+
+bool wf::test::wayland_xdg_client_t::dispatch_until_configure(int max_iterations)
+{
+    for (int i = 0; i < max_iterations; ++i)
+    {
+        if (priv->configured)
+        {
+            return true;
+        }
+
+        dispatch_once(10);
+    }
+
+    return priv->configured;
+}
+
+bool wf::test::wayland_xdg_client_t::has_required_globals() const
+{
+    return priv->compositor && priv->shm && priv->wm_base;
+}
+
+void wf::test::wayland_xdg_client_t::create_toplevel(const std::string& title,
+    const std::string& app_id)
+{
+    if (!has_required_globals())
+    {
+        throw std::runtime_error("Tried to create xdg toplevel before binding required globals");
+    }
+
+    xdg_wm_base_add_listener(priv->wm_base, &impl::wm_base_listener, priv.get());
+    priv->surface = wl_compositor_create_surface(priv->compositor);
+    priv->shell_surface = xdg_wm_base_get_xdg_surface(priv->wm_base, priv->surface);
+    xdg_surface_add_listener(priv->shell_surface, &impl::xdg_surface_listener, priv.get());
+    priv->shell_toplevel = xdg_surface_get_toplevel(priv->shell_surface);
+
+    xdg_toplevel_set_title(priv->shell_toplevel, title.c_str());
+    xdg_toplevel_set_app_id(priv->shell_toplevel, app_id.c_str());
+    wl_surface_commit(priv->surface);
+    wl_display_flush(priv->display);
+}
+
+bool wf::test::wayland_xdg_client_t::has_pending_configure() const
+{
+    return priv->configured;
+}
+
+uint32_t wf::test::wayland_xdg_client_t::last_configure_serial() const
+{
+    return priv->configure_serial;
+}
+
+void wf::test::wayland_xdg_client_t::ack_last_configure()
+{
+    if (!priv->configured)
+    {
+        throw std::runtime_error("Tried to ack configure before receiving one");
+    }
+
+    xdg_surface_ack_configure(priv->shell_surface, priv->configure_serial);
+}
+
+void wf::test::wayland_xdg_client_t::attach_and_commit(int width, int height)
+{
+    const int stride  = width * 4;
+    const size_t size = stride * height;
+    int fd = create_shm_file(size);
+    if (fd < 0)
+    {
+        throw std::runtime_error("Failed to create shared memory file for test buffer");
+    }
+
+    void *data = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (data == MAP_FAILED)
+    {
+        close(fd);
+        throw std::runtime_error("Failed to mmap test buffer");
+    }
+
+    std::fill_n(static_cast<uint32_t*>(data), width * height, 0xff336699u);
+    auto *pool = wl_shm_create_pool(priv->shm, fd, size);
+    priv->buffer = wl_shm_pool_create_buffer(pool, 0, width, height, stride,
+        WL_SHM_FORMAT_XRGB8888);
+    wl_shm_pool_destroy(pool);
+    munmap(data, size);
+    close(fd);
+
+    wl_surface_attach(priv->surface, priv->buffer, 0, 0);
+    wl_surface_damage_buffer(priv->surface, 0, 0, width, height);
+    wl_surface_commit(priv->surface);
+    wl_display_flush(priv->display);
+}
+
+void wf::test::wayland_xdg_client_t::commit_surface()
+{
+    wl_surface_commit(priv->surface);
+    wl_display_flush(priv->display);
+}
+
+void wf::test::wayland_xdg_client_t::destroy_toplevel()
+{
+    if (priv->buffer)
+    {
+        wl_buffer_destroy(priv->buffer);
+        priv->buffer = nullptr;
+    }
+
+    if (priv->shell_toplevel)
+    {
+        xdg_toplevel_destroy(priv->shell_toplevel);
+        priv->shell_toplevel = nullptr;
+    }
+
+    if (priv->shell_surface)
+    {
+        xdg_surface_destroy(priv->shell_surface);
+        priv->shell_surface = nullptr;
+    }
+
+    if (priv->surface)
+    {
+        wl_surface_destroy(priv->surface);
+        priv->surface = nullptr;
+    }
+
+    if (priv->display)
+    {
+        wl_display_flush(priv->display);
+    }
+}

--- a/test/support/wayland-xdg-client.cpp
+++ b/test/support/wayland-xdg-client.cpp
@@ -1,10 +1,5 @@
 #include "wayland-xdg-client.hpp"
 
-#include <sys/mman.h>
-#include <poll.h>
-#include <unistd.h>
-#include <fcntl.h>
-
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -12,29 +7,8 @@
 #include <wayland-client-core.h>
 #include <wayland-client-protocol.h>
 
+#include "wayland-client-utils.hpp"
 #include "xdg-shell-client-protocol.h"
-
-namespace
-{
-int create_shm_file(size_t size)
-{
-    char name[] = "/wayfire-test-XXXXXX";
-    int fd = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
-    if (fd < 0)
-    {
-        return -1;
-    }
-
-    shm_unlink(name);
-    if (ftruncate(fd, size) < 0)
-    {
-        close(fd);
-        return -1;
-    }
-
-    return fd;
-}
-}
 
 struct wf::test::wayland_xdg_client_t::impl
 {
@@ -152,29 +126,7 @@ void wf::test::wayland_xdg_client_t::roundtrip()
 
 void wf::test::wayland_xdg_client_t::dispatch_once(int timeout_ms)
 {
-    wl_display_dispatch_pending(priv->display);
-    wl_display_flush(priv->display);
-
-    if (wl_display_prepare_read(priv->display) != 0)
-    {
-        wl_display_dispatch_pending(priv->display);
-        return;
-    }
-
-    pollfd pfd = {
-        .fd     = wl_display_get_fd(priv->display),
-        .events = POLLIN,
-        .revents = 0,
-    };
-
-    if (poll(&pfd, 1, timeout_ms) > 0)
-    {
-        wl_display_read_events(priv->display);
-        wl_display_dispatch_pending(priv->display);
-    } else
-    {
-        wl_display_cancel_read(priv->display);
-    }
+    wayland_dispatch_once(priv->display, timeout_ms);
 }
 
 bool wf::test::wayland_xdg_client_t::dispatch_until_configure(int max_iterations)
@@ -239,28 +191,7 @@ void wf::test::wayland_xdg_client_t::ack_last_configure()
 
 void wf::test::wayland_xdg_client_t::attach_and_commit(int width, int height)
 {
-    const int stride  = width * 4;
-    const size_t size = stride * height;
-    int fd = create_shm_file(size);
-    if (fd < 0)
-    {
-        throw std::runtime_error("Failed to create shared memory file for test buffer");
-    }
-
-    void *data = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-    if (data == MAP_FAILED)
-    {
-        close(fd);
-        throw std::runtime_error("Failed to mmap test buffer");
-    }
-
-    std::fill_n(static_cast<uint32_t*>(data), width * height, 0xff336699u);
-    auto *pool = wl_shm_create_pool(priv->shm, fd, size);
-    priv->buffer = wl_shm_pool_create_buffer(pool, 0, width, height, stride,
-        WL_SHM_FORMAT_XRGB8888);
-    wl_shm_pool_destroy(pool);
-    munmap(data, size);
-    close(fd);
+    priv->buffer = create_shm_buffer(priv->shm, width, height, 0xff336699u);
 
     wl_surface_attach(priv->surface, priv->buffer, 0, 0);
     wl_surface_damage_buffer(priv->surface, 0, 0, width, height);

--- a/test/support/wayland-xdg-client.hpp
+++ b/test/support/wayland-xdg-client.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string>
+
+struct wl_display;
+struct wl_registry;
+struct wl_compositor;
+struct wl_shm;
+struct wl_surface;
+struct wl_buffer;
+struct xdg_wm_base;
+struct xdg_surface;
+struct xdg_toplevel;
+
+namespace wf::test
+{
+class wayland_xdg_client_t
+{
+  public:
+    explicit wayland_xdg_client_t(const std::string& socket_name);
+    ~wayland_xdg_client_t();
+
+    wayland_xdg_client_t(const wayland_xdg_client_t&) = delete;
+    wayland_xdg_client_t(wayland_xdg_client_t&&) = delete;
+    wayland_xdg_client_t& operator =(const wayland_xdg_client_t&) = delete;
+    wayland_xdg_client_t& operator =(wayland_xdg_client_t&&) = delete;
+
+    void roundtrip();
+    void dispatch_once(int timeout_ms = 0);
+    bool dispatch_until_configure(int max_iterations = 200);
+
+    bool has_required_globals() const;
+    void create_toplevel(const std::string& title, const std::string& app_id);
+    bool has_pending_configure() const;
+    uint32_t last_configure_serial() const;
+    void ack_last_configure();
+    void attach_and_commit(int width, int height);
+    void commit_surface();
+    void destroy_toplevel();
+
+  private:
+    struct impl;
+    std::unique_ptr<impl> priv;
+};
+}


### PR DESCRIPTION
This PR includes some of my AI-assisted explorations of how to unit/integration test core.

The motivation is simple. While our end-to-end tests at https://github.com/ammen99/wayfire-tests are very useful in catching bugs (and still have their place as a full-compositor test), the amount of tests there is growing rapidly. Given that each test needs a few seconds, this very quickly means that it is impractical to run all of the tests all of the time. By aiming for unit tests, we can hopefully have a much more comprehensive test suite, which also runs fast. For example, a simple xdg-shell test runs in 0.1s on my laptop.
