### PR TITLE
seat: update last_cursor_name when client sets cursor

### DIFF
--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -161,6 +161,7 @@ void wf::cursor_t::init_cursor_shape_manager()
         if (can_client_set_cursor())
         {
             wlr_cursor_set_xcursor(cursor, xcursor, shape_name);
+            last_cursor_name = shape_name;
         }
     });
     request_set_cursor_shape.connect(&cursor_shape_manager->events.request_set_shape);


### PR DESCRIPTION
Fixes the bug when cursor shape is not changed to default when opening expo. If a client sets a cursor shape (for example to "xterm" or "hand2"), last_cursor_name remains "left_ptr" from the previous compositor call. When expo then calls set_cursor("default"), the early-return fires ("left_ptr" == last_cursor_name) and the cursor is not updated.

https://github.com/user-attachments/assets/dd612c52-a3b1-40b2-9f74-34b4d182c788

