### PR TITLE
decoration: fix render region

### DIFF
--- a/plugins/decor/deco-subsurface.cpp
+++ b/plugins/decor/deco-subsurface.cpp
@@ -189,7 +189,7 @@ class simple_decoration_node_t : public wf::scene::node_t, public wf::pointer_in
         void schedule_instructions(std::vector<wf::scene::render_instruction_t>& instructions,
             const wf::render_target_t& target, wf::regionf_t& damage) override
         {
-            auto our_region = self->get_bounding_box();
+            auto our_region = self->cached_region + self->get_offset();
             wf::regionf_t our_damage = damage & our_region;
             if (!our_damage.empty())
             {


### PR DESCRIPTION
I'm having the same problem as #3111.
Please refer to the issue for a description of the problem.

This PR partially reverts d4835f263.
In #3032, which introduced the commit, there is the following comment:

> This PR has been largely generated with the help of LLMs and still needs to be reviewed very carefully

So, the change appears to have been overlooked during the review.

closes: #3111