### PR TITLE
touch improvements

### DIFF
--- a/metadata/input.xml
+++ b/metadata/input.xml
@@ -253,6 +253,12 @@
 				<min>0.1</min>
 				<max>5.0</max>
 			</option>
+			<option name="gesture_finger_count" type="int">
+				<_short>Touchscreen gesture finger count</_short>
+				<_long>The number of touch points required before touchscreen input is treated as a gesture and cancelled for clients.</_long>
+				<default>3</default>
+				<min>1</min>
+			</option>
 			<option name="touchpad_scroll_speed" type="double">
 				<_short>Touchpad scroll speed</_short>
 				<_long>Changes the touchpad scroll factor.  Scroll speed will be scaled by the given value, which must be non-negative.</_long>

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -107,7 +107,7 @@ using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 /**
  * The version is defined as macro as well, to allow conditional compilation.
  */
-#define WAYFIRE_API_ABI_VERSION_MACRO 2026'07'15
+#define WAYFIRE_API_ABI_VERSION_MACRO 2026'07'18
 
 /**
  * The version of Wayfire's API/ABI

--- a/src/core/seat/bindings-repository-impl.hpp
+++ b/src/core/seat/bindings-repository-impl.hpp
@@ -28,6 +28,24 @@ struct wf::bindings_repository_t::impl
 
     void reparse_extensions();
 
+    bool has_gesture(const wf::touchgesture_t& gesture) const
+    {
+        if (!enabled)
+        {
+            return false;
+        }
+
+        for (auto& binding : activators)
+        {
+            if (binding->activated_by->get_value().has_match(gesture))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     binding_container_t<wf::keybinding_t, key_callback> keys;
     binding_container_t<wf::keybinding_t, axis_callback> axes;
     binding_container_t<wf::buttonbinding_t, button_callback> buttons;

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -258,8 +258,19 @@ void wf::cursor_t::set_touchscreen_mode(bool enabled)
     if (enabled)
     {
         hide_cursor();
+        if (!touchscreen_mode_disabled_pointer_focus)
+        {
+            seat->priv->lpointer->set_enable_focus(false);
+            touchscreen_mode_disabled_pointer_focus = true;
+        }
     } else
     {
+        if (touchscreen_mode_disabled_pointer_focus)
+        {
+            seat->priv->lpointer->set_enable_focus(true);
+            touchscreen_mode_disabled_pointer_focus = false;
+        }
+
         unhide_cursor();
     }
 }

--- a/src/core/seat/cursor.hpp
+++ b/src/core/seat/cursor.hpp
@@ -77,6 +77,7 @@ struct cursor_t
     std::string last_cursor_name;
 
     bool touchscreen_mode_active = false;
+    bool touchscreen_mode_disabled_pointer_focus = false;
 };
 }
 

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -10,6 +10,7 @@
 #include "wayfire/util.hpp"
 #include "wayfire/output-layout.hpp"
 #include <glm/glm.hpp>
+#include <algorithm>
 
 class touch_timer_adapter_t : public wf::touch::timer_interface_t
 {
@@ -241,6 +242,34 @@ void wf::touch_interface_t::update_gestures(const wf::touch::gesture_event_t& ev
     }
 }
 
+void wf::touch_interface_t::cancel_client_touches()
+{
+    std::vector<wlr_seat_client*> clients;
+    for (auto& [id, node] : focus)
+    {
+        if (!node)
+        {
+            continue;
+        }
+
+        auto *point = wlr_seat_touch_get_point(seat, id);
+        if (point && point->client &&
+            (std::find(clients.begin(), clients.end(), point->client) == clients.end()))
+        {
+            clients.push_back(point->client);
+        }
+    }
+
+    for (auto *client : clients)
+    {
+        wlr_seat_touch_notify_cancel(seat, client);
+    }
+
+    focus.clear();
+    focus_grab_kind.clear();
+    client_touches_cancelled = true;
+}
+
 void wf::touch_interface_t::handle_touch_down(int32_t id, uint32_t time,
     wf::pointf_t point, input_event_processing_mode_t mode)
 {
@@ -265,7 +294,13 @@ void wf::touch_interface_t::handle_touch_down(int32_t id, uint32_t time,
     };
     finger_state.update(gesture_event);
 
-    if (mode != input_event_processing_mode_t::FULL)
+    if (!client_touches_cancelled &&
+        ((int)finger_state.fingers.size() >= gesture_finger_count))
+    {
+        cancel_client_touches();
+    }
+
+    if ((mode != input_event_processing_mode_t::FULL) || client_touches_cancelled)
     {
         update_gestures(gesture_event);
         update_cursor_state();
@@ -329,7 +364,7 @@ void wf::touch_interface_t::handle_touch_motion(int32_t id, uint32_t time,
         }
     }
 
-    if (focus[id])
+    if (!client_touches_cancelled && focus[id])
     {
         auto local = get_node_local_coords(focus[id].get(), point);
         focus[id]->touch_interaction().handle_touch_motion(time, id, local, kind);
@@ -354,8 +389,20 @@ void wf::touch_interface_t::handle_touch_up(int32_t id, uint32_t time,
     update_gestures(gesture_event);
     finger_state.update(gesture_event);
 
+    if (finger_state.fingers.empty())
+    {
+        client_touches_cancelled = false;
+    }
+
     update_cursor_state();
-    set_touch_focus(nullptr, id, time, {lift_off_position.x, lift_off_position.y});
+    if (!client_touches_cancelled)
+    {
+        set_touch_focus(nullptr, id, time, {lift_off_position.x, lift_off_position.y});
+    } else
+    {
+        focus.erase(id);
+        focus_grab_kind.erase(id);
+    }
 }
 
 void wf::touch_interface_t::update_cursor_state()

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -730,8 +730,8 @@ void wf::touch_interface_t::add_default_gestures()
         return (int)state.fingers.size() >= gesture_finger_count;
     };
 
-    auto consume_edge_swipe = [this, consume_multitouch] (const wf::touch::gesture_state_t& state,
-                                                          const wf::touch::gesture_event_t& event)
+    auto consume_edge_swipe = [consume_multitouch] (const wf::touch::gesture_state_t& state,
+                                                    const wf::touch::gesture_event_t& event)
     {
         return consume_multitouch(state, event) ||
                ((event.type == wf::touch::EVENT_TYPE_TOUCH_DOWN) &&

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -2,6 +2,7 @@
 #include <wayfire/bindings-repository.hpp>
 
 #include "touch.hpp"
+#include "bindings-repository-impl.hpp"
 #include "cursor.hpp"
 #include "input-manager.hpp"
 #include "../core-impl.hpp"
@@ -11,6 +12,10 @@
 #include "wayfire/output-layout.hpp"
 #include <glm/glm.hpp>
 #include <algorithm>
+#include <array>
+
+static uint32_t find_swipe_edges(wf::touch::point_t point);
+static bool has_edge_swipe_binding(uint32_t edge_directions);
 
 class touch_timer_adapter_t : public wf::touch::timer_interface_t
 {
@@ -242,6 +247,20 @@ void wf::touch_interface_t::update_gestures(const wf::touch::gesture_event_t& ev
     }
 }
 
+bool wf::touch_interface_t::should_consume_touch(
+    const wf::touch::gesture_event_t& event) const
+{
+    for (auto& gesture : this->gestures)
+    {
+        if (gesture->should_consume(this->finger_state, event))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 void wf::touch_interface_t::cancel_client_touches()
 {
     std::vector<wlr_seat_client*> clients;
@@ -294,8 +313,7 @@ void wf::touch_interface_t::handle_touch_down(int32_t id, uint32_t time,
     };
     finger_state.update(gesture_event);
 
-    if (!client_touches_cancelled &&
-        ((int)finger_state.fingers.size() >= gesture_finger_count))
+    if (!client_touches_cancelled && should_consume_touch(gesture_event))
     {
         cancel_client_touches();
     }
@@ -333,8 +351,13 @@ void wf::touch_interface_t::handle_touch_motion(int32_t id, uint32_t time,
             .finger = id,
             .pos    = {point.x, point.y}
         };
-        update_gestures(gesture_event);
         finger_state.update(gesture_event);
+        if (!client_touches_cancelled && should_consume_touch(gesture_event))
+        {
+            cancel_client_touches();
+        }
+
+        update_gestures(gesture_event);
     }
 
     auto kind = get_current_grab_kind(id);
@@ -364,7 +387,7 @@ void wf::touch_interface_t::handle_touch_motion(int32_t id, uint32_t time,
         }
     }
 
-    if (!client_touches_cancelled && focus[id])
+    if (focus[id])
     {
         auto local = get_node_local_coords(focus[id].get(), point);
         focus[id]->touch_interaction().handle_touch_motion(time, id, local, kind);
@@ -413,9 +436,10 @@ void wf::touch_interface_t::update_cursor_state()
 }
 
 // Swipe params
-constexpr static int EDGE_SWIPE_THRESHOLD  = 10;
-constexpr static double MIN_SWIPE_DISTANCE = 30;
-constexpr static double MAX_SWIPE_DISTANCE = 450;
+constexpr static int EDGE_SWIPE_THRESHOLD   = 10;
+constexpr static int MAX_EDGE_SWIPE_FINGERS = 5;
+constexpr static double MIN_SWIPE_DISTANCE  = 30;
+constexpr static double MAX_SWIPE_DISTANCE  = 450;
 constexpr static double SWIPE_INCORRECT_DRAG_TOLERANCE = 150;
 
 // Pinch params
@@ -556,6 +580,40 @@ static uint32_t find_swipe_edges(wf::touch::point_t point)
     return edge_directions;
 }
 
+static bool has_edge_swipe_binding(uint32_t edge_directions)
+{
+    const std::array<uint32_t, 4> directions = {
+        wf::GESTURE_DIRECTION_RIGHT,
+        wf::GESTURE_DIRECTION_LEFT,
+        wf::GESTURE_DIRECTION_UP,
+        wf::GESTURE_DIRECTION_DOWN,
+    };
+
+    for (auto direction : directions)
+    {
+        if (!(edge_directions & direction))
+        {
+            continue;
+        }
+
+        for (int fingers = 1; fingers <= MAX_EDGE_SWIPE_FINGERS; ++fingers)
+        {
+            auto gesture = wf::touchgesture_t{
+                wf::GESTURE_TYPE_EDGE_SWIPE,
+                direction,
+                fingers
+            };
+
+            if (wf::get_core().bindings->priv->has_gesture(gesture))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 static uint32_t wf_touch_to_wf_dir(uint32_t touch_dir)
 {
     uint32_t gesture_dir = 0;
@@ -666,12 +724,27 @@ void wf::touch_interface_t::add_default_gestures()
         wf::get_core().bindings->handle_gesture(gesture);
     };
 
+    auto consume_multitouch = [this] (const wf::touch::gesture_state_t& state,
+                                      const wf::touch::gesture_event_t&)
+    {
+        return (int)state.fingers.size() >= gesture_finger_count;
+    };
+
+    auto consume_edge_swipe = [this, consume_multitouch] (const wf::touch::gesture_state_t& state,
+                                                          const wf::touch::gesture_event_t& event)
+    {
+        return consume_multitouch(state, event) ||
+               ((event.type == wf::touch::EVENT_TYPE_TOUCH_DOWN) &&
+                   (state.fingers.size() == 1) &&
+                   has_edge_swipe_binding(find_swipe_edges(event.pos)));
+    };
+
     this->multiswipe = std::make_unique<gesture_t>(std::move(
-        swipe_actions), ack_swipe);
+        swipe_actions), ack_swipe, [] () {}, consume_multitouch);
     this->edgeswipe = std::make_unique<gesture_t>(std::move(
-        edge_swipe_actions), ack_edge_swipe);
+        edge_swipe_actions), ack_edge_swipe, [] () {}, consume_edge_swipe);
     this->multipinch = std::make_unique<gesture_t>(std::move(
-        pinch_actions), ack_pinch);
+        pinch_actions), ack_pinch, [] () {}, consume_multitouch);
     this->add_touch_gesture(this->multiswipe);
     this->add_touch_gesture(this->edgeswipe);
     this->add_touch_gesture(this->multipinch);

--- a/src/core/seat/touch.hpp
+++ b/src/core/seat/touch.hpp
@@ -10,6 +10,11 @@
 // TODO: tests
 namespace wf
 {
+namespace test
+{
+class headless_core_harness_t;
+}
+
 using input_surface_selector_t =
     std::function<wf::scene::node_ptr(const wf::pointf_t&)>;
 
@@ -61,6 +66,7 @@ class touch_interface_t
         bool real_event, input_event_processing_mode_t mode);
     void handle_touch_up(int32_t id, uint32_t time,
         input_event_processing_mode_t mode);
+    void cancel_client_touches();
 
     void set_touch_focus(wf::scene::node_ptr node,
         int32_t id, int64_t time, wf::pointf_t current);
@@ -70,6 +76,7 @@ class touch_interface_t
     /** Pressed a finger on a surface and dragging outside of it now */
     std::map<int, wf::scene::node_ptr> focus;
     std::map<int, input_grab_kind_t> focus_grab_kind;
+    bool client_touches_cancelled = false;
 
     void update_gestures(const wf::touch::gesture_event_t& event);
     std::vector<nonstd::observer_ptr<touch::gesture_t>> gestures;
@@ -83,6 +90,9 @@ class touch_interface_t
     /** Enable/disable cursor depending on how many touch points are there */
     void update_cursor_state();
     input_grab_kind_t get_current_grab_kind(int32_t id) const;
+    wf::option_wrapper_t<int> gesture_finger_count{"input/gesture_finger_count"};
+
+    friend class wf::test::headless_core_harness_t;
 };
 }
 

--- a/src/core/seat/touch.hpp
+++ b/src/core/seat/touch.hpp
@@ -67,6 +67,7 @@ class touch_interface_t
     void handle_touch_up(int32_t id, uint32_t time,
         input_event_processing_mode_t mode);
     void cancel_client_touches();
+    bool should_consume_touch(const wf::touch::gesture_event_t& event) const;
 
     void set_touch_focus(wf::scene::node_ptr node,
         int32_t id, int64_t time, wf::pointf_t current);

--- a/src/view/xwayland.cpp
+++ b/src/view/xwayland.cpp
@@ -275,6 +275,7 @@ void wf::fini_xwayland()
         on_xwayland_surface_created.disconnect();
         on_xwayland_ready.disconnect();
         wlr_xwayland_destroy(xwayland_handle);
+        xwayland_handle = nullptr;
     }
 
 #endif

--- a/test/protocol/meson.build
+++ b/test/protocol/meson.build
@@ -91,6 +91,17 @@ scaling_test = executable(
     ],
     install: false)
 
+touch_test = executable(
+    'touch-test',
+    'touch-test.cpp',
+    test_support_sources,
+    dependencies: [doctest, libwayfire, wayland_client],
+    cpp_args: [
+        '-DTEST_METADATA_DIR="' + meson.project_source_root() + '/metadata"',
+        '-DTEST_DEFAULTS_INI="' + meson.project_source_root() + '/wayfire.ini"',
+    ],
+    install: false)
+
 # This test uses a different value for a workaround option. Keep it in a separate
 # executable because static option_wrapper_t instances cache options per process.
 native_buffer_size_scaling_test = executable(
@@ -107,4 +118,5 @@ native_buffer_size_scaling_test = executable(
 test('Xdg-shell test', xdg_shell_test)
 test('Layer-shell test', layer_shell_test)
 test('Scaling test', scaling_test)
+test('Touch test', touch_test)
 test('Native buffer size scaling test', native_buffer_size_scaling_test)

--- a/test/protocol/touch-test.cpp
+++ b/test/protocol/touch-test.cpp
@@ -1,0 +1,81 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/doctest.h>
+
+#include <wayfire/core.hpp>
+#include <wayfire/signal-definitions.hpp>
+#include <wayfire/toplevel-view.hpp>
+
+#include <vector>
+
+#include "../support/headless-core-harness.hpp"
+#include "../support/wayland-xdg-client.hpp"
+
+namespace
+{
+static void flush_touch(wf::test::headless_core_harness_t& harness,
+    wf::test::wayland_xdg_client_t& client)
+{
+    harness.touch_frame();
+    harness.dispatch_once();
+    client.dispatch_once();
+}
+}
+
+TEST_CASE("configured gesture finger count controls touch cancel threshold")
+{
+    wf::test::headless_core_harness_t harness{
+        "[input]\n"
+        "gesture_finger_count = 4\n"};
+    harness.enable_touch_input();
+
+    std::vector<wayfire_view> mapped;
+    wf::signal::connection_t<wf::view_mapped_signal> on_map = [&] (wf::view_mapped_signal *ev)
+    {
+        mapped.push_back(ev->view);
+    };
+    wf::get_core().connect(&on_map);
+
+    wf::test::wayland_xdg_client_t client{harness.socket_name()};
+    REQUIRE(harness.run_until([&]
+    {
+        client.dispatch_once();
+        return client.has_required_globals() && client.has_touch();
+    }));
+
+    client.create_toplevel("touch threshold test", "org.wayfire.TouchThresholdTest");
+    REQUIRE(harness.run_until([&]
+    {
+        client.dispatch_once();
+        return client.has_pending_configure();
+    }));
+
+    client.attach_and_commit(200, 120);
+    REQUIRE(harness.run_until([&] () { return mapped.size() == 1; }));
+
+    auto view = wf::toplevel_cast(mapped.front());
+    REQUIRE(view != nullptr);
+    auto geometry = view->get_geometry();
+    const double x = geometry.x + 20.0;
+    const double y = geometry.y + 20.0;
+
+    harness.touch_down(0, x, y);
+    flush_touch(harness, client);
+    harness.touch_down(1, x + 30.0, y);
+    flush_touch(harness, client);
+    harness.touch_down(2, x + 60.0, y);
+    flush_touch(harness, client);
+
+    REQUIRE(client.touch_events().size() == 6);
+    CHECK(client.touch_events()[0].type == wf::test::touch_event_t::DOWN);
+    CHECK(client.touch_events()[0].id == 0);
+    CHECK(client.touch_events()[2].type == wf::test::touch_event_t::DOWN);
+    CHECK(client.touch_events()[2].id == 1);
+    CHECK(client.touch_events()[4].type == wf::test::touch_event_t::DOWN);
+    CHECK(client.touch_events()[4].id == 2);
+
+    harness.touch_down(3, x + 90.0, y);
+    flush_touch(harness, client);
+
+    REQUIRE(client.touch_events().size() == 7);
+    CHECK(client.touch_events()[6].type == wf::test::touch_event_t::CANCEL);
+}

--- a/test/protocol/touch-test.cpp
+++ b/test/protocol/touch-test.cpp
@@ -23,7 +23,8 @@ static void flush_touch(wf::test::headless_core_harness_t& harness,
 }
 
 static wayfire_toplevel_view map_touch_client(wf::test::headless_core_harness_t& harness,
-    wf::test::wayland_xdg_client_t& client, const std::string& title)
+    wf::test::wayland_xdg_client_t& client, const std::string& title,
+    bool require_pointer = false)
 {
     std::vector<wayfire_view> mapped;
     wf::signal::connection_t<wf::view_mapped_signal> on_map = [&] (wf::view_mapped_signal *ev)
@@ -35,7 +36,8 @@ static wayfire_toplevel_view map_touch_client(wf::test::headless_core_harness_t&
     REQUIRE(harness.run_until([&]
     {
         client.dispatch_once();
-        return client.has_required_globals() && client.has_touch();
+        return client.has_required_globals() && client.has_touch() &&
+        (!require_pointer || client.has_pointer());
     }));
 
     client.create_toplevel(title, "org.wayfire.TouchTest");
@@ -184,4 +186,32 @@ TEST_CASE("custom touch gestures can consume client touch sequences")
     CHECK(client.touch_events().empty());
 
     wf::get_core().rem_touch_gesture(&custom_gesture);
+}
+
+TEST_CASE("touch input clears pointer focus")
+{
+    wf::test::headless_core_harness_t harness;
+    harness.enable_pointer_input();
+    harness.enable_touch_input();
+
+    wf::test::wayland_xdg_client_t client{harness.socket_name()};
+    auto view     = map_touch_client(harness, client, "touch clears pointer focus test", true);
+    auto geometry = view->get_geometry();
+    const double x = geometry.x + 20.0;
+    const double y = geometry.y + 20.0;
+
+    harness.pointer_motion(x, y);
+    client.dispatch_once();
+
+    REQUIRE(client.pointer_events().size() >= 2);
+    CHECK(client.pointer_events()[0].type == wf::test::pointer_event_t::ENTER);
+    CHECK(client.pointer_events()[1].type == wf::test::pointer_event_t::FRAME);
+
+    client.clear_pointer_events();
+    harness.touch_down(0, x, y);
+    flush_touch(harness, client);
+
+    REQUIRE(client.pointer_events().size() >= 2);
+    CHECK(client.pointer_events()[0].type == wf::test::pointer_event_t::LEAVE);
+    CHECK(client.pointer_events()[1].type == wf::test::pointer_event_t::FRAME);
 }

--- a/test/protocol/touch-test.cpp
+++ b/test/protocol/touch-test.cpp
@@ -2,7 +2,9 @@
 #include <doctest/doctest.h>
 
 #include <wayfire/core.hpp>
+#include <wayfire/bindings-repository.hpp>
 #include <wayfire/signal-definitions.hpp>
+#include <wayfire/touch/touch.hpp>
 #include <wayfire/toplevel-view.hpp>
 
 #include <vector>
@@ -19,15 +21,10 @@ static void flush_touch(wf::test::headless_core_harness_t& harness,
     harness.dispatch_once();
     client.dispatch_once();
 }
-}
 
-TEST_CASE("configured gesture finger count controls touch cancel threshold")
+static wayfire_toplevel_view map_touch_client(wf::test::headless_core_harness_t& harness,
+    wf::test::wayland_xdg_client_t& client, const std::string& title)
 {
-    wf::test::headless_core_harness_t harness{
-        "[input]\n"
-        "gesture_finger_count = 4\n"};
-    harness.enable_touch_input();
-
     std::vector<wayfire_view> mapped;
     wf::signal::connection_t<wf::view_mapped_signal> on_map = [&] (wf::view_mapped_signal *ev)
     {
@@ -35,14 +32,13 @@ TEST_CASE("configured gesture finger count controls touch cancel threshold")
     };
     wf::get_core().connect(&on_map);
 
-    wf::test::wayland_xdg_client_t client{harness.socket_name()};
     REQUIRE(harness.run_until([&]
     {
         client.dispatch_once();
         return client.has_required_globals() && client.has_touch();
     }));
 
-    client.create_toplevel("touch threshold test", "org.wayfire.TouchThresholdTest");
+    client.create_toplevel(title, "org.wayfire.TouchTest");
     REQUIRE(harness.run_until([&]
     {
         client.dispatch_once();
@@ -54,6 +50,27 @@ TEST_CASE("configured gesture finger count controls touch cancel threshold")
 
     auto view = wf::toplevel_cast(mapped.front());
     REQUIRE(view != nullptr);
+    view->move(0, 0);
+    return view;
+}
+
+static void add_edge_swipe_binding(const std::string& binding_description,
+    wf::activator_callback& callback)
+{
+    auto binding = wf::create_option_string<wf::activatorbinding_t>(binding_description);
+    wf::get_core().bindings->add_activator(binding, &callback);
+}
+}
+
+TEST_CASE("configured gesture finger count controls touch cancel threshold")
+{
+    wf::test::headless_core_harness_t harness{
+        "[input]\n"
+        "gesture_finger_count = 4\n"};
+    harness.enable_touch_input();
+
+    wf::test::wayland_xdg_client_t client{harness.socket_name()};
+    auto view     = map_touch_client(harness, client, "touch threshold test");
     auto geometry = view->get_geometry();
     const double x = geometry.x + 20.0;
     const double y = geometry.y + 20.0;
@@ -78,4 +95,93 @@ TEST_CASE("configured gesture finger count controls touch cancel threshold")
 
     REQUIRE(client.touch_events().size() == 7);
     CHECK(client.touch_events()[6].type == wf::test::touch_event_t::CANCEL);
+
+    client.clear_touch_events();
+    harness.touch_up(3);
+    flush_touch(harness, client);
+    harness.touch_up(2);
+    flush_touch(harness, client);
+    harness.touch_up(1);
+    flush_touch(harness, client);
+    harness.touch_up(0);
+    flush_touch(harness, client);
+    CHECK(client.touch_events().empty());
+}
+
+TEST_CASE("edge swipe bindings preempt only matching screen edges")
+{
+    wf::test::headless_core_harness_t harness;
+    harness.enable_touch_input();
+
+    wf::test::wayland_xdg_client_t client{harness.socket_name()};
+    auto view     = map_touch_client(harness, client, "edge swipe test");
+    auto geometry = view->get_geometry();
+
+    wf::activator_callback non_matching_callback = [] (const wf::activator_data_t&) { return true; };
+    add_edge_swipe_binding("edge-swipe left 3", non_matching_callback);
+
+    harness.touch_down(0, geometry.x + 20.0, geometry.y + 1.0);
+    flush_touch(harness, client);
+
+    REQUIRE(client.touch_events().size() == 2);
+    CHECK(client.touch_events()[0].type == wf::test::touch_event_t::DOWN);
+    CHECK(client.touch_events()[1].type == wf::test::touch_event_t::FRAME);
+
+    harness.touch_up(0);
+    flush_touch(harness, client);
+    client.clear_touch_events();
+
+    wf::activator_callback matching_callback = [] (const wf::activator_data_t&) { return true; };
+    add_edge_swipe_binding("edge-swipe down 3", matching_callback);
+
+    harness.touch_down(0, geometry.x + 20.0, geometry.y + 1.0);
+    flush_touch(harness, client);
+    harness.touch_motion(0, geometry.x + 20.0, geometry.y + 30.0);
+    flush_touch(harness, client);
+    harness.touch_up(0);
+    flush_touch(harness, client);
+
+    CHECK(client.touch_events().empty());
+
+    wf::get_core().bindings->rem_binding(&matching_callback);
+    wf::get_core().bindings->rem_binding(&non_matching_callback);
+}
+
+TEST_CASE("custom touch gestures can consume client touch sequences")
+{
+    wf::test::headless_core_harness_t harness;
+    harness.enable_touch_input();
+
+    wf::test::wayland_xdg_client_t client{harness.socket_name()};
+    auto view     = map_touch_client(harness, client, "custom gesture consume test");
+    auto geometry = view->get_geometry();
+
+    std::vector<std::unique_ptr<wf::touch::gesture_action_t>> actions;
+    actions.emplace_back(std::make_unique<wf::touch::touch_action_t>(2, true));
+    wf::touch::gesture_t custom_gesture{std::move(actions), [] () {}, [] () {},
+        [] (const wf::touch::gesture_state_t& state, const wf::touch::gesture_event_t&)
+        {
+            return state.fingers.size() == 2;
+        }
+    };
+    wf::get_core().add_touch_gesture(&custom_gesture);
+
+    harness.touch_down(0, geometry.x + 20.0, geometry.y + 20.0);
+    flush_touch(harness, client);
+    harness.touch_down(1, geometry.x + 50.0, geometry.y + 20.0);
+    flush_touch(harness, client);
+
+    REQUIRE(client.touch_events().size() == 3);
+    CHECK(client.touch_events()[0].type == wf::test::touch_event_t::DOWN);
+    CHECK(client.touch_events()[1].type == wf::test::touch_event_t::FRAME);
+    CHECK(client.touch_events()[2].type == wf::test::touch_event_t::CANCEL);
+
+    client.clear_touch_events();
+    harness.touch_up(1);
+    flush_touch(harness, client);
+    harness.touch_up(0);
+    flush_touch(harness, client);
+    CHECK(client.touch_events().empty());
+
+    wf::get_core().rem_touch_gesture(&custom_gesture);
 }

--- a/test/support/headless-core-harness.cpp
+++ b/test/support/headless-core-harness.cpp
@@ -29,6 +29,8 @@
 #include <wayland-server-protocol.h>
 
 #include "../../src/core/core-impl.hpp"
+#include "../../src/core/seat/cursor.hpp"
+#include "../../src/core/seat/pointer.hpp"
 #include "../../src/core/seat/seat-impl.hpp"
 #include "../../src/core/seat/touch.hpp"
 
@@ -337,6 +339,13 @@ void wf::test::headless_core_harness_t::enable_touch_input()
         seat->capabilities | WL_SEAT_CAPABILITY_TOUCH);
 }
 
+void wf::test::headless_core_harness_t::enable_pointer_input()
+{
+    auto *seat = priv->core->seat->seat;
+    wlr_seat_set_capabilities(seat,
+        seat->capabilities | WL_SEAT_CAPABILITY_POINTER);
+}
+
 void wf::test::headless_core_harness_t::touch_down(int32_t id, double x, double y)
 {
     priv->core->seat->priv->touch->handle_touch_down(id, priv->touch_time++,
@@ -358,6 +367,14 @@ void wf::test::headless_core_harness_t::touch_up(int32_t id)
 void wf::test::headless_core_harness_t::touch_frame()
 {
     wlr_seat_touch_notify_frame(priv->core->seat->seat);
+    wl_display_flush_clients(priv->core->display);
+}
+
+void wf::test::headless_core_harness_t::pointer_motion(double x, double y)
+{
+    priv->core->seat->priv->cursor->warp_cursor({x, y});
+    priv->core->seat->priv->lpointer->update_cursor_position(priv->touch_time++);
+    wlr_seat_pointer_notify_frame(priv->core->seat->seat);
     wl_display_flush_clients(priv->core->display);
 }
 

--- a/test/support/headless-core-harness.cpp
+++ b/test/support/headless-core-harness.cpp
@@ -26,8 +26,11 @@
 #include <wayfire/util/log.hpp>
 
 #include <wayland-server-core.h>
+#include <wayland-server-protocol.h>
 
 #include "../../src/core/core-impl.hpp"
+#include "../../src/core/seat/seat-impl.hpp"
+#include "../../src/core/seat/touch.hpp"
 
 namespace
 {
@@ -129,6 +132,7 @@ struct wf::test::headless_core_harness_t::impl
     std::string test_runtime_dir;
     bool had_wayland_display = false;
     bool had_xdg_runtime_dir = false;
+    uint32_t touch_time = 1000;
 
     std::vector<uint32_t> capture_output_pixels()
     {
@@ -324,6 +328,37 @@ bool wf::test::headless_core_harness_t::run_until(const std::function<bool()>& p
     }
 
     return predicate();
+}
+
+void wf::test::headless_core_harness_t::enable_touch_input()
+{
+    auto *seat = priv->core->seat->seat;
+    wlr_seat_set_capabilities(seat,
+        seat->capabilities | WL_SEAT_CAPABILITY_TOUCH);
+}
+
+void wf::test::headless_core_harness_t::touch_down(int32_t id, double x, double y)
+{
+    priv->core->seat->priv->touch->handle_touch_down(id, priv->touch_time++,
+        {x, y}, wf::input_event_processing_mode_t::FULL);
+}
+
+void wf::test::headless_core_harness_t::touch_motion(int32_t id, double x, double y)
+{
+    priv->core->seat->priv->touch->handle_touch_motion(id, priv->touch_time++,
+        {x, y}, true, wf::input_event_processing_mode_t::FULL);
+}
+
+void wf::test::headless_core_harness_t::touch_up(int32_t id)
+{
+    priv->core->seat->priv->touch->handle_touch_up(id, priv->touch_time++,
+        wf::input_event_processing_mode_t::FULL);
+}
+
+void wf::test::headless_core_harness_t::touch_frame()
+{
+    wlr_seat_touch_notify_frame(priv->core->seat->seat);
+    wl_display_flush_clients(priv->core->display);
 }
 
 wf::output_t*wf::test::headless_core_harness_t::output() const

--- a/test/support/headless-core-harness.hpp
+++ b/test/support/headless-core-harness.hpp
@@ -22,6 +22,11 @@ class headless_core_harness_t
     void dispatch_once(int timeout_ms = 0);
     void roundtrip();
     bool run_until(const std::function<bool()>& predicate, int max_iterations = 200);
+    void enable_touch_input();
+    void touch_down(int32_t id, double x, double y);
+    void touch_motion(int32_t id, double x, double y);
+    void touch_up(int32_t id);
+    void touch_frame();
 
     wf::output_t *output() const;
     const std::string& socket_name() const;

--- a/test/support/headless-core-harness.hpp
+++ b/test/support/headless-core-harness.hpp
@@ -22,11 +22,13 @@ class headless_core_harness_t
     void dispatch_once(int timeout_ms = 0);
     void roundtrip();
     bool run_until(const std::function<bool()>& predicate, int max_iterations = 200);
+    void enable_pointer_input();
     void enable_touch_input();
     void touch_down(int32_t id, double x, double y);
     void touch_motion(int32_t id, double x, double y);
     void touch_up(int32_t id);
     void touch_frame();
+    void pointer_motion(double x, double y);
 
     wf::output_t *output() const;
     const std::string& socket_name() const;

--- a/test/support/wayland-xdg-client.cpp
+++ b/test/support/wayland-xdg-client.cpp
@@ -19,7 +19,9 @@ struct wf::test::wayland_xdg_client_t::impl
     wl_display *display   = nullptr;
     wl_registry *registry = nullptr;
     wl_compositor *compositor = nullptr;
-    wl_shm *shm = nullptr;
+    wl_shm *shm     = nullptr;
+    wl_seat *seat   = nullptr;
+    wl_touch *touch = nullptr;
     xdg_wm_base *wm_base = nullptr;
     wp_fractional_scale_manager_v1 *fractional_scale_manager = nullptr;
     wp_viewporter *viewporter = nullptr;
@@ -38,6 +40,7 @@ struct wf::test::wayland_xdg_client_t::impl
     int preferred_buffer_scale = 1;
     std::optional<uint32_t> preferred_fractional_scale;
     std::pair<int, int> committed_buffer_size = {0, 0};
+    std::vector<touch_event_t> touch_events;
 
     static void handle_registry_global(void *data, wl_registry *registry,
         uint32_t name, const char *interface, uint32_t version)
@@ -51,6 +54,11 @@ struct wf::test::wayland_xdg_client_t::impl
         {
             self->shm = static_cast<wl_shm*>(wl_registry_bind(registry,
                 name, &wl_shm_interface, 1));
+        } else if (std::string{interface} == wl_seat_interface.name)
+        {
+            self->seat = static_cast<wl_seat*>(wl_registry_bind(registry,
+                name, &wl_seat_interface, std::min(version, 7u)));
+            wl_seat_add_listener(self->seat, &seat_listener, self);
         } else if (std::string{interface} == xdg_wm_base_interface.name)
         {
             self->wm_base = static_cast<xdg_wm_base*>(wl_registry_bind(registry,
@@ -73,6 +81,78 @@ struct wf::test::wayland_xdg_client_t::impl
     static constexpr wl_registry_listener registry_listener = {
         .global = handle_registry_global,
         .global_remove = handle_registry_remove,
+    };
+
+    static void handle_seat_capabilities(void *data, wl_seat *seat, uint32_t capabilities)
+    {
+        auto *self = static_cast<impl*>(data);
+        if ((capabilities & WL_SEAT_CAPABILITY_TOUCH) && !self->touch)
+        {
+            self->touch = wl_seat_get_touch(seat);
+            wl_touch_add_listener(self->touch, &touch_listener, self);
+        } else if (!(capabilities & WL_SEAT_CAPABILITY_TOUCH) && self->touch)
+        {
+            wl_touch_destroy(self->touch);
+            self->touch = nullptr;
+        }
+    }
+
+    static void handle_seat_name(void*, wl_seat*, const char*)
+    {}
+
+    static constexpr wl_seat_listener seat_listener = {
+        .capabilities = handle_seat_capabilities,
+        .name = handle_seat_name,
+    };
+
+    static void handle_touch_down(void *data, wl_touch*, uint32_t, uint32_t,
+        wl_surface*, int32_t id, wl_fixed_t x, wl_fixed_t y)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->touch_events.push_back({touch_event_t::DOWN, id,
+            wl_fixed_to_double(x), wl_fixed_to_double(y)});
+    }
+
+    static void handle_touch_up(void *data, wl_touch*, uint32_t, uint32_t, int32_t id)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->touch_events.push_back({touch_event_t::UP, id});
+    }
+
+    static void handle_touch_motion(void *data, wl_touch*, uint32_t,
+        int32_t id, wl_fixed_t x, wl_fixed_t y)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->touch_events.push_back({touch_event_t::MOTION, id,
+            wl_fixed_to_double(x), wl_fixed_to_double(y)});
+    }
+
+    static void handle_touch_frame(void *data, wl_touch*)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->touch_events.push_back({touch_event_t::FRAME});
+    }
+
+    static void handle_touch_cancel(void *data, wl_touch*)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->touch_events.push_back({touch_event_t::CANCEL});
+    }
+
+    static void handle_touch_shape(void*, wl_touch*, int32_t, wl_fixed_t, wl_fixed_t)
+    {}
+
+    static void handle_touch_orientation(void*, wl_touch*, int32_t, wl_fixed_t)
+    {}
+
+    static constexpr wl_touch_listener touch_listener = {
+        .down   = handle_touch_down,
+        .up     = handle_touch_up,
+        .motion = handle_touch_motion,
+        .frame  = handle_touch_frame,
+        .cancel = handle_touch_cancel,
+        .shape  = handle_touch_shape,
+        .orientation = handle_touch_orientation,
     };
 
     static void handle_ping(void*, xdg_wm_base *wm_base, uint32_t serial)
@@ -197,6 +277,16 @@ wf::test::wayland_xdg_client_t::~wayland_xdg_client_t()
         xdg_wm_base_destroy(priv->wm_base);
     }
 
+    if (priv->touch)
+    {
+        wl_touch_destroy(priv->touch);
+    }
+
+    if (priv->seat)
+    {
+        wl_seat_destroy(priv->seat);
+    }
+
     if (priv->registry)
     {
         wl_registry_destroy(priv->registry);
@@ -246,6 +336,11 @@ bool wf::test::wayland_xdg_client_t::dispatch_until_configure(int max_iterations
 bool wf::test::wayland_xdg_client_t::has_required_globals() const
 {
     return priv->compositor && priv->shm && priv->wm_base && priv->viewporter;
+}
+
+bool wf::test::wayland_xdg_client_t::has_touch() const
+{
+    return priv->touch;
 }
 
 void wf::test::wayland_xdg_client_t::create_toplevel(const std::string& title,
@@ -447,4 +542,14 @@ void wf::test::wayland_xdg_client_t::destroy_toplevel()
     {
         wl_display_flush(priv->display);
     }
+}
+
+const std::vector<wf::test::touch_event_t>& wf::test::wayland_xdg_client_t::touch_events() const
+{
+    return priv->touch_events;
+}
+
+void wf::test::wayland_xdg_client_t::clear_touch_events()
+{
+    priv->touch_events.clear();
 }

--- a/test/support/wayland-xdg-client.cpp
+++ b/test/support/wayland-xdg-client.cpp
@@ -19,9 +19,10 @@ struct wf::test::wayland_xdg_client_t::impl
     wl_display *display   = nullptr;
     wl_registry *registry = nullptr;
     wl_compositor *compositor = nullptr;
-    wl_shm *shm     = nullptr;
-    wl_seat *seat   = nullptr;
-    wl_touch *touch = nullptr;
+    wl_shm *shm   = nullptr;
+    wl_seat *seat = nullptr;
+    wl_pointer *pointer = nullptr;
+    wl_touch *touch     = nullptr;
     xdg_wm_base *wm_base = nullptr;
     wp_fractional_scale_manager_v1 *fractional_scale_manager = nullptr;
     wp_viewporter *viewporter = nullptr;
@@ -40,6 +41,7 @@ struct wf::test::wayland_xdg_client_t::impl
     int preferred_buffer_scale = 1;
     std::optional<uint32_t> preferred_fractional_scale;
     std::pair<int, int> committed_buffer_size = {0, 0};
+    std::vector<pointer_event_t> pointer_events;
     std::vector<touch_event_t> touch_events;
 
     static void handle_registry_global(void *data, wl_registry *registry,
@@ -86,6 +88,16 @@ struct wf::test::wayland_xdg_client_t::impl
     static void handle_seat_capabilities(void *data, wl_seat *seat, uint32_t capabilities)
     {
         auto *self = static_cast<impl*>(data);
+        if ((capabilities & WL_SEAT_CAPABILITY_POINTER) && !self->pointer)
+        {
+            self->pointer = wl_seat_get_pointer(seat);
+            wl_pointer_add_listener(self->pointer, &pointer_listener, self);
+        } else if (!(capabilities & WL_SEAT_CAPABILITY_POINTER) && self->pointer)
+        {
+            wl_pointer_destroy(self->pointer);
+            self->pointer = nullptr;
+        }
+
         if ((capabilities & WL_SEAT_CAPABILITY_TOUCH) && !self->touch)
         {
             self->touch = wl_seat_get_touch(seat);
@@ -103,6 +115,69 @@ struct wf::test::wayland_xdg_client_t::impl
     static constexpr wl_seat_listener seat_listener = {
         .capabilities = handle_seat_capabilities,
         .name = handle_seat_name,
+    };
+
+    static void handle_pointer_enter(void *data, wl_pointer*, uint32_t,
+        wl_surface*, wl_fixed_t x, wl_fixed_t y)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->pointer_events.push_back({pointer_event_t::ENTER,
+            wl_fixed_to_double(x), wl_fixed_to_double(y)});
+    }
+
+    static void handle_pointer_leave(void *data, wl_pointer*, uint32_t, wl_surface*)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->pointer_events.push_back({pointer_event_t::LEAVE});
+    }
+
+    static void handle_pointer_motion(void *data, wl_pointer*, uint32_t,
+        wl_fixed_t x, wl_fixed_t y)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->pointer_events.push_back({pointer_event_t::MOTION,
+            wl_fixed_to_double(x), wl_fixed_to_double(y)});
+    }
+
+    static void handle_pointer_button(void*, wl_pointer*, uint32_t, uint32_t, uint32_t, uint32_t)
+    {}
+
+    static void handle_pointer_axis(void*, wl_pointer*, uint32_t, uint32_t, wl_fixed_t)
+    {}
+
+    static void handle_pointer_frame(void *data, wl_pointer*)
+    {
+        auto *self = static_cast<impl*>(data);
+        self->pointer_events.push_back({pointer_event_t::FRAME});
+    }
+
+    static void handle_pointer_axis_source(void*, wl_pointer*, uint32_t)
+    {}
+
+    static void handle_pointer_axis_stop(void*, wl_pointer*, uint32_t, uint32_t)
+    {}
+
+    static void handle_pointer_axis_discrete(void*, wl_pointer*, uint32_t, int32_t)
+    {}
+
+    static void handle_pointer_axis_value120(void*, wl_pointer*, uint32_t, int32_t)
+    {}
+
+    static void handle_pointer_axis_relative_direction(void*, wl_pointer*, uint32_t, uint32_t)
+    {}
+
+    static constexpr wl_pointer_listener pointer_listener = {
+        .enter  = handle_pointer_enter,
+        .leave  = handle_pointer_leave,
+        .motion = handle_pointer_motion,
+        .button = handle_pointer_button,
+        .axis   = handle_pointer_axis,
+        .frame  = handle_pointer_frame,
+        .axis_source   = handle_pointer_axis_source,
+        .axis_stop     = handle_pointer_axis_stop,
+        .axis_discrete = handle_pointer_axis_discrete,
+        .axis_value120 = handle_pointer_axis_value120,
+        .axis_relative_direction = handle_pointer_axis_relative_direction,
     };
 
     static void handle_touch_down(void *data, wl_touch*, uint32_t, uint32_t,
@@ -282,6 +357,11 @@ wf::test::wayland_xdg_client_t::~wayland_xdg_client_t()
         wl_touch_destroy(priv->touch);
     }
 
+    if (priv->pointer)
+    {
+        wl_pointer_destroy(priv->pointer);
+    }
+
     if (priv->seat)
     {
         wl_seat_destroy(priv->seat);
@@ -336,6 +416,11 @@ bool wf::test::wayland_xdg_client_t::dispatch_until_configure(int max_iterations
 bool wf::test::wayland_xdg_client_t::has_required_globals() const
 {
     return priv->compositor && priv->shm && priv->wm_base && priv->viewporter;
+}
+
+bool wf::test::wayland_xdg_client_t::has_pointer() const
+{
+    return priv->pointer;
 }
 
 bool wf::test::wayland_xdg_client_t::has_touch() const
@@ -542,6 +627,16 @@ void wf::test::wayland_xdg_client_t::destroy_toplevel()
     {
         wl_display_flush(priv->display);
     }
+}
+
+const std::vector<wf::test::pointer_event_t>& wf::test::wayland_xdg_client_t::pointer_events() const
+{
+    return priv->pointer_events;
+}
+
+void wf::test::wayland_xdg_client_t::clear_pointer_events()
+{
+    priv->pointer_events.clear();
 }
 
 const std::vector<wf::test::touch_event_t>& wf::test::wayland_xdg_client_t::touch_events() const

--- a/test/support/wayland-xdg-client.hpp
+++ b/test/support/wayland-xdg-client.hpp
@@ -13,6 +13,7 @@ struct wl_shm;
 struct wl_surface;
 struct wl_buffer;
 struct wl_seat;
+struct wl_pointer;
 struct wl_touch;
 struct xdg_wm_base;
 struct xdg_surface;
@@ -36,6 +37,20 @@ struct touch_event_t
     double y   = 0.0;
 };
 
+struct pointer_event_t
+{
+    enum type_t
+    {
+        ENTER,
+        LEAVE,
+        MOTION,
+        FRAME,
+    } type;
+
+    double x = 0.0;
+    double y = 0.0;
+};
+
 class wayland_xdg_client_t
 {
   public:
@@ -52,6 +67,7 @@ class wayland_xdg_client_t
     bool dispatch_until_configure(int max_iterations = 200);
 
     bool has_required_globals() const;
+    bool has_pointer() const;
     bool has_touch() const;
     void create_toplevel(const std::string& title, const std::string& app_id);
     bool has_pending_configure() const;
@@ -70,6 +86,8 @@ class wayland_xdg_client_t
     std::pair<int, int> last_committed_buffer_size() const;
     void commit_surface();
     void destroy_toplevel();
+    const std::vector<pointer_event_t>& pointer_events() const;
+    void clear_pointer_events();
     const std::vector<touch_event_t>& touch_events() const;
     void clear_touch_events();
 

--- a/test/support/wayland-xdg-client.hpp
+++ b/test/support/wayland-xdg-client.hpp
@@ -12,12 +12,30 @@ struct wl_compositor;
 struct wl_shm;
 struct wl_surface;
 struct wl_buffer;
+struct wl_seat;
+struct wl_touch;
 struct xdg_wm_base;
 struct xdg_surface;
 struct xdg_toplevel;
 
 namespace wf::test
 {
+struct touch_event_t
+{
+    enum type_t
+    {
+        DOWN,
+        UP,
+        MOTION,
+        CANCEL,
+        FRAME,
+    } type;
+
+    int32_t id = -1;
+    double x   = 0.0;
+    double y   = 0.0;
+};
+
 class wayland_xdg_client_t
 {
   public:
@@ -34,6 +52,7 @@ class wayland_xdg_client_t
     bool dispatch_until_configure(int max_iterations = 200);
 
     bool has_required_globals() const;
+    bool has_touch() const;
     void create_toplevel(const std::string& title, const std::string& app_id);
     bool has_pending_configure() const;
     uint32_t last_configure_serial() const;
@@ -51,6 +70,8 @@ class wayland_xdg_client_t
     std::pair<int, int> last_committed_buffer_size() const;
     void commit_surface();
     void destroy_toplevel();
+    const std::vector<touch_event_t>& touch_events() const;
+    void clear_touch_events();
 
   private:
     struct impl;


### PR DESCRIPTION
Changes:

- We consume the entire event sequence if we get >= 3 fingers (could be configured to a higher number if you need clients which require more than 2 fingers)
- We consume the entire event sequence if the touch originates in an edge zone where we have a configured edge swipe gesture
- Pointer input is totally disabled while using touch - fixes some annoying cases where for example you scroll on a laptop with touchscreen but the invisible pointer is hovering random UI elements

Fixes #1554
Fixes #2615
