### PR TITLE
api: standardize floating-point rendering helpers

### DIFF
--- a/plugins/blur/blur.cpp
+++ b/plugins/blur/blur.cpp
@@ -207,12 +207,8 @@ class blur_render_instance_t : public transformer_render_instance_t<blur_node_t>
         auto bounding_box = self->get_bounding_box();
         data.pass->custom_gles_subpass([&]
         {
-            auto contents = get_texture(data.target.scale);
-            const bool is_zerocopy = (contents->get_wlr_texture() == self->inner_content.get_texture());
-            double render_width    = is_zerocopy ? self->inner_content.get_size().width / data.target.scale :
-                bounding_box.width;
-            double render_height = is_zerocopy ? self->inner_content.get_size().height / data.target.scale :
-                bounding_box.height;
+            wf::dimensionsf_t render_size;
+            auto contents = get_texture(data.target.scale, &render_size);
 
             auto tex = wf::gles_texture_t{contents};
             if (!data.damage.empty())
@@ -220,10 +216,7 @@ class blur_render_instance_t : public transformer_render_instance_t<blur_node_t>
                 auto translucent_damage = calculate_translucent_damage(data.target, data.damage);
                 self->provider()->prepare_blur(data.target, translucent_damage);
 
-                wf::geometry_t render_geometry = {
-                    bounding_box.x, bounding_box.y, render_width, render_height
-                };
-
+                wf::geometry_t render_geometry = wf::construct_box(wf::origin(bounding_box), render_size);
                 render_geometry = data.target.aligned_geometry_from_geometry_box(render_geometry);
                 self->provider()->render(tex, render_geometry, data.damage, data.target, data.target);
             }

--- a/plugins/wobbly/wobbly.cpp
+++ b/plugins/wobbly/wobbly.cpp
@@ -1005,7 +1005,7 @@ class wobbly_render_instance_t :
             {
                 wf::gles::render_target_logic_scissor(data.target, box);
                 wobbly_graphics::render_triangles(self->wobbly_program, tex,
-                    wf::gles::render_target_orthographic_projection(data.target),
+                    wf::gles::render_target_aligned_orthographic_projection(data.target),
                     vert.data(), uv.data(), count_triangles);
             }
         });

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -107,7 +107,7 @@ using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 /**
  * The version is defined as macro as well, to allow conditional compilation.
  */
-#define WAYFIRE_API_ABI_VERSION_MACRO 2026'07'20
+#define WAYFIRE_API_ABI_VERSION_MACRO 2026'07'23
 
 /**
  * The version of Wayfire's API/ABI

--- a/src/api/wayfire/scene.hpp
+++ b/src/api/wayfire/scene.hpp
@@ -285,7 +285,7 @@ class node_t : public std::enable_shared_from_this<node_t>,
      * node. It is simply the bounding box of the bounding boxes of the children
      * as reported by their get_bounding_box() method.
      */
-    wf::geometry_t get_children_bounding_box();
+    wf::geometry_t get_children_bounding_box() const;
 
     /**
      * Structure nodes are special nodes which core usually creates when Wayfire

--- a/src/api/wayfire/unstable/wlr-surface-node.hpp
+++ b/src/api/wayfire/unstable/wlr-surface-node.hpp
@@ -68,7 +68,8 @@ class wlr_surface_node_t : public node_t, public zero_copy_texturable_node_t
     void gen_render_instances(std::vector<render_instance_uptr>& instances, damage_callback damage,
         wf::output_t *output) override;
     wf::geometry_t get_bounding_box() override;
-    std::shared_ptr<wf::texture_t> to_texture() const override;
+    std::shared_ptr<wf::texture_t> to_texture(
+        wf::dimensionsf_t *out_logical_size = nullptr) const override;
 
     wlr_surface *get_surface() const;
     virtual void apply_state(surface_state_t&& state);

--- a/src/api/wayfire/view-transform.hpp
+++ b/src/api/wayfire/view-transform.hpp
@@ -21,8 +21,11 @@ class zero_copy_texturable_node_t
     /**
      * Get a texture from the node without copying.
      * Note that this operation might fail for non-trivial transformers.
+     *
+     * @param out_logical_size If provided, the logical size of the returned texture is written here.
      */
-    virtual std::shared_ptr<wf::texture_t> to_texture() const
+    virtual std::shared_ptr<wf::texture_t> to_texture(
+        wf::dimensionsf_t *out_logical_size = nullptr) const
     {
         return nullptr;
     }
@@ -50,6 +53,15 @@ class transformer_base_node_t : public scene::floating_inner_node_t
 {
   public:
     using floating_inner_node_t::floating_inner_node_t;
+
+    /**
+     * Attempt to convert the children to a texture without copying.
+     * Works only if the node has a single child which supports zero-copy texture generation via @to_texture.
+     *
+     * @param out_logical_size If provided, the logical size of the returned texture is written here.
+     */
+    std::shared_ptr<wf::texture_t> zero_copy_texture(
+        wf::dimensionsf_t *out_logical_size = nullptr) const;
 
     uint32_t optimize_update(uint32_t flags) override;
 
@@ -94,23 +106,6 @@ template<class NodeType>
 class transformer_render_instance_t : public render_instance_t
 {
   protected:
-    std::shared_ptr<wf::texture_t> zero_copy_texture()
-    {
-        if (self->get_children().size() == 1)
-        {
-            auto child = self->get_children().front().get();
-            if (auto zcopy = dynamic_cast<zero_copy_texturable_node_t*>(child))
-            {
-                if (auto tex = zcopy->to_texture())
-                {
-                    return tex;
-                }
-            }
-        }
-
-        return nullptr;
-    }
-
     // A pointer to the transformer node this render instance belongs to.
     std::shared_ptr<NodeType> self;
 
@@ -128,19 +123,31 @@ class transformer_render_instance_t : public render_instance_t
      * @param scale The scale to use when generating the texture. The scale
      *   indicates how much bigger the temporary buffer should be than its logical
      *   size.
+     *
+     * @param out_logical_size If provided, the logical size of the texture is written to this pointer.
      */
-    std::shared_ptr<wf::texture_t> get_texture(float scale)
+    std::shared_ptr<wf::texture_t> get_texture(float scale, wf::dimensionsf_t *out_logical_size = nullptr)
     {
         // Optimization: if we have a single child (usually the surface root node)
         // and we can directly convert it to texture, we don't need a full render
         // pass.
-        if (auto tex = zero_copy_texture())
+        if (auto tex = self->zero_copy_texture(out_logical_size))
         {
             self->release_buffers();
             return tex;
         }
 
-        return self->get_updated_contents(self->get_children_bounding_box(), scale, children, _shown_on);
+        auto contents =
+            self->get_updated_contents(self->get_children_bounding_box(), scale, children, _shown_on);
+        if (out_logical_size)
+        {
+            *out_logical_size = wf::dimensionsf_t{
+                self->inner_content.get_size().width / scale,
+                self->inner_content.get_size().height / scale
+            };
+        }
+
+        return contents;
     }
 
     void presentation_feedback(wf::output_t *output) override

--- a/src/api/wayfire/vulkan.hpp
+++ b/src/api/wayfire/vulkan.hpp
@@ -458,8 +458,13 @@ glm::mat4 geometry_mat(const wf::geometry_t& box);
 
 /**
  * Helper method to calculate a transformation from logical render target coordinates to final NDC space.
+ *
+ * @param aligned Here aligned is to be understood as
+ *   aligned = target.aligned_geometry_from_geometry_box(target.geometry).
+ *   When set to true, the orthographic projection will map the aligned geometry to the final NDC space.
+ *   When set to false, it will map the unaligned target.geometry to the NDC space.
  */
-glm::mat4 render_target_transform(const wf::render_target_t& target);
+glm::mat4 render_target_transform(const wf::render_target_t& target, bool aligned = false);
 }
 
 /**

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -366,11 +366,10 @@ glm::mat4 wf::gles::render_target_orthographic_projection(const wf::render_targe
 
 glm::mat4 wf::gles::render_target_aligned_orthographic_projection(const wf::render_target_t& target)
 {
-    auto aligned = target.aligned_geometry_from_geometry_box(target.geometry);
-    auto ortho   = glm::ortho((float)aligned.x, (float)(aligned.x + aligned.width),
-        (float)(aligned.y + aligned.height), (float)aligned.y);
-
-    return gles::render_target_gl_to_framebuffer(target) * ortho;
+    return render_target_gl_to_framebuffer(target) *
+           glm::ortho(0.0f, (float)target.get_size().width, (float)target.get_size().height, 0.0f) *
+           glm::scale(glm::mat4(1.0), glm::vec3(target.scale, target.scale, 1.0)) *
+           glm::translate(glm::mat4(1.0), glm::vec3(-target.geometry.x, -target.geometry.y, 1.0));
 }
 
 glm::mat4 wf::gles::render_target_gl_to_framebuffer(const wf::render_target_t& target)

--- a/src/core/scene.cpp
+++ b/src/core/scene.cpp
@@ -253,7 +253,7 @@ void node_t::gen_render_instances(std::vector<render_instance_uptr> & instances,
     }
 }
 
-wf::geometry_t node_t::get_children_bounding_box()
+wf::geometry_t node_t::get_children_bounding_box() const
 {
     if (children.empty())
     {

--- a/src/core/vulkan.cpp
+++ b/src/core/vulkan.cpp
@@ -554,14 +554,22 @@ std::pair<VkPipelineLayout, VkPipeline> graphics_pipeline_t::pipeline_for(const 
     return {layout, pipeline};
 }
 
-glm::mat4 render_target_transform(const wf::render_target_t& target)
-
+glm::mat4 render_target_transform(const wf::render_target_t& target, bool aligned)
 {
-    glm::mat4 ortho = glm::ortho(
-        1.0f * target.geometry.x,
-        1.0f * target.geometry.x + 1.0f * target.geometry.width,
-        1.0f * target.geometry.y,
-        1.0f * target.geometry.y + 1.0f * target.geometry.height);
+    glm::mat4 ortho;
+    if (aligned)
+    {
+        ortho = glm::ortho(0.0f, (float)target.get_size().width, (float)target.get_size().height, 0.0f) *
+            glm::scale(glm::mat4(1.0), glm::vec3(target.scale, target.scale, 1.0)) *
+            glm::translate(glm::mat4(1.0), glm::vec3(-target.geometry.x, -target.geometry.y, 1.0));
+    } else
+    {
+        ortho = glm::ortho(
+            1.0f * target.geometry.x,
+            1.0f * target.geometry.x + 1.0f * target.geometry.width,
+            1.0f * target.geometry.y,
+            1.0f * target.geometry.y + 1.0f * target.geometry.height);
+    }
 
     ortho[1][1] *= -1; // Invert Y axis to match Vulkan's coordinate system
     return ortho * gles::render_target_gl_to_framebuffer(target);

--- a/src/view/layer-shell/layer-shell-node.cpp
+++ b/src/view/layer-shell/layer-shell-node.cpp
@@ -93,7 +93,8 @@ wf::regionf_t wf::layer_shell_node_t::get_opaque_region() const
     return {};
 }
 
-std::shared_ptr<wf::texture_t> wf::layer_shell_node_t::to_texture() const
+std::shared_ptr<wf::texture_t> wf::layer_shell_node_t::to_texture(
+    wf::dimensionsf_t *out_logical_size) const
 {
     auto view = _view.lock();
     if (!view || !view->is_mapped() || (get_children().size() != 1))
@@ -103,7 +104,7 @@ std::shared_ptr<wf::texture_t> wf::layer_shell_node_t::to_texture() const
 
     if (auto texturable = dynamic_cast<zero_copy_texturable_node_t*>(get_children().front().get()))
     {
-        return texturable->to_texture();
+        return texturable->to_texture(out_logical_size);
     }
 
     return nullptr;

--- a/src/view/layer-shell/layer-shell-node.hpp
+++ b/src/view/layer-shell/layer-shell-node.hpp
@@ -23,7 +23,8 @@ class layer_shell_node_t : public wf::scene::translation_node_t,
     void gen_render_instances(std::vector<scene::render_instance_uptr>& instances,
         scene::damage_callback push_damage, wf::output_t *output) override;
 
-    std::shared_ptr<wf::texture_t> to_texture() const override;
+    std::shared_ptr<wf::texture_t> to_texture(
+        wf::dimensionsf_t *out_logical_size = nullptr) const override;
     wf::regionf_t get_opaque_region() const override;
 
   protected:

--- a/src/view/toplevel-node.cpp
+++ b/src/view/toplevel-node.cpp
@@ -125,7 +125,8 @@ void wf::toplevel_view_node_t::gen_render_instances(
     instances.push_back(std::make_unique<toplevel_view_render_instance_t>(this, push_damage, output));
 }
 
-std::shared_ptr<wf::texture_t> wf::toplevel_view_node_t::to_texture() const
+std::shared_ptr<wf::texture_t> wf::toplevel_view_node_t::to_texture(
+    wf::dimensionsf_t *out_logical_size) const
 {
     auto view = _view.lock();
     if (!view || !view->is_mapped() || (get_children().size() != 1))
@@ -135,7 +136,7 @@ std::shared_ptr<wf::texture_t> wf::toplevel_view_node_t::to_texture() const
 
     if (auto texturable = dynamic_cast<zero_copy_texturable_node_t*>(get_children().front().get()))
     {
-        return texturable->to_texture();
+        return texturable->to_texture(out_logical_size);
     }
 
     return nullptr;

--- a/src/view/toplevel-node.hpp
+++ b/src/view/toplevel-node.hpp
@@ -24,7 +24,8 @@ class toplevel_view_node_t : public wf::scene::translation_node_t,
     void gen_render_instances(std::vector<scene::render_instance_uptr>& instances,
         scene::damage_callback push_damage, wf::output_t *output) override;
 
-    std::shared_ptr<wf::texture_t> to_texture() const override;
+    std::shared_ptr<wf::texture_t> to_texture(
+        wf::dimensionsf_t *out_logical_size = nullptr) const override;
     wf::regionf_t get_opaque_region() const override;
 
   protected:

--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -36,10 +36,10 @@ wf::geometry_t get_bbox_for_node(scene::node_t *node, wf::geometry_t box)
     const auto p4 = node->to_global(
         wf::pointf_t(box.x + box.width, box.y + box.height));
 
-    const double x1 = std::floor(std::min({p1.x, p2.x, p3.x, p4.x}));
-    const double x2 = std::ceil(std::max({p1.x, p2.x, p3.x, p4.x}));
-    const double y1 = std::floor(std::min({p1.y, p2.y, p3.y, p4.y}));
-    const double y2 = std::ceil(std::max({p1.y, p2.y, p3.y, p4.y}));
+    const double x1 = std::min({p1.x, p2.x, p3.x, p4.x});
+    const double x2 = std::max({p1.x, p2.x, p3.x, p4.x});
+    const double y1 = std::min({p1.y, p2.y, p3.y, p4.y});
+    const double y2 = std::max({p1.y, p2.y, p3.y, p4.y});
     return {x1, y1, x2 - x1, y2 - y1};
 }
 
@@ -651,6 +651,24 @@ void transformer_base_node_t::release_buffers()
 transformer_base_node_t::~transformer_base_node_t()
 {
     release_buffers();
+}
+
+std::shared_ptr<wf::texture_t> transformer_base_node_t::zero_copy_texture(
+    wf::dimensionsf_t *out_logical_size) const
+{
+    if (get_children().size() == 1)
+    {
+        auto child = get_children().front().get();
+        if (auto zcopy = dynamic_cast<zero_copy_texturable_node_t*>(child))
+        {
+            if (auto tex = zcopy->to_texture(out_logical_size))
+            {
+                return tex;
+            }
+        }
+    }
+
+    return nullptr;
 }
 } // namespace scene
 }

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -239,6 +239,7 @@ void wf::scene::wlr_surface_node_t::apply_state(surface_state_t&& state)
 
     this->current_state = std::move(state);
     this->size_on_primary_output = new_size;
+    this->current_state.opaque_region &= get_render_geometry();
 
     wf::scene::damage_node(this, current_state.accumulated_damage);
     if (size_changed)
@@ -392,7 +393,7 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
     void schedule_instructions(std::vector<render_instruction_t>& instructions,
         const wf::render_target_t& target, wf::regionf_t& damage) override
     {
-        wf::regionf_t our_damage = damage & self->get_render_geometry();
+        wf::regionf_t our_damage = damage & self->get_bounding_box();
         if (!our_damage.empty())
         {
             instructions.push_back(render_instruction_t{
@@ -534,7 +535,8 @@ wlr_surface*wf::scene::wlr_surface_node_t::get_surface() const
     return this->surface;
 }
 
-std::shared_ptr<wf::texture_t> wf::scene::wlr_surface_node_t::to_texture() const
+std::shared_ptr<wf::texture_t> wf::scene::wlr_surface_node_t::to_texture(
+    wf::dimensionsf_t *out_logical_size) const
 {
     if (this->current_state.current_buffer)
     {
@@ -542,6 +544,11 @@ std::shared_ptr<wf::texture_t> wf::scene::wlr_surface_node_t::to_texture() const
         tex->set_source_box(current_state.src_viewport);
         tex->set_transform(current_state.transform);
         tex->set_color_transform(current_state.color_transform);
+        if (out_logical_size)
+        {
+            *out_logical_size = size_on_primary_output;
+        }
+
         return tex;
     }
 

--- a/test/protocol/native-buffer-size-scaling-test.cpp
+++ b/test/protocol/native-buffer-size-scaling-test.cpp
@@ -6,12 +6,51 @@
 #include <wayfire/output-layout.hpp>
 #include <wayfire/signal-definitions.hpp>
 #include <wayfire/toplevel-view.hpp>
+#include <wayfire/view-transform.hpp>
 
 #include <algorithm>
 #include <vector>
 
 #include "../support/headless-core-harness.hpp"
 #include "../support/wayland-xdg-client.hpp"
+
+namespace
+{
+class logical_size_transformer_t : public wf::scene::transformer_base_node_t
+{
+  public:
+    logical_size_transformer_t() : transformer_base_node_t(false)
+    {}
+
+    std::string stringify() const override
+    {
+        return "logical-size-test-transformer";
+    }
+
+    class render_instance_t :
+        public wf::scene::transformer_render_instance_t<logical_size_transformer_t>
+    {
+      public:
+        using transformer_render_instance_t::transformer_render_instance_t;
+
+        void render(const wf::scene::render_instruction_t& data) override
+        {
+            wf::dimensionsf_t logical_size;
+            auto texture  = get_texture(data.target.scale, &logical_size);
+            auto geometry = wf::construct_box(
+                wf::origin(self->get_children_bounding_box()), logical_size);
+            geometry = data.target.aligned_geometry_from_geometry_box(geometry);
+            data.pass->add_texture(texture, data.target, geometry, data.damage);
+        }
+    };
+
+    void gen_render_instances(std::vector<wf::scene::render_instance_uptr>& instances,
+        wf::scene::damage_callback push_damage, wf::output_t *shown_on) override
+    {
+        instances.push_back(std::make_unique<render_instance_t>(this, push_damage, shown_on));
+    }
+};
+}
 
 TEST_CASE("fractional-scale rounded client buffers render pixel-aligned")
 {
@@ -95,6 +134,18 @@ TEST_CASE("fractional-scale rounded client buffers render pixel-aligned")
         view->get_geometry().height == logical_height;
     }));
 
+    SUBCASE("direct surface path")
+    {
+        CHECK(view->get_transformed_node()->get_transformer("logical-size-test-transformer") == nullptr);
+    }
+
+    SUBCASE("transformed zero-copy path")
+    {
+        auto transformer = std::make_shared<logical_size_transformer_t>();
+        view->get_transformed_node()->add_transformer(transformer, wf::TRANSFORMER_HIGHLEVEL,
+            "logical-size-test-transformer");
+    }
+
     auto output_pixels = harness.capture_output_pixels();
     const int output_width = output->handle->width;
     const int output_height = output->handle->height;
@@ -136,12 +187,18 @@ TEST_CASE("fractional-scale rounded client buffers render pixel-aligned")
     REQUIRE(max_y >= min_y);
     const int expected_x = static_cast<int>(std::floor(view_x * output->get_scale()));
     const int expected_y = static_cast<int>(std::floor(view_y * output->get_scale()));
+    const int bounding_width = static_cast<int>(std::ceil(
+        (view_x + logical_width) * output->get_scale())) - expected_x;
+    const int bounding_height = static_cast<int>(std::ceil(
+        (view_y + logical_height) * output->get_scale())) - expected_y;
 
     CHECK(min_x == expected_x);
     CHECK(min_y == expected_y);
-    CHECK(max_x - min_x + 1 == buffer_width);
-    CHECK(max_y - min_y + 1 == buffer_height);
+    CHECK(max_x - min_x + 1 == std::min(buffer_width, bounding_width));
+    CHECK(max_y - min_y + 1 == std::min(buffer_height, bounding_height));
     CHECK(is_background(output_pixels[expected_y * output_width + expected_x - 1]));
     CHECK(is_background(output_pixels[(expected_y - 1) * output_width + expected_x]));
+    CHECK(is_background(output_pixels[expected_y * output_width + max_x + 1]));
+    CHECK(is_background(output_pixels[(max_y + 1) * output_width + expected_x]));
     CHECK(mixed_pixels == 0);
 }


### PR DESCRIPTION
For view transformers, `get_texture` now supports an optional parameter which can give plugins information about the real size of the texture.

Another helper function is render_target_t::aligned_geometry_from_geometry_box() which takes a geometry in the logical coordinate space (for example constructed out of the node bounding box and the logical size of the texture in transformers) and aligns it with the underlying pixel grid. The end result can then be projected with wf::gles::get_aligned_orthographic_projection() to render pixel-aligned textures without any bluriness.

Fixes #3077
