### PR TITLE
seat: select drag-and-drop action from keyboard modifiers

### DIFF
--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -11,6 +11,7 @@
 #include "touch.hpp"
 #include "input-manager.hpp"
 #include "input-method-relay.hpp"
+#include "seat-impl.hpp"
 #include "wayfire/signal-definitions.hpp"
 #include <wayfire/config-backend.hpp>
 
@@ -109,6 +110,27 @@ void wf::keyboard_t::setup_listeners()
             }
 
             wlr_seat_keyboard_send_modifiers(seat, &kbd->modifiers);
+        }
+
+        auto& seat_priv = wf::get_core().seat->priv;
+        if (seat_priv->active_drag && seat_priv->active_drag->source)
+        {
+            uint32_t mods = wlr_keyboard_get_modifiers(kbd);
+            bool ctrl     = mods & WLR_MODIFIER_CTRL;
+            bool shift    = mods & WLR_MODIFIER_SHIFT;
+            uint32_t action = WL_DATA_DEVICE_MANAGER_DND_ACTION_NONE;
+            if (ctrl && shift)
+            {
+                action = WL_DATA_DEVICE_MANAGER_DND_ACTION_ASK;
+            } else if (ctrl)
+            {
+                action = WL_DATA_DEVICE_MANAGER_DND_ACTION_COPY;
+            } else if (shift)
+            {
+                action = WL_DATA_DEVICE_MANAGER_DND_ACTION_MOVE;
+            }
+
+            seat_priv->active_drag->source->compositor_action = action;
         }
 
         wf::get_core().seat->notify_activity();

--- a/src/core/seat/pointer.cpp
+++ b/src/core/seat/pointer.cpp
@@ -246,7 +246,7 @@ void wf::pointer_t::grab_surface(wf::scene::node_ptr node)
 
     if (node)
     {
-        set_grab(node, seat->priv->drag_active ? input_grab_kind_t::DND : input_grab_kind_t::IMPLICIT);
+        set_grab(node, seat->priv->is_drag_active() ? input_grab_kind_t::DND : input_grab_kind_t::IMPLICIT);
         return;
     }
 
@@ -268,7 +268,7 @@ wf::input_grab_kind_t wf::pointer_t::get_current_grab_kind() const
         return input_grab_kind_t::NONE;
     }
 
-    if ((current_grab_kind == input_grab_kind_t::IMPLICIT) && seat->priv->drag_active)
+    if ((current_grab_kind == input_grab_kind_t::IMPLICIT) && seat->priv->is_drag_active())
     {
         return input_grab_kind_t::DND;
     }

--- a/src/core/seat/seat-impl.hpp
+++ b/src/core/seat/seat-impl.hpp
@@ -91,8 +91,15 @@ struct seat_t::impl
 
     // Current drag icon
     std::unique_ptr<wf::drag_icon_t> drag_icon;
+    // The active drag, or NULL if no drag is in progress. Note we can have a
+    // drag without a drag icon, and active_drag->source may be NULL.
+    wlr_drag *active_drag = nullptr;
+
     // Is dragging active. Note we can have a drag without a drag icon.
-    bool drag_active = false;
+    bool is_drag_active() const
+    {
+        return active_drag != nullptr;
+    }
 
     /** Update the position of the drag icon, if it exists */
     void update_drag_icon();

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -289,10 +289,10 @@ wf::seat_t::seat_t(wl_display *display, std::string name) : seat(wlr_seat_create
             this->priv->drag_icon = std::make_unique<wf::drag_icon_t>(d->icon);
         }
 
-        this->priv->drag_active = true;
+        this->priv->active_drag = d;
         priv->end_drag.set_callback([&] (void*)
         {
-            this->priv->drag_active = false;
+            this->priv->active_drag = nullptr;
             priv->end_drag.disconnect();
         });
         priv->end_drag.connect(&d->events.destroy);
@@ -325,7 +325,7 @@ wf::seat_t::seat_t(wl_display *display, std::string name) : seat(wlr_seat_create
 
     priv->on_wlr_pointer_grab_end.set_callback([&] (void*)
     {
-        if (priv->drag_active)
+        if (priv->is_drag_active())
         {
             // Drag is handled separately.
             return;

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -150,7 +150,7 @@ wf::input_grab_kind_t wf::touch_interface_t::get_current_grab_kind(int32_t id) c
         return input_grab_kind_t::NONE;
     }
 
-    if ((it->second == input_grab_kind_t::NONE) && wf::get_core_impl().seat->priv->drag_active)
+    if ((it->second == input_grab_kind_t::NONE) && wf::get_core_impl().seat->priv->is_drag_active())
     {
         return input_grab_kind_t::DND;
     }

--- a/src/view/wlr-surface-touch-interaction.cpp
+++ b/src/view/wlr-surface-touch-interaction.cpp
@@ -28,7 +28,7 @@ class wlr_surface_touch_interaction_t final : public wf::touch_interaction_t
         seat->priv->last_press_release_serial =
             wlr_seat_touch_notify_down(seat->seat, surface, time_ms, finger_id, local.x, local.y);
 
-        if ((grab == input_grab_kind_t::NONE) && !seat->priv->drag_active)
+        if ((grab == input_grab_kind_t::NONE) && !seat->priv->is_drag_active())
         {
             wf::xwayland_bring_to_front(surface);
         }


### PR DESCRIPTION
The `drag_handle_keyboard_modifiers` implementation in [wlroots](https://gitlab.freedesktop.org/wlroots/wlroots/-/raw/master/types/data_device/wlr_drag.c) is empty, so `ctrl`/`shift` have no effect on a drag. 

```c
static void drag_handle_keyboard_modifiers(struct wlr_seat_keyboard_grab *grab,
		const struct wlr_keyboard_modifiers *modifiers) {
	//struct wlr_keyboard *keyboard = grab->seat->keyboard_state.keyboard;
	// TODO change the dnd action based on what modifier is pressed on the
	// keyboard
}
```

Separately, it was stated that this should be implemented by the compositor https://github.com/swaywm/sway/issues/8219#issuecomment-2395368597

Map the modifiers to `wlr_data_source::compositor_action` on each modifier's event while a drag is active: `ctrl` copies, `shift` moves, `ctrl+shift` asks.


As an example, Thunar:

Without the patch, dragging a file between two windows while pressing `CTRL` moves it:

https://github.com/user-attachments/assets/1b0cc409-5feb-45ff-bfe9-28a77e567710

With the patch applied, dragging a file between two windows while pressing `CTRL` copies it:


https://github.com/user-attachments/assets/4eb826b7-56c1-43e1-99e5-4ac26968499e



