### PR TITLE
workarounds: add use_native_buffer_size option for fractional scaling

### DIFF
--- a/metadata/workarounds.xml
+++ b/metadata/workarounds.xml
@@ -110,5 +110,10 @@
 			<_long>Disables the default blurry scaling for Xwayland and forces client-side scaling for Xwayland windows dependent on the DPI settings.</_long>
 			<default>false</default>
 		</option>
+		<option name="use_native_buffer_size" type="bool">
+			<_short>Use the native buffer size for client surfaces</_short>
+			<_long>When this option is enabled, Wayfire will use the buffer size in pixels to determine a surface size, instead of relying on the client-provided logical size. This ensures that text remains crisp at fractional scales, but may result in cropping or empty pixels at surface boundaries.</_long>
+			<default>false</default>
+		</option>
 	</plugin>
 </wayfire>

--- a/plugins/blur/blur-base.cpp
+++ b/plugins/blur/blur-base.cpp
@@ -231,11 +231,11 @@ void wf_blur_base::render(wf::gles_texture_t src_tex, wf::geometry_t src_box, co
     };
 
     const float vertex_data_pos[] = {
-        static_cast<float>(1.0f * src_box.x), static_cast<float>(1.0f * src_box.y + src_box.height),
-        static_cast<float>(1.0f * src_box.x + src_box.width),
-        static_cast<float>(1.0f * src_box.y + src_box.height),
-        static_cast<float>(1.0f * src_box.x + src_box.width), static_cast<float>(1.0f * src_box.y),
-        static_cast<float>(1.0f * src_box.x), static_cast<float>(1.0f * src_box.y),
+        static_cast<float>(src_box.x), static_cast<float>(src_box.y + src_box.height),
+        static_cast<float>(src_box.x + src_box.width),
+        static_cast<float>(src_box.y + src_box.height),
+        static_cast<float>(src_box.x + src_box.width), static_cast<float>(src_box.y),
+        static_cast<float>(src_box.x), static_cast<float>(src_box.y),
     };
 
     blend_program.attrib_pointer("position", 2, 0, vertex_data_pos);
@@ -269,7 +269,7 @@ void wf_blur_base::render(wf::gles_texture_t src_tex, wf::geometry_t src_box, co
     blend_program.uniformMatrix4f("background_uv_matrix", composite);
 
     /* Blend blurred background with window texture src_tex */
-    blend_program.uniformMatrix4f("mvp", wf::gles::render_target_orthographic_projection(target_fb));
+    blend_program.uniformMatrix4f("mvp", wf::gles::render_target_aligned_orthographic_projection(target_fb));
     /* XXX: core should give us the number of texture units used */
     blend_program.uniform1i("bg_texture", 1);
     blend_program.uniform1f("sat", saturation_opt);

--- a/plugins/blur/blur-base.cpp
+++ b/plugins/blur/blur-base.cpp
@@ -1,5 +1,6 @@
 #include "blur.hpp"
 #include "wayfire/core.hpp"
+#include "wayfire/debug.hpp"
 #include "wayfire/geometry.hpp"
 #include "wayfire/region.hpp"
 #include "wayfire/scene-render.hpp"
@@ -217,7 +218,6 @@ static wf::pointf_t get_center(wf::geometry_t g)
 void wf_blur_base::render(wf::gles_texture_t src_tex, wf::geometry_t src_box, const wf::regionf_t& damage,
     const wf::render_target_t& background_source_fb, const wf::render_target_t& target_fb)
 {
-    src_box = target_fb.aligned_geometry_from_geometry_box(src_box);
     wf::gles_texture_t blurred_background = wf::gles_texture_t::from_aux(fb[0]);
     wf::gles::ensure_render_buffer_fb_id(target_fb);
     blend_program.use(src_tex.type);

--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -207,14 +207,25 @@ class blur_render_instance_t : public transformer_render_instance_t<blur_node_t>
         auto bounding_box = self->get_bounding_box();
         data.pass->custom_gles_subpass([&]
         {
-            auto tex = wf::gles_texture_t{get_texture(data.target.scale)};
+            auto contents = get_texture(data.target.scale);
+            const bool is_zerocopy = (contents->get_wlr_texture() == self->inner_content.get_texture());
+            double render_width    = is_zerocopy ? self->inner_content.get_size().width / data.target.scale :
+                bounding_box.width;
+            double render_height = is_zerocopy ? self->inner_content.get_size().height / data.target.scale :
+                bounding_box.height;
+
+            auto tex = wf::gles_texture_t{contents};
             if (!data.damage.empty())
             {
-                auto translucent_damage    = calculate_translucent_damage(data.target, data.damage);
-                auto translucent_damage_fb =
-                    data.target.framebuffer_region_from_geometry_region(translucent_damage);
+                auto translucent_damage = calculate_translucent_damage(data.target, data.damage);
                 self->provider()->prepare_blur(data.target, translucent_damage);
-                self->provider()->render(tex, bounding_box, data.damage, data.target, data.target);
+
+                wf::geometry_t render_geometry = {
+                    bounding_box.x, bounding_box.y, render_width, render_height
+                };
+
+                render_geometry = data.target.aligned_geometry_from_geometry_box(render_geometry);
+                self->provider()->render(tex, render_geometry, data.damage, data.target, data.target);
             }
 
             GL_CALL(glDisable(GL_SCISSOR_TEST));

--- a/src/api/wayfire/geometry.hpp
+++ b/src/api/wayfire/geometry.hpp
@@ -176,4 +176,6 @@ bool operator &(const geometry_t& r1, const geometry_t& r2);
 std::ostream& operator <<(std::ostream& stream, const geometry_t& geometry);
 }
 
+std::ostream& operator <<(std::ostream& stream, const wlr_box& geometry);
+
 #endif /* end of include guard: WF_GEOMETRY_HPP */

--- a/src/api/wayfire/opengl.hpp
+++ b/src/api/wayfire/opengl.hpp
@@ -46,6 +46,20 @@ void scissor_render_buffer(const render_buffer_t& buffer, wlr_box box);
  * coordinates to the framebuffer coordinates. */
 glm::mat4 render_target_orthographic_projection(const render_target_t& target);
 
+/*
+ * Returns a matrix which contains an orthographic projection from aligned "geometry"
+ * coordinates to the framebuffer coordinates.
+ *
+ * Here aligned is to be understood as target.aligned_geometry_from_geometry_box(target.geometry).
+ *
+ * The difference with the function above is that the given orthographic projection is more precise for
+ * fractional scaling, i.e where it is possible that the logical size of the render target is some fractional
+ * value. Example: if we have a scale of 2.0 and a buffer size of 51, then the 'full' logical size is 25.5,
+ * however, for window management purposes targets very often have logical sizes rounded down, for example to
+ * 25 in the previous example. This happens because for example the logical size of outputs is always integer.
+ */
+glm::mat4 render_target_aligned_orthographic_projection(const render_target_t& target);
+
 /* Returns a matrix which contains an orthographic projection from OpenGL [-1, 1]
  * coordinates coordinates to the framebuffer coordinates (includes rotation,
  * subbuffer, etc). */

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -107,7 +107,7 @@ using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 /**
  * The version is defined as macro as well, to allow conditional compilation.
  */
-#define WAYFIRE_API_ABI_VERSION_MACRO 2026'07'09
+#define WAYFIRE_API_ABI_VERSION_MACRO 2026'07'15
 
 /**
  * The version of Wayfire's API/ABI

--- a/src/api/wayfire/unstable/wlr-surface-node.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-node.hpp
@@ -98,6 +98,9 @@ class wlr_surface_node_t : public node_t, public zero_copy_texturable_node_t
 
   protected:
     surface_state_t current_state;
+    wf::dimensionsf_t size_on_primary_output = {0, 0};
+    wf::output_t *guess_primary_output();
+    wf::geometry_t get_render_geometry() const;
 };
 }
 }

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -364,6 +364,15 @@ glm::mat4 wf::gles::render_target_orthographic_projection(const wf::render_targe
     return gles::render_target_gl_to_framebuffer(target) * ortho;
 }
 
+glm::mat4 wf::gles::render_target_aligned_orthographic_projection(const wf::render_target_t& target)
+{
+    auto aligned = target.aligned_geometry_from_geometry_box(target.geometry);
+    auto ortho   = glm::ortho((float)aligned.x, (float)(aligned.x + aligned.width),
+        (float)(aligned.y + aligned.height), (float)aligned.y);
+
+    return gles::render_target_gl_to_framebuffer(target) * ortho;
+}
+
 glm::mat4 wf::gles::render_target_gl_to_framebuffer(const wf::render_target_t& target)
 {
     if (target.subbuffer)

--- a/src/core/output-layout.cpp
+++ b/src/core/output-layout.cpp
@@ -111,6 +111,16 @@ wl_output_transform wf::layout_detail::get_transform_from_string(std::string_vie
     return WL_OUTPUT_TRANSFORM_NORMAL;
 }
 
+/**
+ * Ensure that scale is a multiple of 1/120, which makes clients using fractional-scale protocols happy.
+ * See #2967 for more details.
+ */
+float round_scale_to_1_120(float scale)
+{
+    int numerator = std::round(scale * 120);
+    return numerator / 120.0f;
+}
+
 std::string wf::layout_detail::wl_transform_to_string(wl_output_transform transform)
 {
     for (auto& it : output_transforms)
@@ -753,7 +763,7 @@ struct output_layout_output_t
             break;
         }
 
-        state.scale     = scale_opt;
+        state.scale     = round_scale_to_1_120(scale_opt);
         state.transform = layout_detail::get_transform_from_string(std::string{transform_opt});
         state.vrr   = vrr_opt;
         state.hdr   = hdr_opt;
@@ -1435,7 +1445,7 @@ class output_layout_t::impl
             }
 
             state.position  = {head->state.x, head->state.y};
-            state.scale     = head->state.scale;
+            state.scale     = round_scale_to_1_120(head->state.scale);
             state.transform = head->state.transform;
             state.vrr = head->state.adaptive_sync_enabled;
             if ((handle->render_format == DRM_FORMAT_XRGB2101010) ||

--- a/src/geometry.cpp
+++ b/src/geometry.cpp
@@ -11,6 +11,14 @@ std::ostream & wf::operator <<(std::ostream& stream, const wf::geometry_t& geome
     return stream;
 }
 
+std::ostream& operator <<(std::ostream& stream, const wlr_box& geometry)
+{
+    stream << '(' << geometry.x << ',' << geometry.y <<
+        ' ' << geometry.width << 'x' << geometry.height << ')';
+
+    return stream;
+}
+
 std::ostream& wf::operator <<(std::ostream& stream, const wf::point_t& point)
 {
     stream << '(' << point.x << ',' << point.y << ')';

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -3,7 +3,6 @@
 #include "wayfire/dassert.hpp"
 #include "wayfire/nonstd/reverse.hpp"
 #include "wayfire/opengl.hpp"
-#include "wayfire/output.hpp"
 #include <wayfire/scene-render.hpp>
 #include <cmath>
 #include <drm_fourcc.h>

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -421,7 +421,11 @@ wf::dimensions_t wf::auxilliary_buffer_t::get_size() const
 
 wlr_texture*wf::auxilliary_buffer_t::get_texture()
 {
-    wf::dassert(buffer.get_buffer(), "No buffer allocated yet!");
+    if (!buffer.get_buffer())
+    {
+        return nullptr;
+    }
+
     if (!texture)
     {
         texture = wlr_texture_from_buffer(wf::get_core().renderer, buffer.get_buffer());

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -196,6 +196,40 @@ wf::scene::wlr_surface_node_t::wlr_surface_node_t(wlr_surface *surface, bool aut
 
 void wf::scene::wlr_surface_node_t::apply_state(surface_state_t&& state)
 {
+    wf::dimensionsf_t new_size = wf::dimensionsf_t{state.size};
+    static wf::option_wrapper_t<bool> use_native_buffer_size{"workarounds/use_native_buffer_size"};
+
+    // Guess surface size based on the primary output scale.
+    // This is aimed at fixing issues with fractional scaling, where the surface size in logical and
+    // buffer coordinates differ.
+    //
+    // By calculating the floating size in logical coordinates, we can ensure we render aligned with the
+    // underlying pixel grid and avoid blurriness.
+    if (auto primary_output = guess_primary_output();
+        primary_output && state.current_buffer && use_native_buffer_size)
+    {
+        auto vp = state.src_viewport.value_or(wlr_fbox{0, 0,
+            (float)state.current_buffer->width, (float)state.current_buffer->height});
+
+        if (state.transform & WL_OUTPUT_TRANSFORM_90)
+        {
+            std::swap(vp.width, vp.height);
+        }
+
+        const float pixel_aligned_width  = vp.width / primary_output->get_scale();
+        const float pixel_aligned_height = vp.height / primary_output->get_scale();
+
+        if (std::abs(pixel_aligned_width - new_size.width) < 1.0f / primary_output->get_scale())
+        {
+            new_size.width = pixel_aligned_width;
+        }
+
+        if (std::abs(pixel_aligned_height - new_size.height) < 1.0f / primary_output->get_scale())
+        {
+            new_size.height = pixel_aligned_height;
+        }
+    }
+
     const bool size_changed = current_state.size != state.size;
     if (size_changed)
     {
@@ -204,6 +238,8 @@ void wf::scene::wlr_surface_node_t::apply_state(surface_state_t&& state)
     }
 
     this->current_state = std::move(state);
+    this->size_on_primary_output = new_size;
+
     wf::scene::damage_node(this, current_state.accumulated_damage);
     if (size_changed)
     {
@@ -356,7 +392,7 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
     void schedule_instructions(std::vector<render_instruction_t>& instructions,
         const wf::render_target_t& target, wf::regionf_t& damage) override
     {
-        wf::regionf_t our_damage = damage & self->get_bounding_box();
+        wf::regionf_t our_damage = damage & self->get_render_geometry();
         if (!our_damage.empty())
         {
             instructions.push_back(render_instruction_t{
@@ -376,7 +412,7 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
             return;
         }
 
-        data.pass->add_texture(self->to_texture(), data.target, self->get_bounding_box(), data.damage);
+        data.pass->add_texture(self->to_texture(), data.target, self->get_render_geometry(), data.damage);
     }
 
     void presentation_feedback(wf::output_t *output) override
@@ -483,6 +519,11 @@ void wf::scene::wlr_surface_node_t::gen_render_instances(
         std::dynamic_pointer_cast<wlr_surface_node_t>(this->shared_from_this()), damage, output));
 }
 
+wf::geometry_t wf::scene::wlr_surface_node_t::get_render_geometry() const
+{
+    return wf::construct_box({0, 0}, size_on_primary_output);
+}
+
 wf::geometry_t wf::scene::wlr_surface_node_t::get_bounding_box()
 {
     return wf::construct_box({0, 0}, current_state.size);
@@ -554,20 +595,33 @@ void wf::scene::wlr_surface_node_t::update_pending_outputs()
         }
     }
 
-    if (surface && (visibility.size() > 0))
+    if (auto primary_output = guess_primary_output();primary_output && surface)
     {
-        float max_scale = 1;
-        for (auto x : visibility)
-        {
-            max_scale = std::max(max_scale, x.first->handle->scale);
-        }
-
-        wlr_fractional_scale_v1_notify_scale(surface, max_scale);
-        wlr_surface_set_preferred_buffer_scale(surface, max_scale);
+        wlr_fractional_scale_v1_notify_scale(surface, primary_output->get_scale());
+        wlr_surface_set_preferred_buffer_scale(surface, primary_output->get_scale());
         update_preferred_image_description();
     }
 
     pending_visibility_delta.clear();
+}
+
+wf::output_t*wf::scene::wlr_surface_node_t::guess_primary_output()
+{
+    if (visibility.empty())
+    {
+        return nullptr;
+    }
+
+    wf::output_t *primary = nullptr;
+    for (auto& [wo, _] : visibility)
+    {
+        if (!primary || (wo->handle->scale > primary->handle->scale))
+        {
+            primary = wo;
+        }
+    }
+
+    return primary;
 }
 
 void wf::scene::wlr_surface_node_t::update_preferred_image_description()

--- a/test/protocol/meson.build
+++ b/test/protocol/meson.build
@@ -91,6 +91,20 @@ scaling_test = executable(
     ],
     install: false)
 
+# This test uses a different value for a workaround option. Keep it in a separate
+# executable because static option_wrapper_t instances cache options per process.
+native_buffer_size_scaling_test = executable(
+    'native-buffer-size-scaling-test',
+    'native-buffer-size-scaling-test.cpp',
+    test_support_sources,
+    dependencies: [doctest, libwayfire, wayland_client],
+    cpp_args: [
+        '-DTEST_METADATA_DIR="' + meson.project_source_root() + '/metadata"',
+        '-DTEST_DEFAULTS_INI="' + meson.project_source_root() + '/wayfire.ini"',
+    ],
+    install: false)
+
 test('Xdg-shell test', xdg_shell_test)
 test('Layer-shell test', layer_shell_test)
 test('Scaling test', scaling_test)
+test('Native buffer size scaling test', native_buffer_size_scaling_test)

--- a/test/protocol/native-buffer-size-scaling-test.cpp
+++ b/test/protocol/native-buffer-size-scaling-test.cpp
@@ -1,3 +1,4 @@
+#include "wayfire/img.hpp"
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
 
@@ -7,23 +8,26 @@
 #include <wayfire/toplevel-view.hpp>
 
 #include <algorithm>
-#include <sstream>
-#include <set>
 #include <vector>
 
 #include "../support/headless-core-harness.hpp"
 #include "../support/wayland-xdg-client.hpp"
 
-TEST_CASE("fractional-scale render stays pixel-aligned away from origin")
+TEST_CASE("fractional-scale rounded client buffers render pixel-aligned")
 {
-    wf::test::headless_core_harness_t harness;
+    wf::test::headless_core_harness_t harness{
+        "[core]\n"
+        "background_color = 0 0 0 1\n"
+        "[workarounds]\n"
+        "use_native_buffer_size = true\n"
+    };
     auto *output = harness.output();
     REQUIRE(output != nullptr);
 
     auto config = wf::get_core().output_layout->get_current_configuration();
     REQUIRE(config.count(output->handle) == 1);
 
-    config.at(output->handle).scale = 5.0 / 3.0;
+    config.at(output->handle).scale = 1.99;
     REQUIRE(wf::get_core().output_layout->apply_configuration(config));
 
     wf::test::wayland_xdg_client_t client{harness.socket_name()};
@@ -40,7 +44,7 @@ TEST_CASE("fractional-scale render stays pixel-aligned away from origin")
     };
     wf::get_core().connect(&on_map);
 
-    client.create_toplevel("rendering test", "org.wayfire.RenderingTest");
+    client.create_toplevel("rounded fractional scale test", "org.wayfire.RoundedFractionalScaleTest");
     REQUIRE(harness.run_until([&]
     {
         client.dispatch_once();
@@ -53,8 +57,9 @@ TEST_CASE("fractional-scale render stays pixel-aligned away from origin")
     auto view = wf::toplevel_cast(mapped.front());
     REQUIRE(view != nullptr);
     REQUIRE(view->get_output() == output);
-
-    view->move(1, 1);
+    const int view_x = 300;
+    const int view_y = 200;
+    view->move(view_x, view_y);
 
     REQUIRE(harness.run_until([&]
     {
@@ -63,21 +68,14 @@ TEST_CASE("fractional-scale render stays pixel-aligned away from origin")
     }));
 
     REQUIRE(client.last_fractional_scale().has_value());
-    const uint32_t fractional_scale = client.last_fractional_scale().value();
-    const int preferred_scale = client.last_preferred_buffer_scale();
+    CHECK(client.last_fractional_scale().value() == 239);
 
-    CHECK(preferred_scale == 1);
-    CHECK(fractional_scale == 200);
-
-    const int logical_width = 6;
-    const int logical_height = 6;
-    const int buffer_width = 10;
-    const int buffer_height = 10;
-
+    const int logical_width = 300;
+    const int logical_height = 30;
+    const int buffer_width = 598;
+    const int buffer_height = 60;
     const uint32_t red = 0xff0000ffu;
     const uint32_t green = 0x00ff00ffu;
-    const uint32_t background = 0x000000ffu;
-
     std::vector<uint32_t> pixels(buffer_width * buffer_height);
     for (int y = 0; y < buffer_height; ++y)
     {
@@ -91,7 +89,8 @@ TEST_CASE("fractional-scale render stays pixel-aligned away from origin")
     REQUIRE(harness.run_until([&]
     {
         client.dispatch_once();
-        return view->get_geometry().x == 1 && view->get_geometry().y == 1 &&
+        return view->get_geometry().x == view_x &&
+        view->get_geometry().y == view_y &&
         view->get_geometry().width == logical_width &&
         view->get_geometry().height == logical_height;
     }));
@@ -100,33 +99,25 @@ TEST_CASE("fractional-scale render stays pixel-aligned away from origin")
     const int output_width = output->handle->width;
     const int output_height = output->handle->height;
 
-    std::set<uint32_t> unique_pixels(output_pixels.begin(), output_pixels.end());
-
     int min_x = output_width;
     int min_y = output_height;
     int max_x = -1;
     int max_y = -1;
     int mixed_pixels = 0;
-
     const auto is_background = [] (uint32_t pixel)
     {
         return (pixel & 0xffffff00u) == 0;
     };
 
-    INFO("unique pixel count: ", unique_pixels.size());
-    for (auto pixel : unique_pixels)
-    {
-        std::ostringstream out;
-        out << std::hex << pixel;
-        INFO("pixel value: 0x", out.str());
-    }
+    image_io::write_to_file("/tmp/pixels.png",
+        (uint8_t*)output_pixels.data(), output_width, output_height, "png", false);
 
     for (int y = 0; y < output_height; ++y)
     {
         for (int x = 0; x < output_width; ++x)
         {
             auto pixel = output_pixels[y * output_width + x];
-            if (pixel != background)
+            if ((pixel == red) || (pixel == green))
             {
                 min_x = std::min(min_x, x);
                 min_y = std::min(min_y, y);
@@ -143,9 +134,14 @@ TEST_CASE("fractional-scale render stays pixel-aligned away from origin")
 
     REQUIRE(max_x >= min_x);
     REQUIRE(max_y >= min_y);
-    CHECK(min_x == 1);
-    CHECK(min_y == 1);
+    const int expected_x = static_cast<int>(std::floor(view_x * output->get_scale()));
+    const int expected_y = static_cast<int>(std::floor(view_y * output->get_scale()));
+
+    CHECK(min_x == expected_x);
+    CHECK(min_y == expected_y);
     CHECK(max_x - min_x + 1 == buffer_width);
     CHECK(max_y - min_y + 1 == buffer_height);
+    CHECK(is_background(output_pixels[expected_y * output_width + expected_x - 1]));
+    CHECK(is_background(output_pixels[(expected_y - 1) * output_width + expected_x]));
     CHECK(mixed_pixels == 0);
 }

--- a/test/support/headless-core-harness.cpp
+++ b/test/support/headless-core-harness.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <optional>
 #include <stdexcept>
-#include <chrono>
 #include <array>
 #include <vector>
 
@@ -29,7 +28,6 @@
 #include <wayland-server-core.h>
 
 #include "../../src/core/core-impl.hpp"
-#include "../../src/main.hpp"
 
 namespace
 {
@@ -62,7 +60,7 @@ class test_config_backend_t : public wf::config_backend_t
             "auto_reload_config = false\n"
             "enable_input_method_v2 = false\n"
             "use_external_output_configuration = false\n",
-            "xdg-shell-test-config");
+            "default-test-config");
 
         if (!extra_config.empty())
         {
@@ -155,7 +153,7 @@ struct wf::test::headless_core_harness_t::impl
             std::vector<uint32_t> pixels(size.width * size.height);
             wlr_texture_read_pixels_options opts{};
             opts.data   = pixels.data();
-            opts.format = DRM_FORMAT_ABGR8888;
+            opts.format = DRM_FORMAT_RGBA8888;
             opts.stride = size.width * 4;
             if (!wlr_texture_read_pixels(tex, &opts))
             {

--- a/test/support/wayland-client-utils.cpp
+++ b/test/support/wayland-client-utils.cpp
@@ -126,7 +126,7 @@ wl_buffer*wf::test::create_shm_buffer(wl_shm *shm, int width, int height, const 
     std::memcpy(data, pixels.data(), size);
     auto *pool   = wl_shm_create_pool(shm, fd, size);
     auto *buffer = wl_shm_pool_create_buffer(pool, 0, width, height, stride,
-        WL_SHM_FORMAT_XRGB8888);
+        WL_SHM_FORMAT_RGBX8888);
     wl_shm_pool_destroy(pool);
     munmap(data, size);
     close(fd);


### PR DESCRIPTION
This option can be used to force rendering of client textures to the actual buffer size they provide, leaving up to 1 pixel off the boundary of the surface in order to ensure crisp rendering.

Fixes #2697

**To use, enable the config option** like this:

```ini
[workarounds]
use_native_buffer_size = true
```
