### PR TITLE
core: advertise xdg-decoration-v1 version 2

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -186,7 +186,7 @@ void wf::compositor_core_impl_t::init()
 
     /* decoration_manager setup */
     protocols.decorator_manager = wlr_server_decoration_manager_create(display);
-    protocols.xdg_decorator     = wlr_xdg_decoration_manager_v1_create(display);
+    protocols.xdg_decorator     = wlr_xdg_decoration_manager_v1_create(display, 2);
     init_xdg_decoration_handlers();
 
     protocols.vkbd_manager = wlr_virtual_keyboard_manager_v1_create(display);


### PR DESCRIPTION
Depends on this commit: https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/bd99e8c2bd077251e8fe1f21ed5ed2ddb92c9cf0. So this PR will presumably have to wait for wlroots 0.21.

Closes: https://github.com/WayfireWM/wayfire/issues/3034.
