### PR TITLE
decoration: disable resizing on tiled views

### DIFF
--- a/plugins/decor/deco-layout.cpp
+++ b/plugins/decor/deco-layout.cpp
@@ -118,7 +118,7 @@ wf::geometry_t decoration_layout_t::create_buttons(int width, int)
 }
 
 /** Regenerate layout using the new size */
-void decoration_layout_t::resize(int width, int height)
+void decoration_layout_t::resize(int width, int height, bool allow_resize)
 {
     this->layout_areas.clear();
     if (this->titlebar_size > 0)
@@ -145,22 +145,22 @@ void decoration_layout_t::resize(int width, int height)
     /* Resizing edges - left */
     wf::geometry_t border_geometry = {0.0, 0.0, (double)border_size, (double)height};
     this->layout_areas.push_back(std::make_unique<decoration_area_t>(
-        DECORATION_AREA_RESIZE_LEFT, border_geometry));
+        allow_resize ? DECORATION_AREA_RESIZE_LEFT : DECORATION_AREA_EMPTY, border_geometry));
 
     /* Resizing edges - right */
     border_geometry = {(double)(width - border_size), 0.0, (double)border_size, (double)height};
     this->layout_areas.push_back(std::make_unique<decoration_area_t>(
-        DECORATION_AREA_RESIZE_RIGHT, border_geometry));
+        allow_resize ? DECORATION_AREA_RESIZE_RIGHT : DECORATION_AREA_EMPTY, border_geometry));
 
     /* Resizing edges - top */
     border_geometry = {0.0, 0.0, (double)width, (double)border_size};
     this->layout_areas.push_back(std::make_unique<decoration_area_t>(
-        DECORATION_AREA_RESIZE_TOP, border_geometry));
+        allow_resize ? DECORATION_AREA_RESIZE_TOP : DECORATION_AREA_EMPTY, border_geometry));
 
     /* Resizing edges - bottom */
     border_geometry = {0.0, (double)(height - border_size), (double)width, (double)border_size};
     this->layout_areas.push_back(std::make_unique<decoration_area_t>(
-        DECORATION_AREA_RESIZE_BOTTOM, border_geometry));
+        allow_resize ? DECORATION_AREA_RESIZE_BOTTOM : DECORATION_AREA_EMPTY, border_geometry));
 }
 
 /**

--- a/plugins/decor/deco-layout.hpp
+++ b/plugins/decor/deco-layout.hpp
@@ -25,6 +25,7 @@ enum decoration_area_type_t
     DECORATION_AREA_RESIZE_RIGHT  = WLR_EDGE_RIGHT | DECORATION_AREA_RESIZE_BIT,
     DECORATION_AREA_RESIZE_TOP    = WLR_EDGE_TOP | DECORATION_AREA_RESIZE_BIT,
     DECORATION_AREA_RESIZE_BOTTOM = WLR_EDGE_BOTTOM | DECORATION_AREA_RESIZE_BIT,
+    DECORATION_AREA_EMPTY         = 0,
 };
 
 /**
@@ -105,7 +106,7 @@ class decoration_layout_t
         std::function<void(wf::geometry_t)> damage_callback);
 
     /** Regenerate layout using the new size */
-    void resize(int width, int height);
+    void resize(int width, int height, bool allow_resize);
 
     /**
      * @return The decoration areas which need to be rendered, in top to bottom

--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -324,7 +324,8 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         {
             view->damage();
             size = dims;
-            layout.resize(size.width, size.height);
+            bool allow_resize = view->toplevel()->current().tiled_edges != wf::TILED_EDGES_ALL;
+            layout.resize(size.width, size.height, allow_resize);
             if (!view->toplevel()->current().fullscreen)
             {
                 this->cached_region = layout.calculate_region();
@@ -362,6 +363,7 @@ wf::simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
     view->connect(&on_view_activated);
     view->connect(&on_view_geometry_changed);
     view->connect(&on_view_fullscreen);
+    view->connect(&on_view_tiled);
 
     on_view_activated = [this] (auto)
     {
@@ -380,6 +382,11 @@ wf::simple_decorator_t::simple_decorator_t(wayfire_toplevel_view view)
         {
             deco->resize(wf::dimensions(this->view->get_geometry()));
         }
+    };
+
+    on_view_tiled = [this] (auto)
+    {
+        deco->resize(wf::dimensions(this->view->get_geometry()));
     };
 }
 

--- a/plugins/decor/deco-subsurface.hpp
+++ b/plugins/decor/deco-subsurface.hpp
@@ -20,6 +20,7 @@ class simple_decorator_t : public wf::custom_data_t
     wf::signal::connection_t<wf::view_activated_state_signal> on_view_activated;
     wf::signal::connection_t<wf::view_geometry_changed_signal> on_view_geometry_changed;
     wf::signal::connection_t<wf::view_fullscreen_signal> on_view_fullscreen;
+    wf::signal::connection_t<wf::view_tiled_signal> on_view_tiled;
 
   public:
     simple_decorator_t(wayfire_toplevel_view view);


### PR DESCRIPTION
This matches what weston-terminal and GTK applications do as well.

Fixes #570
