### PR TITLE
Add bindings for next/prev workspace in vswitch

### DIFF
--- a/metadata/vswitch.xml
+++ b/metadata/vswitch.xml
@@ -80,6 +80,37 @@
 			<default></default>
 		</option>
 
+		<option name="binding_next" type="activator">
+			<_short>Next</_short>
+			<_long>Switches to next (by numeric order) workspace with the specified activator.</_long>
+			<default>&lt;super&gt; &lt;alt&gt; KEY_PAGEUP</default>
+		</option>
+		<option name="binding_prev" type="activator">
+			<_short>Previous</_short>
+			<_long>Switches to previous (by numeric order) workspace with the specified activator.</_long>
+			<default>&lt;super&gt; &lt;alt&gt; KEY_PAGEDOWN</default>
+		</option>
+		<option name="with_win_next" type="activator">
+			<_short>Next with window</_short>
+			<_long>Switches next (by numeric order) workspace with the focused window with the specified activator.</_long>
+			<default>&lt;super&gt; &lt;alt&gt; &lt;shift&gt; KEY_PAGEUP</default>
+		</option>
+		<option name="with_win_prev" type="activator">
+			<_short>Previous with window</_short>
+			<_long>Switches to previous (by numeric order) with the focused window with the specified activator.</_long>
+			<default>&lt;super&gt; &lt;alt&gt; &lt;shift&gt; KEY_PAGEDOWN</default>
+		</option>
+		<option name="send_win_next" type="activator">
+			<_short>Send window to the next</_short>
+			<_long>Send the focused window to next (by numeric order) workspace.</_long>
+			<default></default>
+		</option>
+		<option name="send_win_prev" type="activator">
+			<_short>Send window to the previous</_short>
+			<_long>Send the focused window to the workspace on previous (by numeric order).</_long>
+			<default></default>
+		</option>
+
 		<option name="workspace_bindings" type="dynamic-list" type-hint="dict">
 			<_short>Go-To-Workspace bindings</_short>
 			<_long>Go-To-Workspace bindings</_long>

--- a/plugins/vswitch/wayfire/plugins/vswitch.hpp
+++ b/plugins/vswitch/wayfire/plugins/vswitch.hpp
@@ -124,6 +124,37 @@ class control_bindings_t
 #undef SETUP_LAST
         /* *INDENT-ON* */
 
+        // Setup the bindings for switching to the next/previous workspace for the output
+        /* *INDENT-OFF* */ // Uncrustify has problems with this macro
+#define SETUP_NEXT_PREV(name, dir, view, only) \
+        wf::option_wrapper_t<wf::activatorbinding_t> binding_##name { \
+            "vswitch/"#name}; \
+        activator_cbs.push_back(std::make_unique<activator_callback>()); \
+        *activator_cbs.back() = [=] (const wf::activator_data_t&) \
+        {\
+            auto [wsize, hsize] = output->wset()->get_workspace_grid_size(); \
+            wf::point_t current = output->wset()->get_current_workspace(); \
+            int nr = current.y * wsize + current.x + dir; \
+            if (wraparound && nr < 0) { \
+                nr = wsize * hsize -1; \
+            } \
+            wf::point_t target{ \
+                nr % wsize, \
+                nr / wsize, \
+            }; \
+            return handle_dir(target - current, view, only, callback); \
+        };\
+        output->add_activator(binding_##name, activator_cbs.back().get());
+
+        SETUP_NEXT_PREV(binding_next, 1, nullptr, false);
+        SETUP_NEXT_PREV(with_win_next, 1, get_target_view(), false);
+        SETUP_NEXT_PREV(send_win_next, 1, get_target_view(), true);
+        SETUP_NEXT_PREV(binding_prev, -1, nullptr, false);
+        SETUP_NEXT_PREV(with_win_prev, -1, get_target_view(), false);
+        SETUP_NEXT_PREV(send_win_prev, -1, get_target_view(), true);
+#undef SETUP_NEXT_PREV
+        /* *INDENT-ON* */
+
         // Setup a binding for going directly to a workspace identified by a name
         const auto& setup_direct_binding = [=] (wf::activatorbinding_t binding,
                                                 std::string workspace_name,


### PR DESCRIPTION
Similar to left/right but based on workspace number (instead of location), so jump to next row instead stay on last / wrap to first column in current row.