### PR TITLE
render: add APIs for aligning rendering to pixel borders

### DIFF
--- a/plugins/blur/blur-base.cpp
+++ b/plugins/blur/blur-base.cpp
@@ -217,6 +217,7 @@ static wf::pointf_t get_center(wf::geometry_t g)
 void wf_blur_base::render(wf::gles_texture_t src_tex, wf::geometry_t src_box, const wf::regionf_t& damage,
     const wf::render_target_t& background_source_fb, const wf::render_target_t& target_fb)
 {
+    src_box = target_fb.aligned_geometry_from_geometry_box(src_box);
     wf::gles_texture_t blurred_background = wf::gles_texture_t::from_aux(fb[0]);
     wf::gles::ensure_render_buffer_fb_id(target_fb);
     blend_program.use(src_tex.type);

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -992,8 +992,9 @@ class wobbly_render_instance_t :
     void render(const wf::scene::render_instruction_t& data) override
     {
         std::vector<float> vert, uv;
-        auto subbox = self->get_children_bounding_box();
+        auto subbox = data.target.aligned_geometry_from_geometry_box(self->get_children_bounding_box());
         wobbly_graphics::prepare_geometry(self->model.get(), subbox, vert, uv);
+
         const int count_triangles = self->model->x_cells * self->model->y_cells * 2;
 
         data.pass->custom_gles_subpass(data.target, [&]

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -107,7 +107,7 @@ using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 /**
  * The version is defined as macro as well, to allow conditional compilation.
  */
-#define WAYFIRE_API_ABI_VERSION_MACRO 2026'06'17
+#define WAYFIRE_API_ABI_VERSION_MACRO 2026'07'09
 
 /**
  * The version of Wayfire's API/ABI

--- a/src/api/wayfire/render.hpp
+++ b/src/api/wayfire/render.hpp
@@ -402,6 +402,20 @@ struct render_target_t : public render_buffer_t
     wf::geometry_t framebuffer_geometry_from_geometry_box(wf::geometry_t box) const;
 
     /**
+     * Get the integer framebuffer box suitable for rendering a texture or rect to @box.
+     *
+     * Unlike framebuffer_box_from_geometry_box(), this preserves exact integer projected sizes when possible,
+     * avoiding an unnecessary extra pixel and resampling when only the projected origin is fractional.
+     */
+    wlr_box framebuffer_texture_dst_box_from_geometry_box(wf::geometry_t box) const;
+
+    /**
+     * Get the logical geometry corresponding to framebuffer_texture_dst_box_from_geometry_box(@box).
+     * This is useful for custom renderers which build their own logical-coordinate quads.
+     */
+    wf::geometry_t aligned_geometry_from_geometry_box(wf::geometry_t box) const;
+
+    /**
      * Get the geometry of the given region after projecting it onto the framebuffer. This is the same as
      * iterating over the rects in the region and transforming them with framebuffer_box_from_geometry_box.
      */

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -634,6 +634,16 @@ wlr_box wf::render_target_t::framebuffer_box_from_geometry_box(wf::geometry_t bo
     return containing_box(framebuffer_geometry_from_geometry_box(box));
 }
 
+wlr_box wf::render_target_t::framebuffer_texture_dst_box_from_geometry_box(wf::geometry_t box) const
+{
+    return round_fbox_to_texture_dst_box(framebuffer_geometry_from_geometry_box(box));
+}
+
+wf::geometry_t wf::render_target_t::aligned_geometry_from_geometry_box(wf::geometry_t box) const
+{
+    return geometry_box_from_framebuffer_box(framebuffer_texture_dst_box_from_geometry_box(box));
+}
+
 wf::region_t wf::render_target_t::framebuffer_region_from_geometry_region(const wf::regionf_t& region) const
 {
     wf::region_t result;
@@ -830,8 +840,7 @@ void wf::render_pass_t::add_texture(const std::shared_ptr<wf::texture_t>& textur
         adjusted_target.wl_transform);
     opts.clip    = fb_damage.to_pixman();
     opts.src_box = texture->get_source_box().value_or(wlr_fbox{0, 0, 0, 0});
-    opts.dst_box = round_fbox_to_texture_dst_box(
-        adjusted_target.framebuffer_geometry_from_geometry_box(geometry));
+    opts.dst_box = adjusted_target.framebuffer_texture_dst_box_from_geometry_box(geometry);
 
     auto ct = texture->get_color_transform();
     wlr_color_primaries primaries{};
@@ -869,8 +878,7 @@ void wf::render_pass_t::add_rect(const wf::color_t& color, const wf::render_targ
     opts.color = color_to_render_color(color, adjusted_target.get_output_transfer_function());
     opts.blend_mode = WLR_RENDER_BLEND_MODE_PREMULTIPLIED;
     opts.clip = fb_damage.to_pixman();
-    opts.box  = round_fbox_to_texture_dst_box(
-        adjusted_target.framebuffer_geometry_from_geometry_box(geometry));
+    opts.box  = adjusted_target.framebuffer_texture_dst_box_from_geometry_box(geometry);
     wf::dassert(opts.box.width >= 0);
     wf::dassert(opts.box.height >= 0);
     wlr_render_pass_add_rect(_get_pass(), &opts);


### PR DESCRIPTION
Useful for some plugins which render views without huge transformations like blur: in these cases, we want to render textures aligned to pixel boundaries to avoid unnecessary blurring.

Fixes #3057
