### PR TITLE
squeezimize: fix default behavior

### DIFF
--- a/plugins/animate/squeezimize.hpp
+++ b/plugins/animate/squeezimize.hpp
@@ -338,8 +338,8 @@ class squeezimize_transformer : public wf::scene::view_2d_transformer_t
         auto geom   = output->get_relative_geometry();
 
         // check which edge the target is closest to
-        double x  = minimize_target.x + minimize_target.width / 2.0;
-        double y  = minimize_target.y + minimize_target.height / 2.0;
+        double x  = this->minimize_target.x + this->minimize_target.width / 2.0;
+        double y  = this->minimize_target.y + this->minimize_target.height / 2.0;
         double y2 = y * geom.width / geom.height;
         if (x < y2)
         {


### PR DESCRIPTION
The default behavior was broken since commit `3b6d5d5286265a58e784e18c1ece5ea867295c52`, where minimize_target (the function input) was being used for calculations instead of using this->minimize_target (the member of the class that stores the final target).

As of now (without this PR), if you run squeezimize you will see it will not squeeze into anything, it'll just float around then pop out of existence.