### PR TITLE
wrot: lower FOV

### DIFF
--- a/src/view/view-3d.cpp
+++ b/src/view/view-3d.cpp
@@ -351,7 +351,7 @@ void view_2d_transformer_t::gen_render_instances(
 }
 
 /* -------------------------------- 3d view --------------------------------- */
-const float view_3d_transformer_t::fov = PI / 4;
+const float view_3d_transformer_t::fov = PI / 12;
 glm::mat4 view_3d_transformer_t::default_view_matrix()
 {
     return glm::lookAt(


### PR DESCRIPTION
un-exaggerates the perspective effect. The view is way flatter and the distortion toward the near plane that comes with the projection is pretty much unnoticeable with this change.


I've personally settled with PI/12, since for my 1080p display it's the highest fov with least amount of distortion.

https://www.mediafire.com/file/3o262gj2umzo70n/DISTORTION_FILES.zip/file