### PR TITLE
blur: expand partial render region by one pixel

### DIFF
--- a/plugins/blur/blur-base.cpp
+++ b/plugins/blur/blur-base.cpp
@@ -119,6 +119,11 @@ void wf_blur_base::render_iteration(wf::region_t blur_region,
     wf::gles::bind_render_buffer(out.get_renderbuffer());
     GL_CALL(glActiveTexture(GL_TEXTURE0));
     GL_CALL(glBindTexture(GL_TEXTURE_2D, tex_id));
+
+    // Blur shaders can sample one texel outside the partial render region.
+    // Render a one-pixel guard band so those samples are initialized.
+    blur_region.expand_edges(1);
+    blur_region &= wlr_box{0, 0, width, height};
     for (auto& b : blur_region)
     {
         wf::gles::scissor_render_buffer(out.get_renderbuffer(), wlr_box_from_pixman_box(b));


### PR DESCRIPTION
Fixes #3113.

Partial blur rendering only writes the current `blur_region` into the
intermediate buffer. A following blur pass can sample one pixel outside
that region, leaving the edge dependent on previous or undefined buffer
contents.

Expand the region by one pixel before scissoring and clip it to the
intermediate buffer size.

Tested on current master (`4c34a7bf`) on an Apple M2 with Asahi/Mesa
26.1.6. The magenta edge described in #3113 disappears with this change.

Also tested with Kawase, Gaussian and Box blur.
